### PR TITLE
Add --sort, --reverse, --time, and --time-format flags to ls and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,60 @@ Flags:
   -v, --verbose            Enable verbose logging
 
 Use "dbxcli [command] --help" for more information about a command.
+```
 
+### Listing files
+
+```sh
+$ dbxcli ls -l /Photos
+Revision              Size    Last modified Path
+abc123                1.2 MiB 3 weeks ago   /Photos/vacation.jpg
+def456                4.5 MiB 1 month ago   /Photos/family.png
+```
+
+#### Time format
+
+By default, `ls -l` and `search -l` show relative timestamps ("3 weeks ago"). Use `--time-format` for absolute dates:
+
+```sh
+$ dbxcli ls -l --time-format=short /Photos
+Revision              Size    Last modified    Path
+abc123                1.2 MiB 2026-05-15 10:30 /Photos/vacation.jpg
+
+$ dbxcli ls -l --time-format=rfc3339 /Photos
+Revision              Size    Last modified        Path
+abc123                1.2 MiB 2026-05-15T10:30:00Z /Photos/vacation.jpg
+```
+
+Use `--time=client` to display client-modified time instead of server-modified (default):
+
+```sh
+$ dbxcli ls -l --time=client --time-format=short /Photos
+```
+
+#### Sorting
+
+Sort results with `--sort` and optionally `--reverse`:
+
+```sh
+$ dbxcli ls -l --sort=size /Documents          # smallest first
+$ dbxcli ls -l --sort=size --reverse /Documents # largest first
+$ dbxcli ls -l --sort=name /Documents           # alphabetical
+$ dbxcli ls -l --sort=time /Documents           # oldest first
+$ dbxcli ls -l --sort=type /Documents           # folders, files, deleted
+```
+
+### Searching
+
+```sh
+$ dbxcli search -l --time-format=short --sort=size "report"
+```
+
+All `--sort`, `--reverse`, `--time`, and `--time-format` flags work with both `ls` and `search`.
+
+### Team management
+
+```sh
 $ dbxcli team --help
 Team management commands
 

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -1,0 +1,117 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/dustin/go-humanize"
+)
+
+type listOptions struct {
+	long       bool
+	timeField  string
+	timeFormat string
+	sortBy     string
+	reverse    bool
+}
+
+func formatTime(t time.Time, opts listOptions) string {
+	switch opts.timeFormat {
+	case "short":
+		return t.Format("2006-01-02 15:04")
+	case "rfc3339":
+		return t.Format(time.RFC3339)
+	default:
+		return humanize.Time(t)
+	}
+}
+
+func getTime(e *files.FileMetadata, opts listOptions) time.Time {
+	if opts.timeField == "client" {
+		return e.ClientModified
+	}
+	return e.ServerModified
+}
+
+func sortEntries(entries []files.IsMetadata, opts listOptions) {
+	if opts.sortBy == "" {
+		return
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		less := compareLess(entries[i], entries[j], opts)
+		if opts.reverse {
+			return !less
+		}
+		return less
+	})
+}
+
+func compareLess(a, b files.IsMetadata, opts listOptions) bool {
+	switch opts.sortBy {
+	case "name":
+		return strings.ToLower(entryPath(a)) < strings.ToLower(entryPath(b))
+	case "size":
+		return entrySize(a) < entrySize(b)
+	case "time":
+		return entryTime(a, opts).Before(entryTime(b, opts))
+	case "type":
+		return entryTypeOrder(a) < entryTypeOrder(b)
+	default:
+		return false
+	}
+}
+
+func entryPath(e files.IsMetadata) string {
+	switch f := e.(type) {
+	case *files.FileMetadata:
+		return f.PathDisplay
+	case *files.FolderMetadata:
+		return f.PathDisplay
+	case *files.DeletedMetadata:
+		return f.PathDisplay
+	}
+	return ""
+}
+
+func entrySize(e files.IsMetadata) uint64 {
+	if f, ok := e.(*files.FileMetadata); ok {
+		return f.Size
+	}
+	return 0
+}
+
+func entryTime(e files.IsMetadata, opts listOptions) time.Time {
+	if f, ok := e.(*files.FileMetadata); ok {
+		return getTime(f, opts)
+	}
+	return time.Time{}
+}
+
+func entryTypeOrder(e files.IsMetadata) int {
+	switch e.(type) {
+	case *files.FolderMetadata:
+		return 0
+	case *files.FileMetadata:
+		return 1
+	case *files.DeletedMetadata:
+		return 2
+	}
+	return 3
+}

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+func TestFormatTimeDefault(t *testing.T) {
+	ts := time.Now().Add(-2 * time.Hour)
+	got := formatTime(ts, listOptions{})
+	if got == "" {
+		t.Error("formatTime default returned empty")
+	}
+	if got == ts.Format(time.RFC3339) {
+		t.Error("default should be relative, not rfc3339")
+	}
+}
+
+func TestFormatTimeShort(t *testing.T) {
+	ts := time.Date(2025, 3, 15, 10, 30, 0, 0, time.UTC)
+	got := formatTime(ts, listOptions{timeFormat: "short"})
+	want := "2025-03-15 10:30"
+	if got != want {
+		t.Errorf("formatTime short = %q, want %q", got, want)
+	}
+}
+
+func TestFormatTimeRFC3339(t *testing.T) {
+	ts := time.Date(2025, 3, 15, 10, 30, 0, 0, time.UTC)
+	got := formatTime(ts, listOptions{timeFormat: "rfc3339"})
+	want := "2025-03-15T10:30:00Z"
+	if got != want {
+		t.Errorf("formatTime rfc3339 = %q, want %q", got, want)
+	}
+}
+
+func TestGetTimeServer(t *testing.T) {
+	serverTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	clientTime := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	meta := &files.FileMetadata{
+		ServerModified: serverTime,
+		ClientModified: clientTime,
+	}
+
+	got := getTime(meta, listOptions{timeField: "server"})
+	if !got.Equal(serverTime) {
+		t.Errorf("getTime server = %v, want %v", got, serverTime)
+	}
+
+	got = getTime(meta, listOptions{})
+	if !got.Equal(serverTime) {
+		t.Errorf("getTime default = %v, want %v", got, serverTime)
+	}
+}
+
+func TestGetTimeClient(t *testing.T) {
+	serverTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	clientTime := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	meta := &files.FileMetadata{
+		ServerModified: serverTime,
+		ClientModified: clientTime,
+	}
+
+	got := getTime(meta, listOptions{timeField: "client"})
+	if !got.Equal(clientTime) {
+		t.Errorf("getTime client = %v, want %v", got, clientTime)
+	}
+}
+
+func TestSortEntriesByName(t *testing.T) {
+	entries := []files.IsMetadata{
+		&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/Zebra"}},
+		&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/apple.txt"}},
+		&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/Banana"}},
+	}
+
+	sortEntries(entries, listOptions{sortBy: "name"})
+
+	paths := []string{entryPath(entries[0]), entryPath(entries[1]), entryPath(entries[2])}
+	if paths[0] != "/apple.txt" || paths[1] != "/Banana" || paths[2] != "/Zebra" {
+		t.Errorf("sort by name = %v, want [/apple.txt /Banana /Zebra]", paths)
+	}
+}
+
+func TestSortEntriesBySize(t *testing.T) {
+	entries := []files.IsMetadata{
+		&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/big"}, Size: 1000},
+		&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/small"}, Size: 10},
+		&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/folder"}},
+	}
+
+	sortEntries(entries, listOptions{sortBy: "size"})
+
+	paths := []string{entryPath(entries[0]), entryPath(entries[1]), entryPath(entries[2])}
+	if paths[0] != "/folder" || paths[1] != "/small" || paths[2] != "/big" {
+		t.Errorf("sort by size = %v, want [/folder /small /big]", paths)
+	}
+}
+
+func TestSortEntriesByTime(t *testing.T) {
+	entries := []files.IsMetadata{
+		&files.FileMetadata{
+			Metadata:       files.Metadata{PathDisplay: "/new"},
+			ServerModified: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		},
+		&files.FileMetadata{
+			Metadata:       files.Metadata{PathDisplay: "/old"},
+			ServerModified: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/folder"}},
+	}
+
+	sortEntries(entries, listOptions{sortBy: "time"})
+
+	paths := []string{entryPath(entries[0]), entryPath(entries[1]), entryPath(entries[2])}
+	if paths[0] != "/folder" || paths[1] != "/old" || paths[2] != "/new" {
+		t.Errorf("sort by time = %v, want [/folder /old /new]", paths)
+	}
+}
+
+func TestSortEntriesByType(t *testing.T) {
+	entries := []files.IsMetadata{
+		&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/file.txt"}},
+		&files.DeletedMetadata{Metadata: files.Metadata{PathDisplay: "/gone"}},
+		&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/folder"}},
+	}
+
+	sortEntries(entries, listOptions{sortBy: "type"})
+
+	paths := []string{entryPath(entries[0]), entryPath(entries[1]), entryPath(entries[2])}
+	if paths[0] != "/folder" || paths[1] != "/file.txt" || paths[2] != "/gone" {
+		t.Errorf("sort by type = %v, want [/folder /file.txt /gone]", paths)
+	}
+}
+
+func TestSortEntriesReverse(t *testing.T) {
+	entries := []files.IsMetadata{
+		&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/a"}},
+		&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/b"}},
+		&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/c"}},
+	}
+
+	sortEntries(entries, listOptions{sortBy: "name", reverse: true})
+
+	paths := []string{entryPath(entries[0]), entryPath(entries[1]), entryPath(entries[2])}
+	if paths[0] != "/c" || paths[1] != "/b" || paths[2] != "/a" {
+		t.Errorf("sort by name reverse = %v, want [/c /b /a]", paths)
+	}
+}
+
+func TestSortEntriesNoSort(t *testing.T) {
+	entries := []files.IsMetadata{
+		&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/z"}},
+		&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/a"}},
+	}
+
+	sortEntries(entries, listOptions{})
+
+	if entryPath(entries[0]) != "/z" || entryPath(entries[1]) != "/a" {
+		t.Error("with no sort, order should be preserved")
+	}
+}
+
+func TestFormatFileMetadataWithOptsShort(t *testing.T) {
+	ts := time.Date(2025, 3, 15, 10, 30, 0, 0, time.UTC)
+	meta := &files.FileMetadata{
+		Metadata:       files.Metadata{PathDisplay: "/test.txt"},
+		Rev:            "abc",
+		Size:           4096,
+		ServerModified: ts,
+	}
+
+	got := formatFileMetadataWithOpts(meta, listOptions{long: false})
+	want := "/test.txt\t"
+	if got != want {
+		t.Errorf("short format = %q, want %q", got, want)
+	}
+}
+
+func TestFormatFileMetadataWithOptsLongShortTime(t *testing.T) {
+	ts := time.Date(2025, 3, 15, 10, 30, 0, 0, time.UTC)
+	meta := &files.FileMetadata{
+		Metadata:       files.Metadata{PathDisplay: "/test.txt"},
+		Rev:            "abc",
+		Size:           4096,
+		ServerModified: ts,
+	}
+
+	got := formatFileMetadataWithOpts(meta, listOptions{long: true, timeFormat: "short"})
+	if !stringContains(got, "2025-03-15 10:30") {
+		t.Errorf("long short-time format should contain absolute time, got %q", got)
+	}
+	if !stringContains(got, "4.0 KiB") {
+		t.Errorf("long format should contain size, got %q", got)
+	}
+}
+
+func TestFormatFileMetadataWithOptsClientTime(t *testing.T) {
+	server := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	client := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	meta := &files.FileMetadata{
+		Metadata:       files.Metadata{PathDisplay: "/test.txt"},
+		Rev:            "abc",
+		Size:           1024,
+		ServerModified: server,
+		ClientModified: client,
+	}
+
+	got := formatFileMetadataWithOpts(meta, listOptions{long: true, timeField: "client", timeFormat: "short"})
+	if !stringContains(got, "2024-06-15 12:00") {
+		t.Errorf("client time format should show client modified, got %q", got)
+	}
+}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -60,9 +60,14 @@ func formatFolderMetadata(e *files.FolderMetadata, longFormat bool) string {
 }
 
 func formatFileMetadata(e *files.FileMetadata, longFormat bool) string {
+	return formatFileMetadataWithOpts(e, listOptions{long: longFormat})
+}
+
+func formatFileMetadataWithOpts(e *files.FileMetadata, opts listOptions) string {
 	text := fmt.Sprintf("%s\t", e.PathDisplay)
-	if longFormat {
-		text = fmt.Sprintf("%s\t%s\t%s\t", e.Rev, humanize.IBytes(e.Size), humanize.Time(e.ServerModified)) + text
+	if opts.long {
+		t := getTime(e, opts)
+		text = fmt.Sprintf("%s\t%s\t%s\t", e.Rev, humanize.IBytes(e.Size), formatTime(t, opts)) + text
 	}
 	return text
 }
@@ -86,6 +91,21 @@ func SetPathDisplayAsDeleted(metadata files.IsMetadata) {
 	}
 }
 
+func parseLsOptions(cmd *cobra.Command) listOptions {
+	long, _ := cmd.Flags().GetBool("long")
+	timeField, _ := cmd.Flags().GetString("time")
+	timeFormat, _ := cmd.Flags().GetString("time-format")
+	sortBy, _ := cmd.Flags().GetString("sort")
+	reverse, _ := cmd.Flags().GetBool("reverse")
+	return listOptions{
+		long:       long,
+		timeField:  timeField,
+		timeFormat: timeFormat,
+		sortBy:     sortBy,
+		reverse:    reverse,
+	}
+}
+
 func ls(cmd *cobra.Command, args []string) (err error) {
 
 	path := ""
@@ -100,7 +120,7 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 	arg.IncludeDeleted, _ = cmd.Flags().GetBool("include-deleted")
 	onlyDeleted, _ := cmd.Flags().GetBool("only-deleted")
 	arg.IncludeDeleted = arg.IncludeDeleted || onlyDeleted
-	long, _ := cmd.Flags().GetBool("long")
+	opts := parseLsOptions(cmd)
 
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 4, 8, 1, ' ', 0)
@@ -108,14 +128,14 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 	printItem := func(message string) {
 		itemCounter = itemCounter + 1
 		fmt.Fprint(w, message)
-		if (itemCounter%4 == 0) || long {
+		if (itemCounter%4 == 0) || opts.long {
 			fmt.Fprintln(w)
 		}
 	}
 
 	dbx := files.New(config)
 
-	if long {
+	if opts.long {
 		fmt.Fprint(w, "Revision\tSize\tLast modified\tPath\n")
 	}
 
@@ -129,7 +149,7 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 		switch f := metaRes.(type) {
 		case *files.FileMetadata:
 			if !onlyDeleted {
-				printItem(formatFileMetadata(f, long))
+				printItem(formatFileMetadataWithOpts(f, opts))
 				err = w.Flush()
 				return err
 			}
@@ -171,6 +191,8 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
+	sortEntries(entries, opts)
+
 	for _, entry := range entries {
 		deletedItem, isDeleted := entry.(*files.DeletedMetadata)
 		if isDeleted {
@@ -201,14 +223,14 @@ func ls(cmd *cobra.Command, args []string) (err error) {
 		switch f := entry.(type) {
 		case *files.FileMetadata:
 			if !onlyDeleted {
-				printItem(formatFileMetadata(f, long))
+				printItem(formatFileMetadataWithOpts(f, opts))
 			}
 		case *files.FolderMetadata:
 			if !onlyDeleted {
-				printItem(formatFolderMetadata(f, long))
+				printItem(formatFolderMetadata(f, opts.long))
 			}
 		case *files.DeletedMetadata:
-			printItem(formatDeletedMetadata(f, long))
+			printItem(formatDeletedMetadata(f, opts.long))
 		}
 	}
 
@@ -234,4 +256,8 @@ func init() {
 	lsCmd.Flags().BoolP("recurse", "R", false, "Recursively list all subfolders")
 	lsCmd.Flags().BoolP("include-deleted", "d", false, "Include deleted files")
 	lsCmd.Flags().BoolP("only-deleted", "D", false, "Only show deleted files")
+	lsCmd.Flags().String("sort", "", "Sort by: name, size, time, type")
+	lsCmd.Flags().BoolP("reverse", "r", false, "Reverse sort order")
+	lsCmd.Flags().String("time", "server", "Time field: server, client")
+	lsCmd.Flags().String("time-format", "", "Time format: short (2006-01-02 15:04), rfc3339")
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -48,26 +48,32 @@ func search(cmd *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	long, _ := cmd.Flags().GetBool("long")
+	opts := parseLsOptions(cmd)
 
-	return renderSearchResults(os.Stdout, res, long)
+	return renderSearchResults(os.Stdout, res, opts)
 }
 
-func renderSearchResults(out io.Writer, res *files.SearchResult, long bool) error {
+func renderSearchResults(out io.Writer, res *files.SearchResult, opts listOptions) error {
 	w := new(tabwriter.Writer)
 	w.Init(out, 4, 8, 1, ' ', 0)
 
-	if long {
+	if opts.long {
 		_, _ = fmt.Fprint(w, "Revision\tSize\tLast modified\tPath\n")
 	}
 
+	entries := make([]files.IsMetadata, 0, len(res.Matches))
 	for _, m := range res.Matches {
-		switch f := m.Metadata.(type) {
+		entries = append(entries, m.Metadata)
+	}
+	sortEntries(entries, opts)
+
+	for _, entry := range entries {
+		switch f := entry.(type) {
 		case *files.FileMetadata:
-			printFileMetadata(w, f, long)
+			_, _ = fmt.Fprint(w, formatFileMetadataWithOpts(f, opts))
 			_, _ = fmt.Fprintln(w)
 		case *files.FolderMetadata:
-			printFolderMetadata(w, f, long)
+			printFolderMetadata(w, f, opts.long)
 			_, _ = fmt.Fprintln(w)
 		}
 	}
@@ -85,4 +91,8 @@ var searchCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(searchCmd)
 	searchCmd.Flags().BoolP("long", "l", false, "Long listing")
+	searchCmd.Flags().String("sort", "", "Sort by: name, size, time, type")
+	searchCmd.Flags().BoolP("reverse", "r", false, "Reverse sort order")
+	searchCmd.Flags().String("time", "server", "Time field: server, client")
+	searchCmd.Flags().String("time-format", "", "Time format: short (2006-01-02 15:04), rfc3339")
 }

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -33,7 +33,7 @@ func TestRenderSearchResultsSeparatesMatchesWithNewlines(t *testing.T) {
 	}, false, 0)
 
 	var out bytes.Buffer
-	if err := renderSearchResults(&out, res, false); err != nil {
+	if err := renderSearchResults(&out, res, listOptions{long: false}); err != nil {
 		t.Fatalf("renderSearchResults returned error: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- `--time-format=short` shows absolute dates (`2006-01-02 15:04`)
- `--time-format=rfc3339` shows RFC3339 timestamps
- `--time=client` uses client-modified instead of server-modified
- `--sort=name|size|time|type` with `--reverse` for descending order
- Flags apply to both `ls` and `search` commands
- Updated README with usage examples

Closes #135
Closes #210

## Test plan
- [x] `go test ./cmd/ -count=1` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual test: all flag combinations for `ls` and `search`
- [x] `--time-format=short` shows `2026-05-11 15:38`
- [x] `--time-format=rfc3339` shows `2026-05-11T15:38:49Z`
- [x] `--time=client` shows different timestamps than server
- [x] `--sort=size --reverse` shows largest first
- [x] `--sort=time` shows oldest first
- [x] `--sort=name` shows alphabetical