### PR TITLE
Add argument information to "usage" section of help text

### DIFF
--- a/cmd/add-member.go
+++ b/cmd/add-member.go
@@ -39,7 +39,7 @@ func addMember(cmd *cobra.Command, args []string) (err error) {
 
 // addMemberCmd represents the add-member command
 var addMemberCmd = &cobra.Command{
-	Use:   "add-member",
+	Use:   "add-member [flags] <email> <first-name> <last-name>",
 	Short: "Add a new member to a team",
 	RunE:  addMember,
 }

--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -31,7 +31,7 @@ func cp(cmd *cobra.Command, args []string) (err error) {
 
 // cpCmd represents the cp command
 var cpCmd = &cobra.Command{
-	Use:   "cp",
+	Use:   "cp [flags] <source> <target>",
 	Short: "Copy files",
 	RunE:  cp,
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -66,7 +66,7 @@ func get(cmd *cobra.Command, args []string) (err error) {
 
 // getCmd represents the get command
 var getCmd = &cobra.Command{
-	Use:   "get",
+	Use:   "get [flags] <source> [<target>]",
 	Short: "Download a file",
 	RunE:  get,
 }

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -89,7 +89,7 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 
 // lsCmd represents the ls command
 var lsCmd = &cobra.Command{
-	Use:   "ls",
+	Use:   "ls [flags] [<path>]",
 	Short: "List folders",
 	Long: `List Folders.
 	Attempting ls on files will fail with 'Error: path/not_folder/.'

--- a/cmd/mkdir.go
+++ b/cmd/mkdir.go
@@ -36,7 +36,7 @@ func mkdir(cmd *cobra.Command, args []string) (err error) {
 
 // mkdirCmd represents the mkdir command
 var mkdirCmd = &cobra.Command{
-	Use:   "mkdir",
+	Use:   "mkdir [flags] <directory>",
 	Short: "Create a new directory",
 	RunE:  mkdir,
 }

--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -31,7 +31,7 @@ func mv(cmd *cobra.Command, args []string) (err error) {
 
 // mvCmd represents the mv command
 var mvCmd = &cobra.Command{
-	Use:   "mv",
+	Use:   "mv [flags] <source> <target>",
 	Short: "Move files",
 	RunE:  mv,
 }

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -98,7 +98,7 @@ func put(cmd *cobra.Command, args []string) (err error) {
 
 // putCmd represents the put command
 var putCmd = &cobra.Command{
-	Use:   "put",
+	Use:   "put [flags] <source> [<target>]",
 	Short: "Upload files",
 	RunE:  put,
 }

--- a/cmd/remove-member.go
+++ b/cmd/remove-member.go
@@ -36,7 +36,7 @@ func removeMember(cmd *cobra.Command, args []string) (err error) {
 
 // removeMemberCmd represents the remove-member command
 var removeMemberCmd = &cobra.Command{
-	Use:   "remove-member",
+	Use:   "remove-member [flags] <email>",
 	Short: "Remove member from a team",
 	RunE:  removeMember,
 }

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -38,7 +38,7 @@ func restore(cmd *cobra.Command, args []string) (err error) {
 
 // restoreCmd represents the restore command
 var restoreCmd = &cobra.Command{
-	Use:   "restore",
+	Use:   "restore [flags] <file> <revision>",
 	Short: "Restore files",
 	RunE:  restore,
 }

--- a/cmd/revs.go
+++ b/cmd/revs.go
@@ -54,7 +54,7 @@ func revs(cmd *cobra.Command, args []string) (err error) {
 
 // revsCmd represents the revs command
 var revsCmd = &cobra.Command{
-	Use:   "revs",
+	Use:   "revs [flags] <file>",
 	Short: "List file revisions",
 	RunE:  revs,
 }

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -36,7 +36,7 @@ func rm(cmd *cobra.Command, args []string) (err error) {
 
 // rmCmd represents the rm command
 var rmCmd = &cobra.Command{
-	Use:   "rm",
+	Use:   "rm [flags] <file>",
 	Short: "Remove files",
 	RunE:  rm,
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -50,7 +50,7 @@ func search(cmd *cobra.Command, args []string) (err error) {
 
 // searchCmd represents the search command
 var searchCmd = &cobra.Command{
-	Use:   "search",
+	Use:   "search [flags] <query>",
 	Short: "Search",
 	RunE:  search,
 }


### PR DESCRIPTION
The help text for most commands didn't mention which arguments they take.
This commit adds that information to the "usage" section of the help text,
using the convention `<arg>` for required arguments and `[<optarg>]` for
optional arguments.

Closes #13.