### PR TITLE
Replace strings with consts defined in root.go

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -102,9 +102,9 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 		fmt.Fprintf(w, "Revision\tSize\tLast modified\tPath\n")
 		for _, entry := range entries {
 			switch entry.Tag {
-			case "folder":
+			case folder:
 				printFolderMetadata(w, entry.Folder, long)
-			case "file":
+			case file:
 				printFileMetadata(w, entry.File, long)
 			}
 		}
@@ -122,9 +122,9 @@ func listOfEntryNames(entries []*files.Metadata) []string {
 
 	for _, entry := range entries {
 		switch entry.Tag {
-		case "folder":
+		case folder:
 			listOfEntryNames = append(listOfEntryNames, entry.Folder.Name)
-		case "file":
+		case file:
 			listOfEntryNames = append(listOfEntryNames, entry.File.Name)
 		}
 	}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -43,9 +43,9 @@ func search(cmd *cobra.Command, args []string) (err error) {
 	for _, m := range res.Matches {
 		e := m.Metadata
 		switch e.Tag {
-		case "folder":
+		case folder:
 			printFolderMetadata(os.Stdout, e.Folder, long)
-		case "file":
+		case file:
 			printFileMetadata(os.Stdout, e.File, long)
 		}
 	}


### PR DESCRIPTION
This would put the consts for `"file"` and `"folder"` that were defined in root.go to use. It's better to have them as constants than strings defined in multiple places.