### PR TITLE
Support `ls` on files

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -117,14 +117,10 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 var lsCmd = &cobra.Command{
 	Use:   "ls [flags] [<path>]",
 	Short: "List files and folders",
-	Long: `List files and folders
-
-Examples:
-$ dbxcli ls / # Or just 'ls'
-$ dbxcli ls /some-folder # Or 'ls some-folder'
-$ dbxcli ls /some-folder/some-file.pdf
-$ dbxcli ls -l # Or 'ls --long'
-`,
+	Example: `  dbxcli ls / # Or just 'ls'
+  dbxcli ls /some-folder # Or 'ls some-folder'
+  dbxcli ls /some-folder/some-file.pdf
+  dbxcli ls -l`,
 	RunE: ls,
 }
 

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -109,16 +109,15 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 // lsCmd represents the ls command
 var lsCmd = &cobra.Command{
 	Use:   "ls [flags] [<path>]",
-	Short: "List folders",
-	Long: `List Folders.
-	Attempting ls on files will fail with 'Error: path/not_folder/.'
+	Short: "List files and folders",
+	Long: `List files and folders
 
-	Examples:
-	$ dbxcli ls / # Or, dbxcli ls
-	$ dbxcli ls some-folder
-	$ dbxcli ls /some-folder # Or dbxcli ls some-folder/
-	$ dbxcli ls -l # Or, dbxcli ls --long
-	`,
+Examples:
+$ dbxcli ls / # Or just 'ls'
+$ dbxcli ls /some-folder # Or 'ls some-folder'
+$ dbxcli ls /some-folder/some-file.pdf
+$ dbxcli ls -l # Or 'ls --long'
+`,
 	RunE: ls,
 }
 


### PR DESCRIPTION
This adds support for running the `ls` command on individual files (in addition to folders). This is accomplished by recovering from the `path/not_folder/` error and sending a follow-up `get_metadata` request to the API. That response is displayed in place of the response from `list_folder`.

I didn't add tests for this feature because there don't appear to be any set up yet; I thought I might do a bigger PR with tests for all commands instead (unless you have other plans).

Closes #8.