### PR TITLE
Allow providing a directory as a destination for `get`

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -42,6 +42,10 @@ func get(cmd *cobra.Command, args []string) (err error) {
 	if len(args) == 2 {
 		dst = args[1]
 	}
+	// If `dst` is a directory, append the source filename.
+	if f, err := os.Stat(dst); err == nil && f.IsDir() {
+		dst = path.Join(dst, path.Base(src))
+	}
 
 	arg := files.NewDownloadArg(src)
 


### PR DESCRIPTION
Previously, running `get` with a directory as the destination argument would return an "is a directory" error message. Now it checks if `dst` is a directory before downloading and appends the filename if that's the case.

**Rationale**: Most file utilities allow specifying a directory as a destination for a file (e.g. `sftp`).