### PR TITLE
Check `args` slice bounds in `get` and `put` functions

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -28,8 +28,8 @@ import (
 )
 
 func get(cmd *cobra.Command, args []string) (err error) {
-	if len(args) < 1 {
-		return errors.New("source is required")
+	if len(args) == 0 || len(args) > 2 {
+		return errors.New("`get` requires 1 or 2 arguments")
 	}
 
 	src, err := validatePath(args[0])

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -37,11 +37,9 @@ func get(cmd *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	var dst string
-	if len(args) < 2 {
-		// If a destination is not specified use the base of the source path
-		dst = path.Base(src)
-	} else {
+	// Default `dst` to the base segment of the source path; use the second argument if provided.
+	dst := path.Base(src)
+	if len(args) == 2 {
 		dst = args[1]
 	}
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -39,6 +39,7 @@ func get(cmd *cobra.Command, args []string) (err error) {
 
 	var dst string
 	if len(args) < 2 {
+		// If a destination is not specified use the base of the source path
 		dst = path.Base(src)
 	} else {
 		dst = args[1]

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,11 +28,20 @@ import (
 )
 
 func get(cmd *cobra.Command, args []string) (err error) {
-	src, err := validatePath(args[0])
-	dst := args[1]
+	if len(args) < 1 {
+		return errors.New("source is required")
+	}
 
-	if dst == "" {
+	src, err := validatePath(args[0])
+	if err != nil {
+		return
+	}
+
+	var dst string
+	if len(args) < 2 {
 		dst = path.Base(src)
+	} else {
+		dst = args[1]
 	}
 
 	arg := files.NewDownloadArg(src)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -29,7 +29,7 @@ import (
 
 func get(cmd *cobra.Command, args []string) (err error) {
 	if len(args) == 0 || len(args) > 2 {
-		return errors.New("`get` requires 1 or 2 arguments")
+		return errors.New("`get` requires `src` and/or `dst` arguments")
 	}
 
 	src, err := validatePath(args[0])

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -63,16 +63,14 @@ func put(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	src := args[0]
-	if err != nil {
-		return
-	}
 
-	var dst string
-	if len(args) < 2 {
-		// If a destination is not specified use the base of the source path
-		dst = "/" + path.Base(src)
-	} else {
+	// Default `dst` to the base segment of the source path; use the second argument if provided.
+	dst := "/" + path.Base(src)
+	if len(args) == 2 {
 		dst, err = validatePath(args[1])
+		if err != nil {
+			return
+		}
 	}
 
 	contents, err := os.Open(src)

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -58,8 +58,8 @@ func uploadChunked(r io.Reader, commitInfo *files.CommitInfo, sizeTotal int64) (
 }
 
 func put(cmd *cobra.Command, args []string) (err error) {
-	if len(args) < 1 {
-		return errors.New("source is required")
+	if len(args) == 0 || len(args) > 2 {
+		return errors.New("`put` requires 1 or 2 arguments")
 	}
 
 	src := args[0]

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -59,7 +59,7 @@ func uploadChunked(r io.Reader, commitInfo *files.CommitInfo, sizeTotal int64) (
 
 func put(cmd *cobra.Command, args []string) (err error) {
 	if len(args) == 0 || len(args) > 2 {
-		return errors.New("`put` requires 1 or 2 arguments")
+		return errors.New("`put` requires `src` and/or `dst` arguments")
 	}
 
 	src := args[0]

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -15,9 +15,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/files"
 	"github.com/dustin/go-humanize"
@@ -56,10 +58,21 @@ func uploadChunked(r io.Reader, commitInfo *files.CommitInfo, sizeTotal int64) (
 }
 
 func put(cmd *cobra.Command, args []string) (err error) {
+	if len(args) < 1 {
+		return errors.New("source is required")
+	}
+
 	src := args[0]
-	dst, err := validatePath(args[1])
 	if err != nil {
 		return
+	}
+
+	var dst string
+	if len(args) < 2 {
+		// If a destination is not specified use the base of the source path
+		dst = "/" + path.Base(src)
+	} else {
+		dst, err = validatePath(args[1])
 	}
 
 	contents, err := os.Open(src)


### PR DESCRIPTION
This adds a bounds check before accessing the `args` slice in the `get` and `put` functions. This has two effects:

1. Displays a friendly error when the first argument (the source path) is not specified, instead of panicking.
2. Allows these commands to work intuitively without a second argument (the destination path) by defaulting the destination path to be the base segment of the source path. This was already partially written into the `get` function but it didn't work and panicked instead.

Fixes #10.