### PR TITLE
Fix search output: add newlines and tabwriter alignment

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -17,8 +17,10 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 	"github.com/spf13/cobra"
@@ -47,20 +49,30 @@ func search(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	long, _ := cmd.Flags().GetBool("long")
+
+	return renderSearchResults(os.Stdout, res, long)
+}
+
+func renderSearchResults(out io.Writer, res *files.SearchResult, long bool) error {
+	w := new(tabwriter.Writer)
+	w.Init(out, 4, 8, 1, ' ', 0)
+
 	if long {
-		fmt.Printf("Revision\tSize\tLast modified\tPath\n")
+		_, _ = fmt.Fprint(w, "Revision\tSize\tLast modified\tPath\n")
 	}
 
 	for _, m := range res.Matches {
 		switch f := m.Metadata.(type) {
 		case *files.FileMetadata:
-			printFileMetadata(os.Stdout, f, long)
+			printFileMetadata(w, f, long)
+			_, _ = fmt.Fprintln(w)
 		case *files.FolderMetadata:
-			printFolderMetadata(os.Stdout, f, long)
+			printFolderMetadata(w, f, long)
+			_, _ = fmt.Fprintln(w)
 		}
 	}
 
-	return
+	return w.Flush()
 }
 
 // searchCmd represents the search command

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+func TestSearchArgValidation(t *testing.T) {
+	err := search(searchCmd, []string{})
+	if err == nil {
+		t.Error("expected error for no args")
+	}
+}
+
+func TestSearchPathScopeValidation(t *testing.T) {
+	err := search(searchCmd, []string{"query", "no-slash"})
+	if err == nil {
+		t.Error("expected error for path-scope without leading slash")
+	}
+}
+
+func TestRenderSearchResultsSeparatesMatchesWithNewlines(t *testing.T) {
+	res := files.NewSearchResult([]*files.SearchMatch{
+		files.NewSearchMatch(nil, &files.FileMetadata{
+			Metadata: files.Metadata{PathDisplay: "/first.txt"},
+		}),
+		files.NewSearchMatch(nil, &files.FolderMetadata{
+			Metadata: files.Metadata{PathDisplay: "/second"},
+		}),
+	}, false, 0)
+
+	var out bytes.Buffer
+	if err := renderSearchResults(&out, res, false); err != nil {
+		t.Fatalf("renderSearchResults returned error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSuffix(out.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected one output line per match, got %d lines in %q", len(lines), out.String())
+	}
+
+	if got, want := strings.TrimSpace(lines[0]), "/first.txt"; got != want {
+		t.Errorf("first rendered match = %q, want %q", got, want)
+	}
+	if got, want := strings.TrimSpace(lines[1]), "/second"; got != want {
+		t.Errorf("second rendered match = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Add newlines between search results — previously all matches ran together on a single line
- Use `tabwriter` for aligned column output in `search -l`, matching `ls -l` behavior
- Extract `renderSearchResults` for testability; add unit tests

Closes #132

## Test plan
- [x] `go test ./cmd/ -count=1` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual test: `dbxcli search "pdf"` shows one result per line
- [x] Manual test: `dbxcli search -l "pdf"` shows aligned columns with header
