### PR TITLE
fix(ls): missing new line

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -212,6 +212,10 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
+	if itemCounter%4 != 0 {
+		fmt.Fprintln(w) // Final newline.
+	}
+
 	err = w.Flush()
 	return err
 }


### PR DESCRIPTION
Fix ls not outputting a final new line if its not a multiple of 4.