### PR TITLE
feat: improve environment support

### DIFF
--- a/cmd/consts.go
+++ b/cmd/consts.go
@@ -1,0 +1,17 @@
+package cmd
+
+const (
+	// Config file name and location.
+	configFileName = "auth.json"
+	appName        = "dbxcli"
+	configBase     = ".config"
+
+	// Environment variable names.
+	tokensEnv              = "DROPBOX_TOKENS"
+	personalAppKeyEnv      = "DROPBOX_PERSONAL_APP_KEY"
+	personalAppSecretEnv   = "DROPBOX_PERSONAL_APP_SECRET"
+	teamAccessAppKeyEnv    = "DROPBOX_TEAM_APP_KEY"
+	teamAccessAppSecretEnv = "DROPBOX_TEAM_APP_SECRET"
+	teamManageAppKeyEnv    = "DROPBOX_MANAGE_APP_KEY"
+	teamManageAppSecretEnv = "DROPBOX_MANAGE_APP_SECRET"
+)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+)
+
+// configFile returns the path to the config file.
+func configFile() (string, error) {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user homedir: %w", err)
+	}
+
+	return path.Join(dir, configBase, appName, configFileName), nil
+}
+
+// readTokens returns a token map read from either the
+// DROPBOX_TOKENS environment variable or the filePath, in that
+// order.
+func readTokens(filePath string) (TokenMap, error) {
+	var data []byte
+	if envTokens := os.Getenv(tokensEnv); envTokens != "" {
+		data = []byte(envTokens)
+	} else {
+		var err error
+		if data, err = os.ReadFile(filePath); err != nil {
+			if os.IsNotExist(err) {
+				return make(TokenMap), nil
+			}
+			return nil, fmt.Errorf("read tokens: %w", err)
+		}
+	}
+
+	var tokens TokenMap
+	if err := json.Unmarshal(data, &tokens); err != nil {
+		return nil, fmt.Errorf("decode tokens: %w", err)
+	}
+
+	return tokens, nil
+}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -15,22 +15,20 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
-	"path"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
 // Command logout revokes all saved API tokens and deletes auth.json.
 func logout(cmd *cobra.Command, args []string) error {
-	dir, err := homedir.Dir()
+	filePath, err := configFile()
 	if err != nil {
-		return err
+		return fmt.Errorf("config file: %w", err)
 	}
-	filePath := path.Join(dir, ".config", "dbxcli", configFileName)
 
 	tokMap, err := readTokens(filePath)
 	if err != nil {

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -96,7 +95,7 @@ func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, 
 
 	written := int64(0)
 	for written < sizeTotal {
-		data, err := ioutil.ReadAll(&io.LimitedReader{R: r, N: chunkSize})
+		data, err := io.ReadAll(&io.LimitedReader{R: r, N: chunkSize})
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e
 	github.com/spf13/cobra v0.0.4-0.20190109003409-7547e83b2d85
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,6 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e h1:Qa6dnn8DlasdXRnacluu8HzPts0S1I9zvvUPDbBnXFI=
 github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e/go.mod h1:waEya8ee1Ro/lgxpVhkJI4BVASzkm3UZqkx/cFJiYHM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Improve support for configuring the tool from the environment as is commonly used for CI use cases.

This adds the ability to read auth tokens from the DROPBOX_TOKENS environment variable instead of from the configuration file.

Also add the ability to configured the personal app key which wasn't named and now configurable using DROPBOX_PERSONAL_APP_KEY environment variable to match the other options.

Constants for config location and environment variable names are now stored in consts.go to make them more visible.

Some additional improvement in error checking and extracting the common configFile helper, including using stdlib os.UserHomeDir instead of the custom library version.

Switch from deprecated ioutil.ReadFile to supported os.ReadFile.