### PR TITLE
Check `args` slice bounds in all commands

### DIFF
--- a/cmd/add-member.go
+++ b/cmd/add-member.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/team"
@@ -22,6 +23,10 @@ import (
 )
 
 func addMember(cmd *cobra.Command, args []string) (err error) {
+	if len(args) != 3 {
+		return errors.New("`add-member` requires `email`, `first`, and `last` arguments")
+	}
+
 	email := args[0]
 	firstName := args[1]
 	lastName := args[2]

--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -14,9 +14,17 @@
 
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
 
 func cp(cmd *cobra.Command, args []string) (err error) {
+	if len(args) != 2 {
+		return errors.New("`cp` requires `src` and `dst` arguments")
+	}
+
 	arg, err := makeRelocationArg(args[0], args[1])
 	if err != nil {
 		return

--- a/cmd/mkdir.go
+++ b/cmd/mkdir.go
@@ -15,11 +15,17 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/dropbox/dropbox-sdk-go-unofficial/files"
 	"github.com/spf13/cobra"
 )
 
 func mkdir(cmd *cobra.Command, args []string) (err error) {
+	if len(args) != 1 {
+		return errors.New("`mkdir` requires a `directory` argument")
+	}
+
 	dst, err := validatePath(args[0])
 	if err != nil {
 		return

--- a/cmd/remove-member.go
+++ b/cmd/remove-member.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/team"
@@ -22,6 +23,10 @@ import (
 )
 
 func removeMember(cmd *cobra.Command, args []string) (err error) {
+	if len(args) != 1 {
+		return errors.New("`remove-member` requires an `email` argument")
+	}
+
 	email := args[0]
 	arg := team.NewMembersRemoveArg(&team.UserSelectorArg{Tag: "email", Email: email})
 	res, err := dbx.MembersRemove(arg)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -15,11 +15,17 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/dropbox/dropbox-sdk-go-unofficial/files"
 	"github.com/spf13/cobra"
 )
 
 func restore(cmd *cobra.Command, args []string) (err error) {
+	if len(args) != 2 {
+		return errors.New("`restore` requires `file` and `revision` arguments")
+	}
+
 	path, err := validatePath(args[0])
 	if err != nil {
 		return

--- a/cmd/revs.go
+++ b/cmd/revs.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -23,6 +24,10 @@ import (
 )
 
 func revs(cmd *cobra.Command, args []string) (err error) {
+	if len(args) != 1 {
+		return errors.New("`revs` requires a `file` argument")
+	}
+
 	path, err := validatePath(args[0])
 	if err != nil {
 		return

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -15,11 +15,17 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/dropbox/dropbox-sdk-go-unofficial/files"
 	"github.com/spf13/cobra"
 )
 
 func rm(cmd *cobra.Command, args []string) (err error) {
+	if len(args) != 1 {
+		return errors.New("`rm` requires a `file` argument")
+	}
+
 	path, err := validatePath(args[0])
 	if err != nil {
 		return

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -23,6 +24,10 @@ import (
 )
 
 func search(cmd *cobra.Command, args []string) (err error) {
+	if len(args) != 1 {
+		return errors.New("`search` requires a `query` argument")
+	}
+
 	arg := files.NewSearchArg("", args[0])
 
 	res, err := dbx.Search(arg)


### PR DESCRIPTION
Several commands panic when not passed enough arguments. They print an unhelpful `index out of range` error and a stack trace. This is undesirable for most routine error conditions.

In the same spirit as #12 I added `len(args)` guard clauses to the remaining commands that require arguments. They now return a helpful error explaining the arguments needed.

Example:
```
$ dbxcli mkdir
Error: `mkdir` requires a `directory` argument
```

Thoughts/questions:

- Should this be DRY'd into a `validateArgs` function in `root.go`? It's only three lines per command, so I wasn't sure if it's worth it.
- Should we print a longer error message including the usage text? We already have that text available in the `cobra.Command` so it would reduce duplication. Many other CLI tools do this. Example from Docker:

```
$ docker pull
docker: "pull" requires 1 argument.
See 'docker pull --help'.

Usage:	docker pull [OPTIONS] NAME[:TAG|@DIGEST]

Pull an image or a repository from a registry
```