### PR TITLE
Display full path

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -43,14 +43,14 @@ func printFolderMetadata(w io.Writer, e *files.FolderMetadata, longFormat bool) 
 	if longFormat {
 		fmt.Fprintf(w, "-\t-\t-\t")
 	}
-	fmt.Fprintf(w, "%s\n", e.Name)
+	fmt.Fprintf(w, "%s\n", e.PathDisplay)
 }
 
 func printFileMetadata(w io.Writer, e *files.FileMetadata, longFormat bool) {
 	if longFormat {
 		fmt.Fprintf(w, "%s\t%s\t%s\t", e.Rev, humanize.IBytes(e.Size), humanize.Time(e.ServerModified))
 	}
-	fmt.Fprintf(w, "%s\n", e.Name)
+	fmt.Fprintf(w, "%s\n", e.PathDisplay)
 }
 
 func ls(cmd *cobra.Command, args []string) (err error) {


### PR DESCRIPTION
When using, for example, `dbx search`, it isn't very helpful to include just filenames. For everything I've ever used this for, I need the full path. This changes the display of the list to include the full path.