### PR TITLE
Add mkdir -p flag to suppress error on existing directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Use "dbxcli team [command] --help" for more information about a command.
 
 The `--verbose` option will turn on verbose logging and is useful for debugging.
 
+### Creating directories
+
+```sh
+$ dbxcli mkdir /projects/2026/reports   # creates all intermediate directories
+$ dbxcli mkdir -p /projects/2026/reports # no error if directory already exists
+```
+
 ## Contributing
 
  * Step 1: If you're submitting a non-trivial change, please fill out the [Dropbox Contributor License Agreement](https://opensource.dropbox.com/cla/) first.

--- a/cmd/mkdir.go
+++ b/cmd/mkdir.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 	"github.com/spf13/cobra"
@@ -33,12 +34,21 @@ func mkdir(cmd *cobra.Command, args []string) (err error) {
 
 	arg := files.NewCreateFolderArg(dst)
 
+	parents, _ := cmd.Flags().GetBool("parents")
+
 	dbx := files.New(config)
 	if _, err = dbx.CreateFolderV2(arg); err != nil {
+		if parents && isConflictError(err) {
+			return nil
+		}
 		return
 	}
 
 	return
+}
+
+func isConflictError(err error) bool {
+	return strings.Contains(err.Error(), "path/conflict")
 }
 
 // mkdirCmd represents the mkdir command
@@ -50,4 +60,5 @@ var mkdirCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(mkdirCmd)
+	mkdirCmd.Flags().BoolP("parents", "p", false, "No error if existing, create parent directories as needed")
 }

--- a/cmd/mkdir_test.go
+++ b/cmd/mkdir_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMkdirArgValidation(t *testing.T) {
+	err := mkdir(mkdirCmd, []string{})
+	if err == nil {
+		t.Error("expected error for no args")
+	}
+}
+
+func TestMkdirTooManyArgs(t *testing.T) {
+	err := mkdir(mkdirCmd, []string{"/a", "/b"})
+	if err == nil {
+		t.Error("expected error for too many args")
+	}
+}
+
+func TestIsConflictError(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want bool
+	}{
+		{"path/conflict/folder/", true},
+		{"path/conflict/file/", true},
+		{"path/not_found/", false},
+		{"some other error", false},
+	}
+
+	for _, tt := range tests {
+		got := isConflictError(fmt.Errorf("%s", tt.msg))
+		if got != tt.want {
+			t.Errorf("isConflictError(%q) = %v, want %v", tt.msg, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `--parents` / `-p` flag to `mkdir`
- With `-p`, no error if directory already exists (suppresses `path/conflict`)
- Dropbox API `CreateFolderV2` already creates intermediate directories automatically

Closes #171

## Test plan
- [x] `go test ./cmd/ -count=1` passes
- [x] `golangci-lint run ./...` clean
- [x] `mkdir /nested/deep/path` — creates all intermediate dirs
- [x] `mkdir /existing` — errors with `path/conflict/folder/`
- [x] `mkdir -p /existing` — silently succeeds
- [x] `mkdir -p /existing/new/nested` — creates new dirs under existing
