### PR TITLE
Add Apple M1 support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,5 +8,5 @@ LDFLAGS+=" -X github.com/dropbox/dbxcli/cmd.teamAccessAppSecret=${ACCESS_SECRET}
 LDFLAGS+=" -X github.com/dropbox/dbxcli/cmd.teamManageAppKey=${MANAGE_KEY}"
 LDFLAGS+=" -X github.com/dropbox/dbxcli/cmd.teamManageAppSecret=${MANAGE_SECRET}"
 GO111MODULE=on gox -ldflags="${LDFLAGS}" \
-    -osarch="darwin/amd64 linux/amd64 windows/amd64 linux/arm openbsd/amd64" \
+    -osarch="darwin/amd64 darwin/arm64 linux/amd64 windows/amd64 linux/arm openbsd/amd64" \
     -output "dist/{{.Dir}}-{{.OS}}-{{.Arch}}"


### PR DESCRIPTION
This PR enables Apple M1 support of this tool. Tested on M1 with Go version 1.18.1.