### PR TITLE
Add option to output file size and date/times in a machine readable format

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -44,9 +44,13 @@ func printFolderMetadata(w io.Writer, e *files.FolderMetadata, longFormat bool) 
 	fmt.Fprintf(w, "%s\t", e.PathDisplay)
 }
 
-func printFileMetadata(w io.Writer, e *files.FileMetadata, longFormat bool) {
+func printFileMetadata(w io.Writer, e *files.FileMetadata, longFormat bool, machineReadable bool) {
 	if longFormat {
-		fmt.Fprintf(w, "%s\t%s\t%s\t", e.Rev, humanize.IBytes(e.Size), humanize.Time(e.ServerModified))
+		if (machineReadable) {
+			fmt.Fprintf(w, "%s\t%d\t%s\t", e.Rev, e.Size, e.ServerModified)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\t", e.Rev, humanize.IBytes(e.Size), humanize.Time(e.ServerModified))
+		}
 	}
 	fmt.Fprintf(w, "%s\t", e.PathDisplay)
 }
@@ -62,6 +66,7 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 
 	arg := files.NewListFolderArg(path)
 	arg.Recursive, _ = cmd.Flags().GetBool("recurse")
+	machineReadable, _ := cmd.Flags().GetBool("machine")
 
 	res, err := dbx.ListFolder(arg)
 	var entries []files.IsMetadata
@@ -110,7 +115,7 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 	for i, entry := range entries {
 		switch f := entry.(type) {
 		case *files.FileMetadata:
-			printFileMetadata(w, f, long)
+			printFileMetadata(w, f, long, machineReadable)
 		case *files.FolderMetadata:
 			printFolderMetadata(w, f, long)
 		}
@@ -139,4 +144,5 @@ func init() {
 
 	lsCmd.Flags().BoolP("long", "l", false, "Long listing")
 	lsCmd.Flags().BoolP("recurse", "R", false, "Recursively list all subfolders")
+	lsCmd.Flags().BoolP("machine", "m", false, "Machine readable file size and time")
 }

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -66,7 +66,6 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 
 	arg := files.NewListFolderArg(path)
 	arg.Recursive, _ = cmd.Flags().GetBool("recurse")
-	machineReadable, _ := cmd.Flags().GetBool("machine")
 
 	res, err := dbx.ListFolder(arg)
 	var entries []files.IsMetadata
@@ -106,7 +105,12 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
+	machineReadable, _ := cmd.Flags().GetBool("machine")
 	long, _ := cmd.Flags().GetBool("long")
+
+	//If machine is set imply long
+	long = long || machineReadable
+
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 4, 8, 1, ' ', 0)
 	if long {

--- a/cmd/revs.go
+++ b/cmd/revs.go
@@ -42,6 +42,7 @@ func revs(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	long, _ := cmd.Flags().GetBool("long")
+	machineReadable, _ := cmd.Flags().GetBool("machine")
 
 	if long {
 		fmt.Printf("Revision\tSize\tLast modified\tPath\n")
@@ -49,7 +50,7 @@ func revs(cmd *cobra.Command, args []string) (err error) {
 
 	for _, e := range res.Entries {
 		if long {
-			printFileMetadata(os.Stdout, e, long)
+			printFileMetadata(os.Stdout, e, long, machineReadable)
 		} else {
 			fmt.Printf("%s\n", e.Rev)
 		}
@@ -69,4 +70,5 @@ func init() {
 	RootCmd.AddCommand(revsCmd)
 
 	revsCmd.Flags().BoolP("long", "l", false, "Long listing")
+	revsCmd.Flags().BoolP("machine", "m", false, "Machine readable file size and time")
 }

--- a/cmd/revs.go
+++ b/cmd/revs.go
@@ -41,8 +41,11 @@ func revs(cmd *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	long, _ := cmd.Flags().GetBool("long")
 	machineReadable, _ := cmd.Flags().GetBool("machine")
+	long, _ := cmd.Flags().GetBool("long")
+
+	//If machine is set imply long
+	long = long || machineReadable
 
 	if long {
 		fmt.Printf("Revision\tSize\tLast modified\tPath\n")

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -46,6 +46,7 @@ func search(cmd *cobra.Command, args []string) (err error) {
 		return
 	}
 
+	machineReadable, _ := cmd.Flags().GetBool("machine")
 	long, _ := cmd.Flags().GetBool("long")
 	if long {
 		fmt.Printf("Revision\tSize\tLast modified\tPath\n")
@@ -54,7 +55,7 @@ func search(cmd *cobra.Command, args []string) (err error) {
 	for _, m := range res.Matches {
 		switch f := m.Metadata.(type) {
 		case *files.FileMetadata:
-			printFileMetadata(os.Stdout, f, long)
+			printFileMetadata(os.Stdout, f, long, machineReadable)
 		case *files.FolderMetadata:
 			printFolderMetadata(os.Stdout, f, long)
 		}
@@ -73,4 +74,5 @@ var searchCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(searchCmd)
 	searchCmd.Flags().BoolP("long", "l", false, "Long listing")
+	searchCmd.Flags().BoolP("machine", "m", false, "Machine readable file size and time")
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -48,6 +48,10 @@ func search(cmd *cobra.Command, args []string) (err error) {
 
 	machineReadable, _ := cmd.Flags().GetBool("machine")
 	long, _ := cmd.Flags().GetBool("long")
+
+	//If machine is set imply long
+	long = long || machineReadable
+
 	if long {
 		fmt.Printf("Revision\tSize\tLast modified\tPath\n")
 	}

--- a/contrib/zsh-completion/_dbxcli
+++ b/contrib/zsh-completion/_dbxcli
@@ -24,6 +24,7 @@ function _dbxcli() {
           _arguments -C \
             '(-l --long)'{-l,--long}'[Long listing]' \
             '(-h --help)'{-h,--help}'[Print information about a command]' \
+            '(-m --machine)'{-m,--machine}'[Output machine readable file sizes and times]' \
             '--token[(string) Access token]' \
             '(-v --verbose)'{-v,--verbose}'[Enable verbose logging]' \
             && ret=0


### PR DESCRIPTION
The usual command flag would be -h to make it human readable but as this is already the default behaviour implementing it in this way would require a change to existing functionality that others may rely on. This change is to add a slightly less conventional switch to allow the output to be more friendly to integrating with scripts.

The change allows for a -m / --machine flag for rev/search/ls commands which will output the file size in bytes and the date in a standard format rather than "X hours ago" etc. This allows for use in scripts where you want to compare a file size or check the modified date (separate PR for maintaining this when uploading via the put command)

The -m / --machine switch implies -l / --long as the standard ls output doesn't include any humanised information anyway.

Existing long output
```
$ dbxcli ls -l
Revision              Size  Last modified Path
5a3f4f259f9d3554dee35 548 B 2 hours ago   /LICENSE
```

```
$ dbxcli ls -m
Revision              Size Last modified                 Path
5a3f4f259f9d3554dee35 548  2020-04-23 13:08:36 +0000 UTC /LICENSE
```