### PR TITLE
Add `logout` command

### DIFF
--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -1,0 +1,49 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+	"path"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+)
+
+func logout(cmd *cobra.Command, args []string) error {
+	dir, err := homedir.Dir()
+	if err != nil {
+		return err
+	}
+	filePath := path.Join(dir, ".config", "dbxcli", configFileName)
+
+	err = os.Remove(filePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// logoutCmd represents the logout command
+var logoutCmd = &cobra.Command{
+	Use:   "logout [flags]",
+	Short: "Log out of the current session",
+	RunE:  logout,
+}
+
+func init() {
+	RootCmd.AddCommand(logoutCmd)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -19,6 +19,12 @@
 			"revisionTime": "2016-07-29T17:17:04Z"
 		},
 		{
+			"checksumSHA1": "gkqoyxhExzsn7cdvhu7QGK121mk=",
+			"path": "github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/auth",
+			"revision": "13ed6f02d47dc93e1db59be7baf38e23f98115f6",
+			"revisionTime": "2016-07-29T17:17:04Z"
+		},
+		{
 			"checksumSHA1": "5T6WkbCA/i4yc3ygXroJcBXYMyo=",
 			"path": "github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/files",
 			"revision": "13ed6f02d47dc93e1db59be7baf38e23f98115f6",


### PR DESCRIPTION
The `logout` command deletes the saved access tokens in `auth.json`, logging the user out of all accounts (personal and team).

**Rationale:** This is needed in order to revoke access to your account, which is important for users on a shared compared or with multiple accounts.

I feel like we should also make a call to `/auth/token/revoke` to permanently revoke the token that was in use, just in case (especially since they never expire). I couldn't find any way of doing that in the SDK, though, so we'd have to wait for that to be added or just make a raw HTTP request.