### PR TITLE
Adds `share list file` (received files).

### DIFF
--- a/cmd/share-list-files.go
+++ b/cmd/share-list-files.go
@@ -1,0 +1,63 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/sharing"
+	"github.com/spf13/cobra"
+)
+
+func shareListFiles(cmd *cobra.Command, args []string) (err error) {
+	arg := sharing.NewListFilesArg()
+
+	dbx := sharing.New(config)
+	res, err := dbx.ListReceivedFiles(arg)
+	if err != nil {
+		return
+	}
+
+	printFiles(res.Entries)
+
+	for len(res.Cursor) > 0 {
+		continueArg := sharing.NewListFilesContinueArg(res.Cursor)
+
+		res, err = dbx.ListReceivedFilesContinue(continueArg)
+		if err != nil {
+			return
+		}
+
+		printFiles(res.Entries)
+	}
+
+	return
+}
+
+func printFiles(entries []*sharing.SharedFileMetadata) {
+	for _, f := range entries {
+		fmt.Printf("%v\t%v\n", f.Name, f.PreviewUrl)
+	}
+}
+
+var shareListFilesCmd = &cobra.Command{
+	Use:   "file",
+	Short: "List shared files (not including those in shared folders)",
+	RunE:  shareListFiles,
+}
+
+func init() {
+	shareListCmd.AddCommand(shareListFilesCmd)
+}

--- a/cmd/share-list-files.go
+++ b/cmd/share-list-files.go
@@ -53,8 +53,8 @@ func printFiles(entries []*sharing.SharedFileMetadata) {
 }
 
 var shareListFilesCmd = &cobra.Command{
-	Use:   "file",
-	Short: "List shared files (not including those in shared folders)",
+	Use:   "received-file",
+	Short: "List received files (not including those in shared folders)",
 	RunE:  shareListFiles,
 }
 

--- a/cmd/share-list-folders.go
+++ b/cmd/share-list-folders.go
@@ -53,11 +53,11 @@ func printFolders(entries []*sharing.SharedFolderMetadata) {
 }
 
 var shareListFoldersCmd = &cobra.Command{
-	Use:   "list-folders",
+	Use:   "folder",
 	Short: "List shared folders",
 	RunE:  shareListFolders,
 }
 
 func init() {
-	shareCmd.AddCommand(shareListFoldersCmd)
+	shareListCmd.AddCommand(shareListFoldersCmd)
 }

--- a/cmd/share-list-links.go
+++ b/cmd/share-list-links.go
@@ -65,11 +65,11 @@ func printLink(sl sharing.SharedLinkMetadata) {
 }
 
 var shareListLinksCmd = &cobra.Command{
-	Use:   "list-links",
+	Use:   "link",
 	Short: "List shared links",
 	RunE:  shareListLinks,
 }
 
 func init() {
-	shareCmd.AddCommand(shareListLinksCmd)
+	shareListCmd.AddCommand(shareListLinksCmd)
 }

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -23,6 +23,12 @@ var shareCmd = &cobra.Command{
 	Short: "Sharing commands",
 }
 
+var shareListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List shared things",
+}
+
 func init() {
 	RootCmd.AddCommand(shareCmd)
+	shareCmd.AddCommand(shareListCmd)
 }


### PR DESCRIPTION
Usage: `share list file`.

PR on top of https://github.com/dropbox/dbxcli/pull/39.
