### PR TITLE
Issue #109: Clarify restore arguments

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -45,7 +45,7 @@ func restore(cmd *cobra.Command, args []string) (err error) {
 
 // restoreCmd represents the restore command
 var restoreCmd = &cobra.Command{
-	Use:   "restore [flags] <file> <revision>",
+	Use:   "restore [flags] <target> <revision>",
 	Short: "Restore files",
 	RunE:  restore,
 }


### PR DESCRIPTION
Fix restore help description to clarify the first argument is the target file.