### PR TITLE
Display file sizes using multiples of 1024 for consistency with other Dropbox apps

### DIFF
--- a/cmd/du.go
+++ b/cmd/du.go
@@ -27,18 +27,18 @@ func du(cmd *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	fmt.Printf("Used: %s\n", humanize.Bytes(usage.Used))
+	fmt.Printf("Used: %s\n", humanize.IBytes(usage.Used))
 	fmt.Printf("Type: %s\n", usage.Allocation.Tag)
 
 	allocation := usage.Allocation
 
 	switch allocation.Tag {
 	case "individual":
-		fmt.Printf("Allocated: %s\n", humanize.Bytes(allocation.Individual.Allocated))
+		fmt.Printf("Allocated: %s\n", humanize.IBytes(allocation.Individual.Allocated))
 	case "team":
 		fmt.Printf("Allocated: %s (Used: %s)\n",
-			humanize.Bytes(allocation.Team.Allocated),
-			humanize.Bytes(allocation.Team.Used))
+			humanize.IBytes(allocation.Team.Allocated),
+			humanize.IBytes(allocation.Team.Used))
 	}
 
 	return

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -61,7 +61,7 @@ func get(cmd *cobra.Command, args []string) (err error) {
 		Reader: contents,
 		DrawFunc: ioprogress.DrawTerminalf(os.Stderr, func(progress, total int64) string {
 			return fmt.Sprintf("Downloading %s/%s",
-				humanize.Bytes(uint64(progress)), humanize.Bytes(uint64(total)))
+				humanize.IBytes(uint64(progress)), humanize.IBytes(uint64(total)))
 		}),
 		Size: int64(res.Size),
 	}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -47,7 +47,7 @@ func printFolderMetadata(w io.Writer, e *files.FolderMetadata, longFormat bool) 
 
 func printFileMetadata(w io.Writer, e *files.FileMetadata, longFormat bool) {
 	if longFormat {
-		fmt.Fprintf(w, "%s\t%s\t%s\t", e.Rev, humanize.Bytes(e.Size), humanize.Time(e.ServerModified))
+		fmt.Fprintf(w, "%s\t%s\t%s\t", e.Rev, humanize.IBytes(e.Size), humanize.Time(e.ServerModified))
 	}
 	fmt.Fprintf(w, "%s\n", e.Name)
 }

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -88,7 +88,7 @@ func put(cmd *cobra.Command, args []string) (err error) {
 		Reader: contents,
 		DrawFunc: ioprogress.DrawTerminalf(os.Stderr, func(progress, total int64) string {
 			return fmt.Sprintf("Uploading %s/%s",
-				humanize.Bytes(uint64(progress)), humanize.Bytes(uint64(total)))
+				humanize.IBytes(uint64(progress)), humanize.IBytes(uint64(total)))
 		}),
 		Size: contentsInfo.Size(),
 	}


### PR DESCRIPTION
The Dropbox website and mobile apps display file sizes and space usage in multiples of 1024 bytes (e.g. a 10,000 byte file is displayed as `9.76 KB`, not `10 KB`). `dbxcli` currently uses multiples of 1000, so files *appear* to have different sizes than they do in the other Dropbox apps. That is somewhat confusing. I propose changing this tool to use 1024-based sizes to be consistent with Dropbox.

This PR replaces calls to [`humanize.Bytes`](https://godoc.org/github.com/dustin/go-humanize#Bytes) with [`humanize.IBytes`](https://godoc.org/github.com/dustin/go-humanize#IBytes) in the `du`, `ls`, `get`, and `put` commands.

Output before:
```
$ dbxcli du
Used: 613 MB
Type: individual
Allocated: 1.1 TB
```

Output after:
```
$dbxcli du
Used: 585 MiB
Type: individual
Allocated: 1.0 TiB
```

The same info as displayed on https://www.dropbox.com:

<img width="208" alt="screen shot 2016-06-11 at 4 32 34 pm" src="https://cloud.githubusercontent.com/assets/972475/15987945/852de5bc-2ff2-11e6-8c9a-1026c5635be0.png">
