### PR TITLE
Allow a path of rev: or id: for get comands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,7 +78,7 @@ func oauthConfig(tokenType string, domain string) *oauth2.Config {
 func validatePath(p string) (path string, err error) {
 	path = p
 
-	if !strings.HasPrefix(path, "/") {
+	if !strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "rev:") && !strings.HasPrefix(path, "id:") {
 		path = fmt.Sprintf("/%s", path)
 	}
 


### PR DESCRIPTION
The API allows for the download (get) command to use "path": "rev:a1c10ce0dd78" or "path": "id:a4ayc_80_OEAAAAAAAAAYa" but the validatePath function adds "/" to the path if it is not there. This
results in "path": "/rev:a1c10ce0dd78" and an error.

This change stops the "/" from being added if the path begins with "rev:" or "id:". This allows the command `dbxcli get rev:a1c10ce0dd78 file.ext` to run and download a specific revision of a file.