### PR TITLE
Add `account` command

### DIFF
--- a/cmd/account.go
+++ b/cmd/account.go
@@ -53,22 +53,22 @@ func printBasicAccount(w *tabwriter.Writer, ba *users.BasicAccount) {
 }
 
 func account(cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return errors.New("`account` accepts an optional `id` argument")
+	}
+
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 4, 8, 1, ' ', 0)
 
-	switch len(args) {
-	case 0:
+	if len(args) == 0 {
 		// If no arguments are provided get the current user's account
 		res, err := dbx.GetCurrentAccount()
 		if err != nil {
 			return err
 		}
 		printFullAccount(w, res)
-	case 1:
+	} else {
 		// Otherwise look up an account with the provided ID
-		if len(args[0]) != 40 {
-			return errors.New("account ID must be 40 characters")
-		}
 		arg := users.NewGetAccountArg(args[0])
 		res, err := dbx.GetAccount(arg)
 		if err != nil {

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -1,0 +1,57 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+func account(cmd *cobra.Command, args []string) error {
+	res, err := dbx.GetCurrentAccount()
+	if err != nil {
+		return err
+	}
+
+	w := new(tabwriter.Writer)
+	w.Init(os.Stdout, 4, 8, 1, ' ', 0)
+
+	fmt.Fprintf(w, "Logged in as %s <%s>\n\n", res.Name.DisplayName, res.Email)
+	fmt.Fprintf(w, "Account Id:\t%s\n", res.AccountId)
+	fmt.Fprintf(w, "Account Type:\t%s\n", res.AccountType.Tag)
+	fmt.Fprintf(w, "Locale:\t%s\n", res.Locale)
+	fmt.Fprintf(w, "Referral Link:\t%s\n", res.ReferralLink)
+	fmt.Fprintf(w, "Paired Account:\t%t\n", res.IsPaired)
+	if res.Team != nil {
+		fmt.Fprintf(w, "Team:\n  Name:\t%s\n  Id:\t%s\n  Member Id:\t%s\n", res.Team.Name, res.Team.Id, res.TeamMemberId)
+	}
+
+	w.Flush()
+
+	return nil
+}
+
+var accountCmd = &cobra.Command{
+	Use:   "account",
+	Short: "Display information about the current account",
+	RunE:  account,
+}
+
+func init() {
+	RootCmd.AddCommand(accountCmd)
+}


### PR DESCRIPTION
The `account` command displays information about the current user's account.
Currently it displays the user's name, email, ID, account type, locale,
referral link, paired status, and team info (if applicable).

It also takes an optional account ID to look up instead of the current user. In this case it displays slightly less info than when displaying the current account (due to API restrictions).

It also displays the team name and member ID if applicable. I don't have a business account to test with, though, so please double-check that it works.

Examples:

```
$ dbxcli account
Logged in as Dylan Waits <dylan@waits.io>

Account Id:        [redacted]
Account Type:      pro
Locale:            en
Referral Link:     [redacted]
Profile Photo Url: [redacted]
Paired Account:    true
```

```
$ dbxcli account dbid:xxxx
Name:              Dylan Waits
Email:             dylan@waits.io
Is Teammate:       true
Profile Photo URL: [redacted]
```
