### PR TITLE
Adds `share link` for creating shared links.

### DIFF
--- a/cmd/share-link.go
+++ b/cmd/share-link.go
@@ -1,0 +1,64 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/sharing"
+	"github.com/spf13/cobra"
+)
+
+func shareLink(cmd *cobra.Command, args []string) (err error) {
+	if len(args) != 1 {
+		return errors.New("`link` requires `path`")
+	}
+
+	path := args[0]
+
+	// TODO(bonafidehan): support other visibility.
+	arg := sharing.NewCreateSharedLinkWithSettingsArg(path)
+
+	dbx := sharing.New(config)
+	res, err := dbx.CreateSharedLinkWithSettings(arg)
+	if err != nil {
+		return
+	}
+
+	switch sl := res.(type) {
+	case *sharing.FileLinkMetadata:
+		printLinkMetadata(sl.SharedLinkMetadata)
+	case *sharing.FolderLinkMetadata:
+		printLinkMetadata(sl.SharedLinkMetadata)
+	}
+
+	return
+}
+
+func printLinkMetadata(sl sharing.SharedLinkMetadata) {
+	fmt.Printf("%v\t%v\n", sl.Name, sl.Url)
+}
+
+// searchCmd represents the search command
+var shareLinkCmd = &cobra.Command{
+	Use:   "link <path>",
+	Short: "Create a shared link with public visibility",
+	RunE:  shareLink,
+}
+
+func init() {
+	shareCmd.AddCommand(shareLinkCmd)
+}

--- a/cmd/share-list-folders.go
+++ b/cmd/share-list-folders.go
@@ -53,11 +53,11 @@ func printFolders(entries []*sharing.SharedFolderMetadata) {
 }
 
 var shareListFoldersCmd = &cobra.Command{
-	Use:   "list-folders",
+	Use:   "folder",
 	Short: "List shared folders",
 	RunE:  shareListFolders,
 }
 
 func init() {
-	shareCmd.AddCommand(shareListFoldersCmd)
+	shareListCmd.AddCommand(shareListFoldersCmd)
 }

--- a/cmd/share-list-links.go
+++ b/cmd/share-list-links.go
@@ -65,11 +65,11 @@ func printLink(sl sharing.SharedLinkMetadata) {
 }
 
 var shareListLinksCmd = &cobra.Command{
-	Use:   "list-links",
+	Use:   "link",
 	Short: "List shared links",
 	RunE:  shareListLinks,
 }
 
 func init() {
-	shareCmd.AddCommand(shareListLinksCmd)
+	shareListCmd.AddCommand(shareListLinksCmd)
 }

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -23,6 +23,12 @@ var shareCmd = &cobra.Command{
 	Short: "Sharing commands",
 }
 
+var shareListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List shared things",
+}
+
 func init() {
 	RootCmd.AddCommand(shareCmd)
+	shareCmd.AddCommand(shareListCmd)
 }


### PR DESCRIPTION
Currently supports only public shared links.

PR on top of https://github.com/dropbox/dbxcli/pull/39.
