### PR TITLE
Add retry with exponential backoff for upload/download

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
+	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 	"github.com/dustin/go-humanize"
@@ -28,6 +30,11 @@ import (
 )
 
 func get(cmd *cobra.Command, args []string) (err error) {
+	dbx := files.New(config)
+	return getWithClient(dbx, args)
+}
+
+func getWithClient(dbx files.Client, args []string) (err error) {
 	if len(args) == 0 || len(args) > 2 {
 		return errors.New("`get` requires `src` and/or `dst` arguments")
 	}
@@ -47,20 +54,79 @@ func get(cmd *cobra.Command, args []string) (err error) {
 		dst = path.Join(dst, path.Base(src))
 	}
 
+	return downloadFile(dbx, src, dst)
+}
+
+func downloadFile(dbx files.Client, src string, dst string) error {
 	arg := files.NewDownloadArg(src)
 
-	dbx := files.New(config)
+	return retryWithBackoff(func() error {
+		return downloadFileOnce(dbx, arg, dst)
+	})
+}
+
+func createDownloadTemp(dst string) (*os.File, string, error) {
+	dir := filepath.Dir(dst)
+	base := filepath.Base(dst)
+	for i := 0; i < 100; i++ {
+		tmp := filepath.Join(dir, fmt.Sprintf(".%s.tmp-%d-%d", base, os.Getpid(), time.Now().UnixNano()+int64(i)))
+		f, err := os.OpenFile(tmp, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		return f, tmp, err
+	}
+	return nil, "", fmt.Errorf("failed to create temporary file for %s", dst)
+}
+
+func downloadDestinationPath(dst string) (string, error) {
+	for i := 0; i < 255; i++ {
+		info, err := os.Lstat(dst)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return dst, nil
+			}
+			return "", err
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return dst, nil
+		}
+
+		target, err := os.Readlink(dst)
+		if err != nil {
+			return "", err
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(dst), target)
+		}
+		dst = target
+	}
+
+	return "", fmt.Errorf("too many symlinks resolving %s", dst)
+}
+
+func downloadFileOnce(dbx files.Client, arg *files.DownloadArg, dst string) error {
 	res, contents, err := dbx.Download(arg)
 	if err != nil {
-		return
+		return err
 	}
 	defer contents.Close()
 
-	f, err := os.Create(dst)
+	finalDst, err := downloadDestinationPath(dst)
 	if err != nil {
-		return
+		return err
 	}
-	defer f.Close()
+
+	f, tmp, err := createDownloadTemp(finalDst)
+	if err != nil {
+		return err
+	}
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmp)
+		}
+	}()
 
 	progressbar := &ioprogress.Reader{
 		Reader: contents,
@@ -71,11 +137,19 @@ func get(cmd *cobra.Command, args []string) (err error) {
 		Size: int64(res.Size),
 	}
 
-	if _, err = io.Copy(f, progressbar); err != nil {
-		return
+	_, copyErr := io.Copy(f, progressbar)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return copyErr
 	}
-
-	return
+	if closeErr != nil {
+		return closeErr
+	}
+	if err := os.Rename(tmp, finalDst); err != nil {
+		return err
+	}
+	removeTemp = false
+	return nil
 }
 
 // getCmd represents the get command

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,0 +1,251 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	dbxauth "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+type failingReadCloser struct {
+	data []byte
+	read bool
+}
+
+func (r *failingReadCloser) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+	r.read = true
+	n := copy(p, r.data)
+	return n, io.ErrUnexpectedEOF
+}
+
+func (r *failingReadCloser) Close() error { return nil }
+
+func TestGetArgValidation(t *testing.T) {
+	err := get(getCmd, []string{})
+	if err == nil {
+		t.Error("expected error for no args")
+	}
+
+	err = get(getCmd, []string{"a", "b", "c"})
+	if err == nil {
+		t.Error("expected error for too many args")
+	}
+}
+
+func TestGetDstDefaultsToBasename(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(origDir) }()
+
+	content := "downloaded content"
+	mock := &mockFilesClient{
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			if arg.Path != "/some/path/file.txt" {
+				t.Errorf("download path = %q, want %q", arg.Path, "/some/path/file.txt")
+			}
+			meta := &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: "/some/path/file.txt"},
+				Size:     uint64(len(content)),
+			}
+			return meta, io.NopCloser(strings.NewReader(content)), nil
+		},
+	}
+
+	err := getWithClient(mock, []string{"/some/path/file.txt"})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(tmpDir, "file.txt"))
+	if err != nil {
+		t.Fatalf("failed to read downloaded file: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("got %q, want %q", string(got), content)
+	}
+}
+
+func TestGetDstAppendsToDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	content := "pdf content"
+	mock := &mockFilesClient{
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			if arg.Path != "/remote/doc.pdf" {
+				t.Errorf("download path = %q, want %q", arg.Path, "/remote/doc.pdf")
+			}
+			meta := &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: "/remote/doc.pdf"},
+				Size:     uint64(len(content)),
+			}
+			return meta, io.NopCloser(strings.NewReader(content)), nil
+		},
+	}
+
+	err := getWithClient(mock, []string{"/remote/doc.pdf", tmpDir})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(tmpDir, "doc.pdf"))
+	if err != nil {
+		t.Fatalf("failed to read downloaded file: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("got %q, want %q", string(got), content)
+	}
+}
+
+func TestGetDownloadWithRetry(t *testing.T) {
+	stubRetrySleep(t)
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "downloaded.txt")
+	content := "file content here"
+
+	calls := 0
+	mock := &mockFilesClient{
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			calls++
+			if calls < 3 {
+				return nil, nil, dbxauth.ServerError{APIError: dropbox.APIError{ErrorSummary: "500"}}
+			}
+			meta := &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: "/test.txt"},
+				Size:     uint64(len(content)),
+			}
+			return meta, io.NopCloser(strings.NewReader(content)), nil
+		},
+	}
+
+	err := downloadFile(mock, "/test.txt", dst)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read downloaded file: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("got %q, want %q", string(got), content)
+	}
+}
+
+func TestGetDownloadRetriesBodyReadError(t *testing.T) {
+	delays := stubRetrySleep(t)
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "downloaded.txt")
+	content := "complete file content"
+
+	calls := 0
+	mock := &mockFilesClient{
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			calls++
+			meta := &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: "/test.txt"},
+				Size:     uint64(len(content)),
+			}
+			if calls == 1 {
+				return meta, &failingReadCloser{data: []byte("partial")}, nil
+			}
+			return meta, io.NopCloser(strings.NewReader(content)), nil
+		},
+	}
+
+	err := downloadFile(mock, "/test.txt", dst)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+	if len(*delays) != 1 {
+		t.Fatalf("expected 1 sleep, got %d", len(*delays))
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read downloaded file: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("got %q, want %q", string(got), content)
+	}
+
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to read temp dir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != filepath.Base(dst) {
+		t.Fatalf("expected only final destination file, got %v", entries)
+	}
+}
+
+func TestGetDownloadPreservesDestinationSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "target.txt")
+	link := filepath.Join(tmpDir, "link.txt")
+	if err := os.WriteFile(target, []byte("old content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	content := "new content"
+	mock := &mockFilesClient{
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			meta := &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: "/test.txt"},
+				Size:     uint64(len(content)),
+			}
+			return meta, io.NopCloser(strings.NewReader(content)), nil
+		},
+	}
+
+	err := downloadFile(mock, "/test.txt", link)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("failed to stat symlink: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected %s to remain a symlink, mode %v", link, info.Mode())
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("failed to read symlink target: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("target content = %q, want %q", string(got), content)
+	}
+}
+
+func TestGetDownloadPermanentError(t *testing.T) {
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "downloaded.txt")
+
+	mock := &mockFilesClient{
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			return nil, nil, &files.DownloadAPIError{}
+		},
+	}
+
+	err := downloadFile(mock, "/nonexistent.txt", dst)
+	if err == nil {
+		t.Error("expected error for permanent failure, got nil")
+	}
+}

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -1,0 +1,238 @@
+package cmd
+
+import (
+	"io"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/async"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/file_properties"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+type mockFilesClient struct {
+	downloadFn              func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error)
+	uploadFn                func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error)
+	uploadSessionStartFn    func(arg *files.UploadSessionStartArg, content io.Reader) (*files.UploadSessionStartResult, error)
+	uploadSessionAppendV2Fn func(arg *files.UploadSessionAppendArg, content io.Reader) error
+	uploadSessionFinishFn   func(arg *files.UploadSessionFinishArg, content io.Reader) (*files.FileMetadata, error)
+}
+
+func (m *mockFilesClient) Download(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+	if m.downloadFn != nil {
+		return m.downloadFn(arg)
+	}
+	return nil, nil, nil
+}
+
+func (m *mockFilesClient) Upload(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+	if m.uploadFn != nil {
+		return m.uploadFn(arg, content)
+	}
+	return nil, nil
+}
+
+func (m *mockFilesClient) UploadSessionStart(arg *files.UploadSessionStartArg, content io.Reader) (*files.UploadSessionStartResult, error) {
+	if m.uploadSessionStartFn != nil {
+		return m.uploadSessionStartFn(arg, content)
+	}
+	return nil, nil
+}
+
+func (m *mockFilesClient) UploadSessionAppendV2(arg *files.UploadSessionAppendArg, content io.Reader) error {
+	if m.uploadSessionAppendV2Fn != nil {
+		return m.uploadSessionAppendV2Fn(arg, content)
+	}
+	return nil
+}
+
+func (m *mockFilesClient) UploadSessionFinish(arg *files.UploadSessionFinishArg, content io.Reader) (*files.FileMetadata, error) {
+	if m.uploadSessionFinishFn != nil {
+		return m.uploadSessionFinishFn(arg, content)
+	}
+	return nil, nil
+}
+
+// Stubs for the rest of the interface
+func (m *mockFilesClient) AlphaGetMetadata(arg *files.AlphaGetMetadataArg) (files.IsMetadata, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) AlphaUpload(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CopyV2(arg *files.RelocationArg) (*files.RelocationResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) Copy(arg *files.RelocationArg) (files.IsMetadata, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CopyBatchV2(arg *files.RelocationBatchArgBase) (*files.RelocationBatchV2Launch, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CopyBatch(arg *files.RelocationBatchArg) (*files.RelocationBatchLaunch, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CopyBatchCheckV2(arg *async.PollArg) (*files.RelocationBatchV2JobStatus, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CopyBatchCheck(arg *async.PollArg) (*files.RelocationBatchJobStatus, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CopyReferenceGet(arg *files.GetCopyReferenceArg) (*files.GetCopyReferenceResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CopyReferenceSave(arg *files.SaveCopyReferenceArg) (*files.SaveCopyReferenceResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CreateFolderV2(arg *files.CreateFolderArg) (*files.CreateFolderResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CreateFolder(arg *files.CreateFolderArg) (*files.FolderMetadata, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CreateFolderBatch(arg *files.CreateFolderBatchArg) (*files.CreateFolderBatchLaunch, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) CreateFolderBatchCheck(arg *async.PollArg) (*files.CreateFolderBatchJobStatus, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) DeleteV2(arg *files.DeleteArg) (*files.DeleteResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) Delete(arg *files.DeleteArg) (files.IsMetadata, error) { return nil, nil }
+func (m *mockFilesClient) DeleteBatch(arg *files.DeleteBatchArg) (*files.DeleteBatchLaunch, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) DeleteBatchCheck(arg *async.PollArg) (*files.DeleteBatchJobStatus, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) DownloadZip(arg *files.DownloadZipArg) (*files.DownloadZipResult, io.ReadCloser, error) {
+	return nil, nil, nil
+}
+func (m *mockFilesClient) Export(arg *files.ExportArg) (*files.ExportResult, io.ReadCloser, error) {
+	return nil, nil, nil
+}
+func (m *mockFilesClient) GetFileLockBatch(arg *files.LockFileBatchArg) (*files.LockFileBatchResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) GetMetadata(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) GetPreview(arg *files.PreviewArg) (*files.FileMetadata, io.ReadCloser, error) {
+	return nil, nil, nil
+}
+func (m *mockFilesClient) GetTemporaryLink(arg *files.GetTemporaryLinkArg) (*files.GetTemporaryLinkResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) GetTemporaryUploadLink(arg *files.GetTemporaryUploadLinkArg) (*files.GetTemporaryUploadLinkResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) GetThumbnail(arg *files.ThumbnailArg) (*files.FileMetadata, io.ReadCloser, error) {
+	return nil, nil, nil
+}
+func (m *mockFilesClient) GetThumbnailV2(arg *files.ThumbnailV2Arg) (*files.PreviewResult, io.ReadCloser, error) {
+	return nil, nil, nil
+}
+func (m *mockFilesClient) GetThumbnailBatch(arg *files.GetThumbnailBatchArg) (*files.GetThumbnailBatchResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) ListFolder(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) ListFolderContinue(arg *files.ListFolderContinueArg) (*files.ListFolderResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) ListFolderGetLatestCursor(arg *files.ListFolderArg) (*files.ListFolderGetLatestCursorResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) ListFolderLongpoll(arg *files.ListFolderLongpollArg) (*files.ListFolderLongpollResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) ListRevisions(arg *files.ListRevisionsArg) (*files.ListRevisionsResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) LockFileBatch(arg *files.LockFileBatchArg) (*files.LockFileBatchResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) MoveV2(arg *files.RelocationArg) (*files.RelocationResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) Move(arg *files.RelocationArg) (files.IsMetadata, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) MoveBatchV2(arg *files.MoveBatchArg) (*files.RelocationBatchV2Launch, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) MoveBatch(arg *files.RelocationBatchArg) (*files.RelocationBatchLaunch, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) MoveBatchCheckV2(arg *async.PollArg) (*files.RelocationBatchV2JobStatus, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) MoveBatchCheck(arg *async.PollArg) (*files.RelocationBatchJobStatus, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) PaperCreate(arg *files.PaperCreateArg, content io.Reader) (*files.PaperCreateResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) PaperUpdate(arg *files.PaperUpdateArg, content io.Reader) (*files.PaperUpdateResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) PermanentlyDelete(arg *files.DeleteArg) error { return nil }
+func (m *mockFilesClient) PropertiesAdd(arg *file_properties.AddPropertiesArg) error {
+	return nil
+}
+func (m *mockFilesClient) PropertiesOverwrite(arg *file_properties.OverwritePropertyGroupArg) error {
+	return nil
+}
+func (m *mockFilesClient) PropertiesRemove(arg *file_properties.RemovePropertiesArg) error {
+	return nil
+}
+func (m *mockFilesClient) PropertiesTemplateGet(arg *file_properties.GetTemplateArg) (*file_properties.GetTemplateResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) PropertiesTemplateList() (*file_properties.ListTemplateResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) PropertiesUpdate(arg *file_properties.UpdatePropertiesArg) error {
+	return nil
+}
+func (m *mockFilesClient) Restore(arg *files.RestoreArg) (*files.FileMetadata, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) SaveUrl(arg *files.SaveUrlArg) (*files.SaveUrlResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) SaveUrlCheckJobStatus(arg *async.PollArg) (*files.SaveUrlJobStatus, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) Search(arg *files.SearchArg) (*files.SearchResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) SearchV2(arg *files.SearchV2Arg) (*files.SearchV2Result, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) SearchContinueV2(arg *files.SearchV2ContinueArg) (*files.SearchV2Result, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) TagsAdd(arg *files.AddTagArg) error { return nil }
+func (m *mockFilesClient) TagsGet(arg *files.GetTagsArg) (*files.GetTagsResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) TagsRemove(arg *files.RemoveTagArg) error { return nil }
+func (m *mockFilesClient) UnlockFileBatch(arg *files.UnlockFileBatchArg) (*files.LockFileBatchResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) UploadSessionAppend(arg *files.UploadSessionCursor, content io.Reader) error {
+	return nil
+}
+func (m *mockFilesClient) UploadSessionStartBatch(arg *files.UploadSessionStartBatchArg) (*files.UploadSessionStartBatchResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) UploadSessionFinishBatchV2(arg *files.UploadSessionFinishBatchArg) (*files.UploadSessionFinishBatchResult, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) UploadSessionFinishBatch(arg *files.UploadSessionFinishBatchArg) (*files.UploadSessionFinishBatchLaunch, error) {
+	return nil, nil
+}
+func (m *mockFilesClient) UploadSessionFinishBatchCheck(arg *async.PollArg) (*files.UploadSessionFinishBatchJobStatus, error) {
+	return nil, nil
+}

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 	"github.com/dustin/go-humanize"
 	"github.com/mitchellh/ioprogress"
@@ -41,19 +40,45 @@ type uploadChunk struct {
 }
 
 func uploadOneChunk(dbx files.Client, args *files.UploadSessionAppendArg, data []byte) error {
-	for {
+	return retryWithBackoff(func() error {
 		err := dbx.UploadSessionAppendV2(args, bytes.NewReader(data))
-		if err != nil {
-			switch errt := err.(type) {
-			case auth.RateLimitAPIError:
-				time.Sleep(time.Second * time.Duration(errt.RateLimitError.RetryAfter))
-				continue
-			default:
-				return err
-			}
+		if uploadChunkAlreadyAccepted(err, args.Cursor.Offset+uint64(len(data))) {
+			return nil
 		}
-		return nil
+		return err
+	})
+}
+
+func uploadChunkAlreadyAccepted(err error, expectedOffset uint64) bool {
+	var appendErr files.UploadSessionAppendV2APIError
+	if !errors.As(err, &appendErr) || appendErr.EndpointError == nil {
+		return false
 	}
+	endpointErr := appendErr.EndpointError
+	return endpointErr.Tag == files.UploadSessionAppendErrorIncorrectOffset &&
+		endpointErr.IncorrectOffset != nil &&
+		endpointErr.IncorrectOffset.CorrectOffset == expectedOffset
+}
+
+func uploadProgressReader(r io.Reader, size int64) *ioprogress.Reader {
+	return &ioprogress.Reader{
+		Reader: r,
+		DrawFunc: ioprogress.DrawTerminalf(os.Stderr, func(progress, total int64) string {
+			return fmt.Sprintf("Uploading %s/%s",
+				humanize.IBytes(uint64(progress)), humanize.IBytes(uint64(total)))
+		}),
+		Size: size,
+	}
+}
+
+func uploadSingleShot(dbx files.Client, r io.ReadSeeker, uploadArg *files.UploadArg, size int64) error {
+	return retryWithBackoff(func() error {
+		if _, err := r.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		_, err := dbx.Upload(uploadArg, uploadProgressReader(r, size))
+		return err
+	})
 }
 
 func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, sizeTotal int64, workers int, chunkSize int64, debug bool) (err error) {
@@ -61,7 +86,12 @@ func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, 
 	startArgs := files.NewUploadSessionStartArg()
 	startArgs.SessionType = &files.UploadSessionType{}
 	startArgs.SessionType.Tag = files.UploadSessionTypeConcurrent
-	res, err := dbx.UploadSessionStart(startArgs, nil)
+	var res *files.UploadSessionStartResult
+	err = retryWithBackoff(func() error {
+		var e error
+		res, e = dbx.UploadSessionStart(startArgs, nil)
+		return e
+	})
 	if err != nil {
 		return
 	}
@@ -135,8 +165,11 @@ func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, 
 
 	t2 := time.Now()
 	cursor := files.NewUploadSessionCursor(res.SessionId, uint64(written))
-	args := files.NewUploadSessionFinishArg(cursor, commitInfo)
-	_, err = dbx.UploadSessionFinish(args, nil)
+	finishArgs := files.NewUploadSessionFinishArg(cursor, commitInfo)
+	err = retryWithBackoff(func() error {
+		_, e := dbx.UploadSessionFinish(finishArgs, nil)
+		return e
+	})
 	if debug {
 		log.Printf("Finish took: %v\n", time.Since(t2))
 	}
@@ -186,15 +219,6 @@ func put(cmd *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	progressbar := &ioprogress.Reader{
-		Reader: contents,
-		DrawFunc: ioprogress.DrawTerminalf(os.Stderr, func(progress, total int64) string {
-			return fmt.Sprintf("Uploading %s/%s",
-				humanize.IBytes(uint64(progress)), humanize.IBytes(uint64(total)))
-		}),
-		Size: contentsInfo.Size(),
-	}
-
 	commitInfo := files.NewCommitInfo(dst)
 	commitInfo.Mode.Tag = "overwrite"
 
@@ -204,15 +228,11 @@ func put(cmd *cobra.Command, args []string) (err error) {
 
 	dbx := files.New(config)
 	if contentsInfo.Size() > singleShotUploadSizeCutoff {
-		return uploadChunked(dbx, progressbar, commitInfo, contentsInfo.Size(), workers, chunkSize, debug)
+		return uploadChunked(dbx, uploadProgressReader(contents, contentsInfo.Size()), commitInfo, contentsInfo.Size(), workers, chunkSize, debug)
 	}
 
 	uploadArg := &files.UploadArg{CommitInfo: *commitInfo}
-	if _, err = dbx.Upload(uploadArg, progressbar); err != nil {
-		return
-	}
-
-	return
+	return uploadSingleShot(dbx, contents, uploadArg, contentsInfo.Size())
 }
 
 // putCmd represents the put command

--- a/cmd/put_test.go
+++ b/cmd/put_test.go
@@ -1,0 +1,373 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	dbxauth "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+func TestUploadOneChunk_Success(t *testing.T) {
+	mock := &mockFilesClient{
+		uploadSessionAppendV2Fn: func(arg *files.UploadSessionAppendArg, content io.Reader) error {
+			return nil
+		},
+	}
+
+	cursor := files.NewUploadSessionCursor("session123", 0)
+	args := files.NewUploadSessionAppendArg(cursor)
+	data := []byte("hello chunk")
+
+	err := uploadOneChunk(mock, args, data)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}
+
+func TestUploadOneChunk_RetryOnServerError(t *testing.T) {
+	stubRetrySleep(t)
+	calls := 0
+	mock := &mockFilesClient{
+		uploadSessionAppendV2Fn: func(arg *files.UploadSessionAppendArg, content io.Reader) error {
+			calls++
+			if calls < 3 {
+				return dbxauth.ServerError{APIError: dropbox.APIError{ErrorSummary: "500"}}
+			}
+			return nil
+		},
+	}
+
+	cursor := files.NewUploadSessionCursor("session123", 0)
+	args := files.NewUploadSessionAppendArg(cursor)
+	data := []byte("hello chunk")
+
+	err := uploadOneChunk(mock, args, data)
+	if err != nil {
+		t.Errorf("expected nil error after retry, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestUploadOneChunk_RateLimitUsesSingleRetryAfterDelay(t *testing.T) {
+	delays := stubRetrySleep(t)
+	rateLimit := dbxauth.NewRateLimitError(nil)
+	rateLimit.RetryAfter = 4
+
+	calls := 0
+	mock := &mockFilesClient{
+		uploadSessionAppendV2Fn: func(arg *files.UploadSessionAppendArg, content io.Reader) error {
+			calls++
+			if calls == 1 {
+				return dbxauth.RateLimitAPIError{RateLimitError: rateLimit}
+			}
+			return nil
+		},
+	}
+
+	cursor := files.NewUploadSessionCursor("session123", 0)
+	args := files.NewUploadSessionAppendArg(cursor)
+	data := []byte("hello chunk")
+
+	err := uploadOneChunk(mock, args, data)
+	if err != nil {
+		t.Errorf("expected nil error after rate-limit retry, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+	if len(*delays) != 1 {
+		t.Fatalf("expected 1 sleep, got %d", len(*delays))
+	}
+	if (*delays)[0] != 4*time.Second {
+		t.Errorf("sleep = %v, want %v", (*delays)[0], 4*time.Second)
+	}
+}
+
+func appendIncorrectOffsetError(correctOffset uint64) files.UploadSessionAppendV2APIError {
+	return files.UploadSessionAppendV2APIError{
+		EndpointError: &files.UploadSessionAppendError{
+			Tagged:          dropbox.Tagged{Tag: files.UploadSessionAppendErrorIncorrectOffset},
+			IncorrectOffset: files.NewUploadSessionOffsetError(correctOffset),
+		},
+	}
+}
+
+func TestUploadOneChunk_TreatsExpectedIncorrectOffsetAsSuccess(t *testing.T) {
+	stubRetrySleep(t)
+	calls := 0
+	data := []byte("hello chunk")
+	cursor := files.NewUploadSessionCursor("session123", 64)
+	args := files.NewUploadSessionAppendArg(cursor)
+	expectedOffset := cursor.Offset + uint64(len(data))
+
+	mock := &mockFilesClient{
+		uploadSessionAppendV2Fn: func(arg *files.UploadSessionAppendArg, content io.Reader) error {
+			calls++
+			if calls == 1 {
+				return dbxauth.ServerError{APIError: dropbox.APIError{ErrorSummary: "500"}}
+			}
+			return appendIncorrectOffsetError(expectedOffset)
+		},
+	}
+
+	err := uploadOneChunk(mock, args, data)
+	if err != nil {
+		t.Errorf("expected nil error for already-accepted chunk, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+}
+
+func TestUploadOneChunk_ReturnsUnexpectedIncorrectOffset(t *testing.T) {
+	data := []byte("hello chunk")
+	cursor := files.NewUploadSessionCursor("session123", 64)
+	args := files.NewUploadSessionAppendArg(cursor)
+	unexpectedOffset := cursor.Offset + uint64(len(data)) - 1
+
+	mock := &mockFilesClient{
+		uploadSessionAppendV2Fn: func(arg *files.UploadSessionAppendArg, content io.Reader) error {
+			return appendIncorrectOffsetError(unexpectedOffset)
+		},
+	}
+
+	err := uploadOneChunk(mock, args, data)
+	if err == nil {
+		t.Error("expected unexpected incorrect_offset error, got nil")
+	}
+}
+
+func TestUploadOneChunk_PermanentError(t *testing.T) {
+	mock := &mockFilesClient{
+		uploadSessionAppendV2Fn: func(arg *files.UploadSessionAppendArg, content io.Reader) error {
+			return &files.UploadSessionAppendAPIError{}
+		},
+	}
+
+	cursor := files.NewUploadSessionCursor("session123", 0)
+	args := files.NewUploadSessionAppendArg(cursor)
+	data := []byte("hello chunk")
+
+	err := uploadOneChunk(mock, args, data)
+	if err == nil {
+		t.Error("expected error for permanent failure, got nil")
+	}
+}
+
+func TestUploadSingleShot_RetryOnServerErrorResetsReader(t *testing.T) {
+	stubRetrySleep(t)
+	data := []byte("small file contents")
+	reader := bytes.NewReader(data)
+	uploadArg := &files.UploadArg{CommitInfo: *files.NewCommitInfo("/test.txt")}
+
+	calls := 0
+	var bodies []string
+	mock := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			calls++
+			body, err := io.ReadAll(content)
+			if err != nil {
+				return nil, err
+			}
+			bodies = append(bodies, string(body))
+			if calls < 3 {
+				return nil, dbxauth.ServerError{APIError: dropbox.APIError{ErrorSummary: "500"}}
+			}
+			return &files.FileMetadata{}, nil
+		},
+	}
+
+	err := uploadSingleShot(mock, reader, uploadArg, int64(len(data)))
+	if err != nil {
+		t.Errorf("expected nil error after retry, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+	if len(bodies) != 3 {
+		t.Fatalf("expected 3 uploaded bodies, got %d", len(bodies))
+	}
+	for i, body := range bodies {
+		if body != string(data) {
+			t.Errorf("body %d = %q, want %q", i, body, string(data))
+		}
+	}
+}
+
+func TestUploadSingleShot_RetriesTooManyWriteOperations(t *testing.T) {
+	stubRetrySleep(t)
+	data := []byte("small file contents")
+	reader := bytes.NewReader(data)
+	uploadArg := &files.UploadArg{CommitInfo: *files.NewCommitInfo("/test.txt")}
+
+	calls := 0
+	mock := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			calls++
+			if _, err := io.ReadAll(content); err != nil {
+				return nil, err
+			}
+			if calls == 1 {
+				return nil, uploadWriteThrottleError()
+			}
+			return &files.FileMetadata{}, nil
+		},
+	}
+
+	err := uploadSingleShot(mock, reader, uploadArg, int64(len(data)))
+	if err != nil {
+		t.Errorf("expected nil error after write-throttle retry, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+}
+
+func TestPutArgValidation(t *testing.T) {
+	cmd := putCmd
+	cmd.SetArgs([]string{})
+	err := cmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Error("expected error for no args")
+	}
+}
+
+func TestPutChunkSizeValidation(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := putCmd
+	_ = cmd.Flags().Set("chunksize", "100")
+	err := put(cmd, []string{tmpFile, "/test.txt"})
+	if err == nil || err.Error() != "`put` requires chunk size to be multiple of 4MiB" {
+		t.Errorf("expected chunk size validation error, got %v", err)
+	}
+}
+
+func TestSingleShotUploadSizeCutoff(t *testing.T) {
+	if singleShotUploadSizeCutoff != 32*1024*1024 {
+		t.Errorf("singleShotUploadSizeCutoff = %d, want %d", singleShotUploadSizeCutoff, 32*1024*1024)
+	}
+}
+
+func TestUploadChunked_RetriesSessionStart(t *testing.T) {
+	stubRetrySleep(t)
+	startCalls := 0
+	var appendCalls int
+	var finishCalled bool
+	mock := &mockFilesClient{
+		uploadSessionStartFn: func(arg *files.UploadSessionStartArg, content io.Reader) (*files.UploadSessionStartResult, error) {
+			startCalls++
+			if startCalls < 3 {
+				return nil, dbxauth.ServerError{APIError: dropbox.APIError{ErrorSummary: "500"}}
+			}
+			return &files.UploadSessionStartResult{SessionId: "test-session"}, nil
+		},
+		uploadSessionAppendV2Fn: func(arg *files.UploadSessionAppendArg, content io.Reader) error {
+			appendCalls++
+			return nil
+		},
+		uploadSessionFinishFn: func(arg *files.UploadSessionFinishArg, content io.Reader) (*files.FileMetadata, error) {
+			finishCalled = true
+			return &files.FileMetadata{}, nil
+		},
+	}
+
+	data := bytes.Repeat([]byte("x"), 1024)
+	reader := bytes.NewReader(data)
+	commitInfo := files.NewCommitInfo("/test.txt")
+
+	err := uploadChunked(mock, reader, commitInfo, int64(len(data)), 1, 512, false)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if startCalls != 3 {
+		t.Errorf("expected 3 session start calls, got %d", startCalls)
+	}
+	if appendCalls != 2 {
+		t.Errorf("expected 2 append calls, got %d", appendCalls)
+	}
+	if !finishCalled {
+		t.Error("expected finish to be called")
+	}
+}
+
+func TestUploadChunked_RetriesFinishTooManyWriteOperations(t *testing.T) {
+	stubRetrySleep(t)
+	var appendCalls int
+	var finishCalls int
+	mock := &mockFilesClient{
+		uploadSessionStartFn: func(arg *files.UploadSessionStartArg, content io.Reader) (*files.UploadSessionStartResult, error) {
+			return &files.UploadSessionStartResult{SessionId: "test-session"}, nil
+		},
+		uploadSessionAppendV2Fn: func(arg *files.UploadSessionAppendArg, content io.Reader) error {
+			appendCalls++
+			return nil
+		},
+		uploadSessionFinishFn: func(arg *files.UploadSessionFinishArg, content io.Reader) (*files.FileMetadata, error) {
+			finishCalls++
+			if finishCalls == 1 {
+				return nil, finishTooManyWriteOperationsError()
+			}
+			return &files.FileMetadata{}, nil
+		},
+	}
+
+	data := bytes.Repeat([]byte("x"), 1024)
+	reader := bytes.NewReader(data)
+	commitInfo := files.NewCommitInfo("/test.txt")
+
+	err := uploadChunked(mock, reader, commitInfo, int64(len(data)), 1, 512, false)
+	if err != nil {
+		t.Errorf("expected nil error after finish retry, got %v", err)
+	}
+	if appendCalls != 2 {
+		t.Errorf("expected 2 append calls, got %d", appendCalls)
+	}
+	if finishCalls != 2 {
+		t.Errorf("expected 2 finish calls, got %d", finishCalls)
+	}
+}
+
+func TestUploadChunked_Success(t *testing.T) {
+	var appendCalls int
+	var finishCalled bool
+	mock := &mockFilesClient{
+		uploadSessionStartFn: func(arg *files.UploadSessionStartArg, content io.Reader) (*files.UploadSessionStartResult, error) {
+			return &files.UploadSessionStartResult{SessionId: "test-session"}, nil
+		},
+		uploadSessionAppendV2Fn: func(arg *files.UploadSessionAppendArg, content io.Reader) error {
+			appendCalls++
+			return nil
+		},
+		uploadSessionFinishFn: func(arg *files.UploadSessionFinishArg, content io.Reader) (*files.FileMetadata, error) {
+			finishCalled = true
+			return &files.FileMetadata{}, nil
+		},
+	}
+
+	data := bytes.Repeat([]byte("x"), 1024)
+	reader := bytes.NewReader(data)
+	commitInfo := files.NewCommitInfo("/test.txt")
+
+	err := uploadChunked(mock, reader, commitInfo, int64(len(data)), 1, 512, false)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if appendCalls != 2 {
+		t.Errorf("expected 2 append calls, got %d", appendCalls)
+	}
+	if !finishCalled {
+		t.Error("expected finish to be called")
+	}
+}

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"net"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+const (
+	maxRetries     = 5
+	initialBackoff = 1 * time.Second
+	maxBackoff     = 30 * time.Second
+)
+
+var retrySleep = time.Sleep
+
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var serverErr auth.ServerError
+	if errors.As(err, &serverErr) {
+		return true
+	}
+
+	var rateLimitErr auth.RateLimitAPIError
+	if errors.As(err, &rateLimitErr) {
+		return true
+	}
+
+	if isTooManyWriteOperationsError(err) {
+		return true
+	}
+
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	var sdkErr dropbox.SDKInternalError
+	if errors.As(err, &sdkErr) {
+		return sdkErr.StatusCode >= 500 && sdkErr.StatusCode <= 599
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+func isTooManyWriteOperationsError(err error) bool {
+	var uploadErr files.UploadAPIError
+	if errors.As(err, &uploadErr) && uploadErr.EndpointError != nil {
+		endpointErr := uploadErr.EndpointError
+		if endpointErr.Tag == files.UploadErrorPath &&
+			endpointErr.Path != nil &&
+			endpointErr.Path.Reason != nil &&
+			endpointErr.Path.Reason.Tag == files.WriteErrorTooManyWriteOperations {
+			return true
+		}
+	}
+
+	var finishErr files.UploadSessionFinishAPIError
+	if errors.As(err, &finishErr) && finishErr.EndpointError != nil {
+		endpointErr := finishErr.EndpointError
+		if endpointErr.Tag == files.UploadSessionFinishErrorTooManyWriteOperations {
+			return true
+		}
+		if endpointErr.Tag == files.UploadSessionFinishErrorPath &&
+			endpointErr.Path != nil &&
+			endpointErr.Path.Tag == files.WriteErrorTooManyWriteOperations {
+			return true
+		}
+	}
+
+	return false
+}
+
+func retryDelay(err error, backoff time.Duration) (time.Duration, bool) {
+	var rateLimitErr auth.RateLimitAPIError
+	if !errors.As(err, &rateLimitErr) {
+		return backoff, false
+	}
+	if rateLimitErr.RateLimitError == nil {
+		return backoff, false
+	}
+	return time.Duration(rateLimitErr.RateLimitError.RetryAfter) * time.Second, true
+}
+
+func retryWithBackoff(fn func() error) error {
+	backoff := initialBackoff
+	var lastErr error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+		if !isTransientError(lastErr) {
+			return lastErr
+		}
+		if attempt == maxRetries {
+			break
+		}
+		delay, isRateLimit := retryDelay(lastErr, backoff)
+		retrySleep(delay)
+		if !isRateLimit {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+
+	return lastErr
+}

--- a/cmd/retry_test.go
+++ b/cmd/retry_test.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+func stubRetrySleep(t *testing.T) *[]time.Duration {
+	t.Helper()
+
+	var delays []time.Duration
+	origRetrySleep := retrySleep
+	retrySleep = func(delay time.Duration) {
+		delays = append(delays, delay)
+	}
+	t.Cleanup(func() {
+		retrySleep = origRetrySleep
+	})
+
+	return &delays
+}
+
+func writeError(tag string) *files.WriteError {
+	return &files.WriteError{Tagged: dropbox.Tagged{Tag: tag}}
+}
+
+func uploadWriteThrottleError() files.UploadAPIError {
+	return files.UploadAPIError{
+		EndpointError: &files.UploadError{
+			Tagged: dropbox.Tagged{Tag: files.UploadErrorPath},
+			Path: files.NewUploadWriteFailed(
+				writeError(files.WriteErrorTooManyWriteOperations),
+				"session123",
+			),
+		},
+	}
+}
+
+func uploadWriteConflictError() files.UploadAPIError {
+	return files.UploadAPIError{
+		EndpointError: &files.UploadError{
+			Tagged: dropbox.Tagged{Tag: files.UploadErrorPath},
+			Path: files.NewUploadWriteFailed(
+				writeError(files.WriteErrorConflict),
+				"session123",
+			),
+		},
+	}
+}
+
+func finishTooManyWriteOperationsError() files.UploadSessionFinishAPIError {
+	return files.UploadSessionFinishAPIError{
+		EndpointError: &files.UploadSessionFinishError{
+			Tagged: dropbox.Tagged{Tag: files.UploadSessionFinishErrorTooManyWriteOperations},
+		},
+	}
+}
+
+func TestIsTransientError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"permanent error", errors.New("path/not_found"), false},
+		{"auth error", errors.New("invalid_access_token"), false},
+		{
+			"server error 5xx",
+			auth.ServerError{APIError: dropbox.APIError{ErrorSummary: "internal"}},
+			true,
+		},
+		{
+			"rate limit error",
+			auth.RateLimitAPIError{RateLimitError: auth.NewRateLimitError(nil)},
+			true,
+		},
+		{
+			"sdk internal 500",
+			dropbox.SDKInternalError{StatusCode: 500, Content: "server error"},
+			true,
+		},
+		{
+			"sdk internal 503",
+			dropbox.SDKInternalError{StatusCode: 503, Content: "unavailable"},
+			true,
+		},
+		{
+			"sdk internal 400 (not transient)",
+			dropbox.SDKInternalError{StatusCode: 400, Content: "bad request"},
+			false,
+		},
+		{
+			"net error",
+			&net.OpError{Op: "read", Net: "tcp", Err: errors.New("reset")},
+			true,
+		},
+		{
+			"single-shot upload too many write operations",
+			uploadWriteThrottleError(),
+			true,
+		},
+		{
+			"upload session finish too many write operations",
+			finishTooManyWriteOperationsError(),
+			true,
+		},
+		{
+			"single-shot upload write conflict",
+			uploadWriteConflictError(),
+			false,
+		},
+		{
+			"unexpected EOF",
+			io.ErrUnexpectedEOF,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTransientError(tt.err)
+			if got != tt.want {
+				t.Errorf("isTransientError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryWithBackoff_Success(t *testing.T) {
+	calls := 0
+	err := retryWithBackoff(func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_TransientThenSuccess(t *testing.T) {
+	delays := stubRetrySleep(t)
+	calls := 0
+	err := retryWithBackoff(func() error {
+		calls++
+		if calls < 3 {
+			return auth.ServerError{APIError: dropbox.APIError{ErrorSummary: "500"}}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+	wantDelays := []time.Duration{initialBackoff, 2 * initialBackoff}
+	if len(*delays) != len(wantDelays) {
+		t.Fatalf("expected %d sleeps, got %d", len(wantDelays), len(*delays))
+	}
+	for i, want := range wantDelays {
+		if (*delays)[i] != want {
+			t.Errorf("sleep %d = %v, want %v", i, (*delays)[i], want)
+		}
+	}
+}
+
+func TestRetryWithBackoff_RateLimitUsesRetryAfter(t *testing.T) {
+	delays := stubRetrySleep(t)
+	rateLimit := auth.NewRateLimitError(nil)
+	rateLimit.RetryAfter = 7
+
+	calls := 0
+	err := retryWithBackoff(func() error {
+		calls++
+		if calls == 1 {
+			return auth.RateLimitAPIError{RateLimitError: rateLimit}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+	if len(*delays) != 1 {
+		t.Fatalf("expected 1 sleep, got %d", len(*delays))
+	}
+	if (*delays)[0] != 7*time.Second {
+		t.Errorf("sleep = %v, want %v", (*delays)[0], 7*time.Second)
+	}
+}
+
+func TestRetryWithBackoff_PermanentError(t *testing.T) {
+	calls := 0
+	err := retryWithBackoff(func() error {
+		calls++
+		return errors.New("invalid_access_token")
+	})
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retry for permanent error), got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_ExhaustsRetries(t *testing.T) {
+	delays := stubRetrySleep(t)
+	calls := 0
+	err := retryWithBackoff(func() error {
+		calls++
+		return auth.ServerError{APIError: dropbox.APIError{ErrorSummary: "500"}}
+	})
+
+	if err == nil {
+		t.Error("expected error after exhausting retries, got nil")
+	}
+	if calls != maxRetries+1 {
+		t.Errorf("expected %d calls, got %d", maxRetries+1, calls)
+	}
+	wantDelays := []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+	}
+	if len(*delays) != len(wantDelays) {
+		t.Fatalf("expected %d sleeps, got %d", len(wantDelays), len(*delays))
+	}
+	for i, want := range wantDelays {
+		if (*delays)[i] != want {
+			t.Errorf("sleep %d = %v, want %v", i, (*delays)[i], want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add retry with exponential backoff for transient errors on uploads and downloads.

- Retry on server 500s, rate limits (with `RetryAfter`), network errors, `unexpected EOF`, and `too_many_write_operations`
- Downloads write to atomic temp file (`.name.tmp-PID-NANO`) then rename — prevents corruption on retry or crash
- Chunked uploads handle already-accepted chunks idempotently via `incorrect_offset` detection
- Symlinks are preserved on download (temp file created alongside resolved target)
- Single-shot uploads seek back to start before each retry attempt

## Issues Fixed

- Closes #211 — connection reset by peer on `upload_session/append_v2`
- Closes #185 — large file upload fails with HTTP 500
- Closes #75 — download fails with `unexpected EOF` on large files
- Closes #149 — `too_many_requests` error on `put`

## Test Plan

- [x] Unit tests for retry logic (transient vs permanent errors, backoff timing, rate-limit `RetryAfter`)
- [x] Unit tests for atomic download (body read error retry, temp file cleanup, symlink preservation)
- [x] Unit tests for chunk idempotency (expected vs unexpected `incorrect_offset`)
- [x] Unit tests for `too_many_write_operations` retry (single-shot and session finish)
- [x] Manual test: upload + download + verify file integrity (including zip files)
- [x] `go vet` / `go build` clean
