### PR TITLE
Preserve modified times on files uploaded with put command

### DIFF
--- a/cmd/put.go
+++ b/cmd/put.go
@@ -100,7 +100,7 @@ func put(cmd *cobra.Command, args []string) (err error) {
 	commitInfo.Mode.Tag = "overwrite"
 
 	// The Dropbox API only accepts timestamps in UTC with second precision.
-	commitInfo.ClientModified = time.Now().UTC().Round(time.Second)
+	commitInfo.ClientModified = contentsInfo.ModTime().UTC().Round(time.Second)
 
 	dbx := files.New(config)
 	if contentsInfo.Size() > chunkSize {


### PR DESCRIPTION
The put command currently sets the client settable file modified date time to be the current date and time. This changes that behaviour to maintain the modified date/time of the file being uploaded from the source file system. The use case inspiring this change is where this tool may be used to migrate content into dropbox from an existing source where not maintaining the existing modified timestamps of files would loose valuable metadata.