### PR TITLE
Add --recursive to the rm command

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -52,15 +52,9 @@ func printFileMetadata(w io.Writer, e *files.FileMetadata, longFormat bool) {
 	fmt.Fprintf(w, "%s\n", e.Name)
 }
 
-func ls(cmd *cobra.Command, args []string) (err error) {
-	path := ""
-	if len(args) > 0 {
-		if path, err = validatePath(args[0]); err != nil {
-			return err
-		}
-	}
-
-	arg := files.NewListFolderArg(path)
+// Return the list of files in a folder
+func ListFiles(folderpath string) ([]*files.Metadata, error) {
+	arg := files.NewListFolderArg(folderpath)
 
 	res, err := dbx.ListFolder(arg)
 	var entries []*files.Metadata
@@ -69,14 +63,14 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 		// get_metadata request for the same path and using that response instead.
 		if strings.Contains(err.Error(), "path/not_folder/") {
 			var metaRes *files.Metadata
-			metaRes, err = getFileMetadata(path)
+			metaRes, err = getFileMetadata(folderpath)
 			entries = []*files.Metadata{metaRes}
 		}
 
 		// Return if there's an error other than "not_folder" or if the follow-up
 		// metadata request fails.
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		entries = res.Entries
@@ -86,11 +80,25 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 
 			res, err = dbx.ListFolderContinue(arg)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			entries = append(entries, res.Entries...)
 		}
+	}
+	return entries, nil
+}
+
+func ls(cmd *cobra.Command, args []string) (err error) {
+	path := ""
+	if len(args) > 0 {
+		if path, err = validatePath(args[0]); err != nil {
+			return err
+		}
+	}
+	entries, err := ListFiles(path)
+	if err != nil {
+		return err
 	}
 
 	w := new(tabwriter.Writer)

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -22,12 +22,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func rm(cmd *cobra.Command, args []string) (err error) {
-	if len(args) != 1 {
-		return errors.New("`rm` requires a `file` argument")
-	}
-
-	path, err := validatePath(args[0])
+func removePath(rawpath string) (err error) {
+	path, err := validatePath(rawpath)
 	if err != nil {
 		return
 	}
@@ -45,8 +41,14 @@ func rm(cmd *cobra.Command, args []string) (err error) {
 	if _, err = dbx.Delete(arg); err != nil {
 		return
 	}
+	return nil
+}
 
-	return
+func rm(cmd *cobra.Command, args []string) (err error) {
+	if len(args) != 1 {
+		return errors.New("`rm` requires a `file` or `folder` argument")
+	}
+	return removePath(args[0])
 }
 
 // rmCmd represents the rm command

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -17,12 +17,13 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	pathmod "path"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/files"
 	"github.com/spf13/cobra"
 )
 
-func removePath(rawpath string) (err error) {
+func removePath(rawpath string, recursive bool) (err error) {
 	path, err := validatePath(rawpath)
 	if err != nil {
 		return
@@ -33,7 +34,21 @@ func removePath(rawpath string) (err error) {
 		return
 	}
 	if pathMetaData.Tag == folder {
-		return fmt.Errorf("rm: cannot remove ‘%s’: Is a directory", path)
+		if !recursive {
+			return fmt.Errorf("rm: cannot remove ‘%s’: Is a directory", path)
+		}
+		entries, err := ListFiles(path)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			switch e.Tag {
+			case "folder":
+				removePath(pathmod.Join(path, e.Folder.Name), recursive)
+			case "file":
+				removePath(pathmod.Join(path, e.File.Name), recursive)
+			}
+		}
 	}
 
 	arg := files.NewDeleteArg(path)
@@ -48,16 +63,20 @@ func rm(cmd *cobra.Command, args []string) (err error) {
 	if len(args) != 1 {
 		return errors.New("`rm` requires a `file` or `folder` argument")
 	}
-	return removePath(args[0])
+	recursive, _ := cmd.Flags().GetBool("recursive")
+	return removePath(args[0], recursive)
 }
 
 // rmCmd represents the rm command
 var rmCmd = &cobra.Command{
 	Use:   "rm [flags] <file>",
 	Short: "Remove files",
-	RunE:  rm,
+	Example: `dbxcli rm <file>
+	dbxcli rm -r <folder>`,
+	RunE: rm,
 }
 
 func init() {
 	RootCmd.AddCommand(rmCmd)
+	rmCmd.Flags().BoolP("recursive", "r", false, "Recursive removal")
 }


### PR DESCRIPTION
I tested with the following folder/file structure, Junk and Junk2 are folders, aa and aaa are files:

Junk
├── Junk2
│   └── aaa
└── aa

./dbxcli rm  Junk # Refuses to remove a folder
Error: rm: cannot remove ‘/Junk’: Is a directory

./dbxcli rm  -r Junk # Works and remove the folder recursively
