### PR TITLE
Add support for Dropbox team folders with path-root header

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -115,24 +115,28 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 
 	dbx := files.New(config)
 
-	// check if given object exists
-	var metaRes files.IsMetadata
-	metaRes, err = getFileMetadata(dbx, path)
-	if err != nil {
-		return err
-	}
-
 	if long {
 		fmt.Fprint(w, "Revision\tSize\tLast modified\tPath\n")
 	}
 
-	// handle case when path to file was given
-	switch f := metaRes.(type) {
-	case *files.FileMetadata:
-		if !onlyDeleted {
-			printItem(formatFileMetadata(f, long))
-			err = w.Flush()
+	// Check whether the path exists and is a file rather than a folder.
+	// Skip this for the root path ("") since get_metadata returns an error for
+	// it ("The root folder is unsupported") and the root is always a folder.
+	if path != "" {
+		var metaRes files.IsMetadata
+		metaRes, err = getFileMetadata(dbx, path)
+		if err != nil {
 			return err
+		}
+
+		// handle case when path to file was given
+		switch f := metaRes.(type) {
+		case *files.FileMetadata:
+			if !onlyDeleted {
+				printItem(formatFileMetadata(f, long))
+				err = w.Flush()
+				return err
+			}
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,9 @@ import (
 	"strings"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/common"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
 	"github.com/spf13/cobra"
 )
 
@@ -167,6 +169,28 @@ func initDbx(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	config = makeDropboxConfig(accessToken, verbose, asMember, domain)
+
+	// Auto-detect the root namespace so that team folders are accessible.
+	// Team manage tokens are for administrative operations and don't need
+	// a path root; skip auto-detection for those.
+	if tokType != tokenTeamManage {
+		usersClient := users.New(config)
+		account, accountErr := usersClient.GetCurrentAccount()
+		if accountErr != nil {
+			config.LogInfo("Warning: could not auto-detect root namespace (%v); team folders may not be accessible", accountErr)
+		} else {
+			var rootNamespaceID string
+			switch ri := account.RootInfo.(type) {
+			case *common.TeamRootInfo:
+				rootNamespaceID = ri.RootNamespaceId
+			case *common.UserRootInfo:
+				rootNamespaceID = ri.RootNamespaceId
+			}
+			if rootNamespaceID != "" {
+				config = config.WithRoot(rootNamespaceID)
+			}
+		}
+	}
 
 	return
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -155,6 +155,7 @@ func initDbx(cmd *cobra.Command, args []string) (err error) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	asMember, _ := cmd.Flags().GetString("as-member")
 	domain, _ := cmd.Flags().GetString("domain")
+	pathRoot, _ := cmd.Flags().GetString("path-root")
 
 	dir, err := homedir.Dir()
 	if err != nil {
@@ -197,6 +198,17 @@ func initDbx(cmd *cobra.Command, args []string) (err error) {
 	if verbose {
 		logLevel = dropbox.LogInfo
 	}
+
+	var headerGenerator func(hostType string, style string, namespace string, route string) map[string]string
+	if pathRoot != "" {
+		pathRootHeader := fmt.Sprintf(`{".tag": "namespace_id", "namespace_id": "%s"}`, pathRoot)
+		headerGenerator = func(_ string, _ string, _ string, _ string) map[string]string {
+			return map[string]string{
+				"Dropbox-API-Path-Root": pathRootHeader,
+			}
+		}
+	}
+
 	config = dropbox.Config{
 		Token:           tokens[tokType],
 		LogLevel:        logLevel,
@@ -204,7 +216,7 @@ func initDbx(cmd *cobra.Command, args []string) (err error) {
 		AsMemberID:      asMember,
 		Domain:          domain,
 		Client:          nil,
-		HeaderGenerator: nil,
+		HeaderGenerator: headerGenerator,
 		URLGenerator:    nil,
 	}
 
@@ -232,6 +244,7 @@ func Execute() {
 func init() {
 	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose logging")
 	RootCmd.PersistentFlags().String("as-member", "", "Member ID to perform action as")
+	RootCmd.PersistentFlags().String("path-root", "", "Namespace ID to use as the path root (for team folders; sets Dropbox-API-Path-Root header)")
 	// This flag should only be used for testing. Marked hidden so it doesn't clutter usage etc.
 	RootCmd.PersistentFlags().String("domain", "", "Override default Dropbox domain, useful for testing")
 	RootCmd.PersistentFlags().MarkHidden("domain")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,9 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/common"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -155,7 +157,6 @@ func initDbx(cmd *cobra.Command, args []string) (err error) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	asMember, _ := cmd.Flags().GetString("as-member")
 	domain, _ := cmd.Flags().GetString("domain")
-	pathRoot, _ := cmd.Flags().GetString("path-root")
 
 	dir, err := homedir.Dir()
 	if err != nil {
@@ -199,16 +200,6 @@ func initDbx(cmd *cobra.Command, args []string) (err error) {
 		logLevel = dropbox.LogInfo
 	}
 
-	var headerGenerator func(hostType string, style string, namespace string, route string) map[string]string
-	if pathRoot != "" {
-		pathRootHeader := fmt.Sprintf(`{".tag": "namespace_id", "namespace_id": "%s"}`, pathRoot)
-		headerGenerator = func(_ string, _ string, _ string, _ string) map[string]string {
-			return map[string]string{
-				"Dropbox-API-Path-Root": pathRootHeader,
-			}
-		}
-	}
-
 	config = dropbox.Config{
 		Token:           tokens[tokType],
 		LogLevel:        logLevel,
@@ -216,8 +207,33 @@ func initDbx(cmd *cobra.Command, args []string) (err error) {
 		AsMemberID:      asMember,
 		Domain:          domain,
 		Client:          nil,
-		HeaderGenerator: headerGenerator,
+		HeaderGenerator: nil,
 		URLGenerator:    nil,
+	}
+
+	// Auto-detect the root namespace so that team folders are accessible.
+	// Team manage tokens are for administrative operations and don't need
+	// a path root; skip auto-detection for those.
+	if tokType != tokenTeamManage {
+		usersClient := users.New(config)
+		account, accountErr := usersClient.GetCurrentAccount()
+		if accountErr != nil {
+			config.LogInfo("Warning: could not auto-detect root namespace (%v); team folders may not be accessible", accountErr)
+		} else {
+			var rootNamespaceID string
+			switch ri := account.RootInfo.(type) {
+			case *common.TeamRootInfo:
+				rootNamespaceID = ri.RootNamespaceId
+			case *common.UserRootInfo:
+				rootNamespaceID = ri.RootNamespaceId
+			}
+			if rootNamespaceID != "" {
+				pathRootHeader := fmt.Sprintf(`{".tag": "root", "root": "%s"}`, rootNamespaceID)
+				config.HeaderGenerator = func(_, _, _, _ string) map[string]string {
+					return map[string]string{"Dropbox-API-Path-Root": pathRootHeader}
+				}
+			}
+		}
 	}
 
 	return
@@ -244,7 +260,6 @@ func Execute() {
 func init() {
 	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose logging")
 	RootCmd.PersistentFlags().String("as-member", "", "Member ID to perform action as")
-	RootCmd.PersistentFlags().String("path-root", "", "Namespace ID to use as the path root (for team folders; sets Dropbox-API-Path-Root header)")
 	// This flag should only be used for testing. Marked hidden so it doesn't clutter usage etc.
 	RootCmd.PersistentFlags().String("domain", "", "Override default Dropbox domain, useful for testing")
 	RootCmd.PersistentFlags().MarkHidden("domain")


### PR DESCRIPTION
This pull request improves the handling of Dropbox root namespaces to ensure team folders are accessible.

* Added logic in `initDbx` (in `cmd/root.go`) to automatically detect and set the Dropbox root namespace header for non-admin tokens, making team folders accessible by default. This involves calling `users.GetCurrentAccount` and setting the `Dropbox-API-Path-Root` header (via `config.WithRoot`) based on the user's or team's root namespace.
* Added new imports for `users` and `common` packages to support root namespace detection.