### PR TITLE
Make cp command for a single source avoid preserving the original folder structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+dbxcli.exe

--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -26,13 +26,16 @@ import (
 func cp(cmd *cobra.Command, args []string) error {
 	var destination string
 	var argsToCopy []string
+	var keepOriginalFolderStructure bool
 
 	if len(args) > 2 {
 		destination = args[len(args)-1]
 		argsToCopy = args[0 : len(args)-1]
+		keepOriginalFolderStructure = true
 	} else if len(args) == 2 {
 		destination = args[1]
 		argsToCopy = append(argsToCopy, args[0])
+		keepOriginalFolderStructure = false
 	} else {
 		return errors.New("cp requires a source and a destination")
 	}
@@ -41,7 +44,13 @@ func cp(cmd *cobra.Command, args []string) error {
 	var relocationArgs []*files.RelocationArg
 
 	for _, argument := range argsToCopy {
-		arg, err := makeRelocationArg(argument, destination+"/"+argument)
+		var actualDestination string
+		if keepOriginalFolderStructure {
+			actualDestination = destination + "/" + argument
+		} else {
+			actualDestination = destination
+		}
+		arg, err := makeRelocationArg(argument, actualDestination)
 		if err != nil {
 			relocationError := fmt.Errorf("Error validating copy for %s to %s: %v", argument, destination, err)
 			cpErrors = append(cpErrors, relocationError)


### PR DESCRIPTION
Using `cp` command I noticed the following behaviour. Let's suppose I have File-A.txt within the following structure:
```
dbxcli.exe ls -l dbxcli/folderA/folder1
Revision              Size Last modified Path
5c5e6a3c10919314d4221 6 B  4 minutes ago /dbxcli/folderA/folder1/File-A.txt
```
while the following folder is empty:
```
dbxcli.exe ls -l dbxcli/folderB/folder1
Revision Size Last modified Path

```
Now I copy File-A.txt to `dbxcli/folderB/folder1/File-A.txt`:
```
dbxcli.exe cp dbxcli/folderA/folder1/File-A.txt dbxcli/folderB/folder1/File-A.txt
```
As a normal `cp` command, I'd expect to find the file in `dbxcli/folderB/folder1/File-A.txt`. Instead, File-A.txt is a folder that contains the whole original folder structure:
```
dbxcli.exe ls -l /dbxcli/folderB/folder1/File-A.txt/dbxcli/folderA/folder1
Revision              Size Last modified Path
5c5e6bd04b28f314d4221 6 B  1 minute ago  /dbxcli/folderB/folder1/File-A.txt/dbxcli/folderA/folder1/File-A.txt 
```
I can see the reason why it is important to preserve the original structure when you specify more than one source (i.e. avoiding name conflicts on the destination), but when there is a classic `cp <from> <to>` structure, I think it would be more useful to use the specified destination as the actual destination where the file/folder will be placed. Otherwise you would not be able to copy a single file from A to B.

The purpose of this merge request is changing `cp` command so that it preserves the original folder structure if and only if more than one source has been specified. Otherwise, it will work as a classic `cp`, having one source and one actual destination.

Starting from the same preconditions as the previous example, now `cp` would work as follows:
```
dbxcli.exe cp dbxcli/folderA/folder1/File-A.txt dbxcli/folderB/folder1/File-A.txt

dbxcli.exe ls -l /dbxcli/folderB/folder1 
Revision              Size Last modified  Path
5c611315ec247314d4221 6 B  25 seconds ago /dbxcli/folderB/folder1/File-A.txt
```