### PR TITLE
Adds another subcommand layer `share list`.

### DIFF
--- a/cmd/share-list-folders.go
+++ b/cmd/share-list-folders.go
@@ -53,11 +53,11 @@ func printFolders(entries []*sharing.SharedFolderMetadata) {
 }
 
 var shareListFoldersCmd = &cobra.Command{
-	Use:   "list-folders",
+	Use:   "folder",
 	Short: "List shared folders",
 	RunE:  shareListFolders,
 }
 
 func init() {
-	shareCmd.AddCommand(shareListFoldersCmd)
+	shareListCmd.AddCommand(shareListFoldersCmd)
 }

--- a/cmd/share-list-links.go
+++ b/cmd/share-list-links.go
@@ -65,11 +65,11 @@ func printLink(sl sharing.SharedLinkMetadata) {
 }
 
 var shareListLinksCmd = &cobra.Command{
-	Use:   "list-links",
+	Use:   "link",
 	Short: "List shared links",
 	RunE:  shareListLinks,
 }
 
 func init() {
-	shareCmd.AddCommand(shareListLinksCmd)
+	shareListCmd.AddCommand(shareListLinksCmd)
 }

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -23,6 +23,12 @@ var shareCmd = &cobra.Command{
 	Short: "Sharing commands",
 }
 
+var shareListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List shared things",
+}
+
 func init() {
 	RootCmd.AddCommand(shareCmd)
+	shareCmd.AddCommand(shareListCmd)
 }


### PR DESCRIPTION
Usage: `share list link` and `share list folder`. Manually tested.