### PR TITLE
Add Output abstraction and fix logout with expired tokens

### DIFF
--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -26,6 +26,8 @@ import (
 
 // Command logout revokes all saved API tokens and deletes auth.json.
 func logout(cmd *cobra.Command, args []string) error {
+	out := commandOutput(cmd)
+
 	dir, err := homedir.Dir()
 	if err != nil {
 		return err
@@ -39,7 +41,7 @@ func logout(cmd *cobra.Command, args []string) error {
 
 	for domain, tokens := range tokMap {
 		for _, token := range tokens {
-			config := dropbox.Config{
+			cfg := dropbox.Config{
 				Token:           token,
 				LogLevel:        dropbox.LogOff,
 				Logger:          nil,
@@ -49,10 +51,9 @@ func logout(cmd *cobra.Command, args []string) error {
 				HeaderGenerator: nil,
 				URLGenerator:    nil,
 			}
-			client := auth.New(config)
-			err = client.TokenRevoke()
-			if err != nil {
-				return err
+			client := auth.New(cfg)
+			if err = client.TokenRevoke(); err != nil {
+				out.Warn("could not revoke token (may be expired): %v", err)
 			}
 		}
 	}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/dropbox/dbxcli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const jsonOutputFlag = "json"
+
+func commandOutput(cmd *cobra.Command) *output.Renderer {
+	if cmd == nil {
+		return output.New(nil, nil, output.FormatText)
+	}
+
+	return output.New(cmd.OutOrStdout(), cmd.ErrOrStderr(), commandOutputFormat(cmd))
+}
+
+func commandOutputFormat(cmd *cobra.Command) output.Format {
+	jsonOutput, err := cmd.Flags().GetBool(jsonOutputFlag)
+	if err != nil {
+		jsonOutput, err = cmd.InheritedFlags().GetBool(jsonOutputFlag)
+	}
+	if err != nil {
+		jsonOutput, err = cmd.PersistentFlags().GetBool(jsonOutputFlag)
+	}
+	if err == nil && jsonOutput {
+		return output.FormatJSON
+	}
+	return output.FormatText
+}

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCommandOutputUsesCobraWriters(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	out := commandOutput(cmd)
+	out.Info("done")
+	out.Error("failed: %d", 1)
+
+	if got, want := stdout.String(), "done\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if got, want := stderr.String(), "Error: failed: 1\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestCommandOutputHonorsJSONFlag(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.Flags().Bool(jsonOutputFlag, true, "")
+
+	out := commandOutput(cmd)
+	err := out.Render(func(w io.Writer) error {
+		t.Fatal("text renderer should not be called for JSON output")
+		return nil
+	}, struct {
+		Status string `json:"status"`
+	}{Status: "ok"})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	if got, want := stdout.String(), "{\"status\":\"ok\"}\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestCommandOutputHonorsInheritedJSONFlag(t *testing.T) {
+	var stdout bytes.Buffer
+	root := &cobra.Command{}
+	root.PersistentFlags().Bool(jsonOutputFlag, true, "")
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	root.AddCommand(cmd)
+
+	out := commandOutput(cmd)
+	err := out.Render(func(w io.Writer) error {
+		t.Fatal("text renderer should not be called for JSON output")
+		return nil
+	}, struct {
+		Status string `json:"status"`
+	}{Status: "ok"})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	if got, want := stdout.String(), "{\"status\":\"ok\"}\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,0 +1,69 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+type Format string
+
+const (
+	FormatText Format = "text"
+	FormatJSON Format = "json"
+)
+
+type Renderer struct {
+	stdout io.Writer
+	stderr io.Writer
+	format Format
+}
+
+func New(stdout, stderr io.Writer, format Format) *Renderer {
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
+	return &Renderer{
+		stdout: stdout,
+		stderr: stderr,
+		format: format,
+	}
+}
+
+func (r *Renderer) RenderText(render func(io.Writer) error) error {
+	if r.format != FormatText {
+		return fmt.Errorf("output format %q requires structured output data", r.format)
+	}
+	return r.Render(render, nil)
+}
+
+func (r *Renderer) Render(renderText func(io.Writer) error, data any) error {
+	switch r.format {
+	case FormatText:
+		if renderText == nil {
+			return nil
+		}
+		return renderText(r.stdout)
+	case FormatJSON:
+		return json.NewEncoder(r.stdout).Encode(data)
+	default:
+		return fmt.Errorf("unsupported output format %q", r.format)
+	}
+}
+
+func (r *Renderer) Warn(format string, args ...any) {
+	_, _ = fmt.Fprintf(r.stderr, "Warning: "+format+"\n", args...)
+}
+
+func (r *Renderer) Error(format string, args ...any) {
+	_, _ = fmt.Fprintf(r.stderr, "Error: "+format+"\n", args...)
+}
+
+func (r *Renderer) Info(format string, args ...any) {
+	_, _ = fmt.Fprintf(r.stdout, format+"\n", args...)
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,103 @@
+package output
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestWarnWritesToStderr(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	out := New(&stdout, &stderr, FormatText)
+	out.Warn("could not revoke token: %s", "expired")
+
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	if got, want := stderr.String(), "Warning: could not revoke token: expired\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestRenderText(t *testing.T) {
+	var stdout bytes.Buffer
+	out := New(&stdout, nil, FormatText)
+
+	err := out.Render(func(w io.Writer) error {
+		_, writeErr := w.Write([]byte("plain\n"))
+		return writeErr
+	}, struct {
+		Status string `json:"status"`
+	}{Status: "ok"})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	if got, want := stdout.String(), "plain\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRenderTextReturnsRenderError(t *testing.T) {
+	wantErr := errors.New("render failed")
+	out := New(nil, nil, FormatText)
+
+	err := out.RenderText(func(w io.Writer) error {
+		return wantErr
+	})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("RenderText error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRenderTextRequiresTextFormat(t *testing.T) {
+	out := New(nil, nil, FormatJSON)
+
+	err := out.RenderText(func(w io.Writer) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error for text-only renderer in JSON format")
+	}
+	if !strings.Contains(err.Error(), "requires structured output data") {
+		t.Fatalf("error = %q, want structured output data", err.Error())
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	out := New(&stdout, nil, FormatJSON)
+
+	err := out.Render(func(w io.Writer) error {
+		t.Fatal("text renderer should not be called for JSON output")
+		return nil
+	}, struct {
+		Status string `json:"status"`
+	}{Status: "ok"})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	if got, want := stdout.String(), "{\"status\":\"ok\"}\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRenderUnsupportedFormat(t *testing.T) {
+	out := New(nil, nil, Format("yaml"))
+
+	err := out.Render(func(w io.Writer) error {
+		return nil
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for unsupported output format")
+	}
+	if !strings.Contains(err.Error(), "unsupported output format") {
+		t.Fatalf("error = %q, want unsupported output format", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Output` struct supporting text and JSON output formats
- Commands use `commandOutput(cmd)` to get format-aware output instance
- `logout` no longer fails when token is expired — prints warning and proceeds to delete `auth.json`
- Prepares infrastructure for `--json` flag on all commands

Closes #208

## Test plan
- [x] `go test ./cmd/ -count=1` passes
- [x] `golangci-lint run ./...` clean
- [x] `logout` with expired token: prints warning, deletes auth.json, exit 0
- [x] `logout` with valid token: revokes cleanly, deletes auth.json, exit 0