### PR TITLE
Fix commands returning exit code 0 on error

### DIFF
--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -58,8 +58,11 @@ func cp(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	for _, cpError := range cpErrors {
-		fmt.Fprintf(os.Stderr, "%v\n", cpError)
+	if len(cpErrors) > 0 {
+		for _, cpError := range cpErrors {
+			_, _ = fmt.Fprintf(os.Stderr, "%v\n", cpError)
+		}
+		return fmt.Errorf("cp: %d error(s)", len(cpErrors))
 	}
 
 	return nil

--- a/cmd/cp_test.go
+++ b/cmd/cp_test.go
@@ -1,0 +1,15 @@
+package cmd
+
+import "testing"
+
+func TestCpArgValidation(t *testing.T) {
+	err := cp(cpCmd, []string{})
+	if err == nil {
+		t.Error("expected error for no args")
+	}
+
+	err = cp(cpCmd, []string{"/only-one"})
+	if err == nil {
+		t.Error("expected error for single arg")
+	}
+}

--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -71,8 +71,11 @@ func mv(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	for _, mvError := range mvErrors {
-		fmt.Fprintf(os.Stderr, "%v\n", mvError)
+	if len(mvErrors) > 0 {
+		for _, mvError := range mvErrors {
+			_, _ = fmt.Fprintf(os.Stderr, "%v\n", mvError)
+		}
+		return fmt.Errorf("mv: %d error(s)", len(mvErrors))
 	}
 
 	return nil

--- a/cmd/mv_test.go
+++ b/cmd/mv_test.go
@@ -1,0 +1,15 @@
+package cmd
+
+import "testing"
+
+func TestMvArgValidation(t *testing.T) {
+	err := mv(mvCmd, []string{})
+	if err == nil {
+		t.Error("expected error for no args")
+	}
+
+	err = mv(mvCmd, []string{"/only-one"})
+	if err == nil {
+		t.Error("expected error for single arg")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -225,7 +225,7 @@ manage your team and more. It is easy, scriptable and works on all platforms!`,
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import "testing"
+
+func TestRootCmdUnknownCommandReturnsError(t *testing.T) {
+	RootCmd.SetArgs([]string{"nonexistent-command"})
+	err := RootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for unknown command")
+	}
+}
+
+func TestRootCmdInvalidFlagReturnsError(t *testing.T) {
+	RootCmd.SetArgs([]string{"ls", "--invalidflag"})
+	err := RootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for invalid flag")
+	}
+}


### PR DESCRIPTION
## Summary

- Change `os.Exit(-1)` to `os.Exit(1)` for standard error exit code
- Fix `mv` and `cp` swallowing errors — they now return an error to cobra instead of printing to stderr and returning nil

## Issues Fixed

- Closes #120
