### PR TITLE
Set `client_modified` parameter when uploading files

### DIFF
--- a/cmd/put.go
+++ b/cmd/put.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/files"
 	"github.com/dustin/go-humanize"
@@ -95,6 +96,9 @@ func put(cmd *cobra.Command, args []string) (err error) {
 
 	commitInfo := files.NewCommitInfo(dst)
 	commitInfo.Mode.Tag = "overwrite"
+
+	// The Dropbox API only accepts timestamps in UTC with second precision.
+	commitInfo.ClientModified = time.Now().UTC().Round(time.Second)
 
 	if contentsInfo.Size() > chunkSize {
 		return uploadChunked(progressbar, commitInfo, contentsInfo.Size())


### PR DESCRIPTION
The `put` command does not set the `client_modified` timestamp on uploaded files. Dropbox displays this field to users in their UI apps (web, mobile). The SDK defaults the empty timestamp to `0001-01-01 00:00:00`, which causes Dropbox to display a time in 2001.

This PR sets the `ClientModified` field on the commit info struct to the current local time before uploading the file. It also converts it to UTC and rounds to the nearest second to play nice with the Dropbox API.

The time will only be as accurate as the user's computer, but I believe that's the intent of the `client_modified` parameter anyways.

More info in #20.