### PR TITLE
Add recursive directory upload (put -r)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   * Supports search with sorting and flexible time formatting
   * Supports file revisions and file restore
   * Chunked uploads for large files, paginated listing for large directories
+  * Recursive directory uploads (`put -r`)
   * Retry with exponential backoff for uploads and downloads
   * Supports a growing set of Team operations
 
@@ -84,7 +85,7 @@ Available Commands:
   ls          List files and folders
   mkdir       Create a new directory
   mv          Move files
-  put         Upload a single file
+  put         Upload files or directories
   restore     Restore files
   revs        List file revisions
   rm          Remove files
@@ -173,6 +174,14 @@ Use "dbxcli team [command] --help" for more information about a command.
 ```
 
 The `--verbose` option will turn on verbose logging and is useful for debugging.
+
+### Uploading files and directories
+
+```sh
+$ dbxcli put file.txt /destination/file.txt        # upload a single file
+$ dbxcli put -r ./project /backup/project          # recursively upload a directory
+$ dbxcli put -r -w 8 ./large-folder /backup/large  # use 8 workers per large file
+```
 
 ### Creating directories
 

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -14,6 +14,7 @@ type mockFilesClient struct {
 	uploadSessionStartFn    func(arg *files.UploadSessionStartArg, content io.Reader) (*files.UploadSessionStartResult, error)
 	uploadSessionAppendV2Fn func(arg *files.UploadSessionAppendArg, content io.Reader) error
 	uploadSessionFinishFn   func(arg *files.UploadSessionFinishArg, content io.Reader) (*files.FileMetadata, error)
+	createFolderV2Fn        func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error)
 }
 
 func (m *mockFilesClient) Download(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
@@ -83,6 +84,9 @@ func (m *mockFilesClient) CopyReferenceSave(arg *files.SaveCopyReferenceArg) (*f
 	return nil, nil
 }
 func (m *mockFilesClient) CreateFolderV2(arg *files.CreateFolderArg) (*files.CreateFolderResult, error) {
+	if m.createFolderV2Fn != nil {
+		return m.createFolderV2Fn(arg)
+	}
 	return nil, nil
 }
 func (m *mockFilesClient) CreateFolder(arg *files.CreateFolderArg) (*files.FolderMetadata, error) {

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -22,9 +22,11 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 	"github.com/dustin/go-humanize"
 	"github.com/mitchellh/ioprogress"
@@ -32,6 +34,10 @@ import (
 )
 
 const singleShotUploadSizeCutoff int64 = 32 * (1 << 20)
+
+var filesNewFunc = func(cfg dropbox.Config) files.Client {
+	return files.New(cfg)
+}
 
 type uploadChunk struct {
 	data   []byte
@@ -176,28 +182,34 @@ func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, 
 	return
 }
 
+type putOptions struct {
+	chunkSize int64
+	workers   int
+	debug     bool
+}
+
 func put(cmd *cobra.Command, args []string) (err error) {
 	if len(args) == 0 || len(args) > 2 {
 		return errors.New("`put` requires `src` and/or `dst` arguments")
 	}
 
-	chunkSize, err := cmd.Flags().GetInt64("chunksize")
+	opts, err := parsePutOptions(cmd)
 	if err != nil {
 		return err
 	}
-	if chunkSize%(1<<22) != 0 {
-		return errors.New("`put` requires chunk size to be multiple of 4MiB")
-	}
-	workers, err := cmd.Flags().GetInt("workers")
-	if err != nil {
-		return err
-	}
-	if workers < 1 {
-		workers = 1
-	}
-	debug, _ := cmd.Flags().GetBool("debug")
+
+	recursive, _ := cmd.Flags().GetBool("recursive")
 
 	src := args[0]
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+
+	if srcInfo.IsDir() && !recursive {
+		return fmt.Errorf("%s is a directory (use --recursive to upload directories)", src)
+	}
 
 	// Default `dst` to the base segment of the source path; use the second argument if provided.
 	dst := "/" + path.Base(src)
@@ -208,15 +220,42 @@ func put(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
+	if srcInfo.IsDir() {
+		return putRecursive(src, dst, opts)
+	}
+
+	return putFile(src, dst, opts)
+}
+
+func parsePutOptions(cmd *cobra.Command) (putOptions, error) {
+	chunkSize, err := cmd.Flags().GetInt64("chunksize")
+	if err != nil {
+		return putOptions{}, err
+	}
+	if chunkSize%(1<<22) != 0 {
+		return putOptions{}, errors.New("`put` requires chunk size to be multiple of 4MiB")
+	}
+	workers, err := cmd.Flags().GetInt("workers")
+	if err != nil {
+		return putOptions{}, err
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	debug, _ := cmd.Flags().GetBool("debug")
+	return putOptions{chunkSize: chunkSize, workers: workers, debug: debug}, nil
+}
+
+func putFile(src, dst string, opts putOptions) error {
 	contents, err := os.Open(src)
 	if err != nil {
-		return
+		return err
 	}
 	defer contents.Close()
 
 	contentsInfo, err := contents.Stat()
 	if err != nil {
-		return
+		return err
 	}
 
 	commitInfo := files.NewCommitInfo(dst)
@@ -226,29 +265,113 @@ func put(cmd *cobra.Command, args []string) (err error) {
 	ts := time.Now().UTC().Round(time.Second)
 	commitInfo.ClientModified = &ts
 
-	dbx := files.New(config)
+	dbx := filesNewFunc(config)
 	if contentsInfo.Size() > singleShotUploadSizeCutoff {
-		return uploadChunked(dbx, uploadProgressReader(contents, contentsInfo.Size()), commitInfo, contentsInfo.Size(), workers, chunkSize, debug)
+		return uploadChunked(dbx, uploadProgressReader(contents, contentsInfo.Size()), commitInfo, contentsInfo.Size(), opts.workers, opts.chunkSize, opts.debug)
 	}
 
 	uploadArg := &files.UploadArg{CommitInfo: *commitInfo}
 	return uploadSingleShot(dbx, contents, uploadArg, contentsInfo.Size())
 }
 
+func putRecursive(src, dst string, opts putOptions) error {
+	src = filepath.Clean(src)
+	var uploadErrors []error
+	dirsWithFiles := make(map[string]bool)
+
+	err := filepath.WalkDir(src, func(filePath string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(src, filePath)
+		if err != nil {
+			return err
+		}
+
+		dirsWithFiles[filepath.Dir(filePath)] = true
+
+		remotePath := path.Join(dst, filepath.ToSlash(relPath))
+		fmt.Fprintf(os.Stderr, "Uploading %s -> %s\n", filePath, remotePath)
+
+		if err := putFile(filePath, remotePath, opts); err != nil {
+			uploadErrors = append(uploadErrors, fmt.Errorf("%s: %w", filePath, err))
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	dbx := filesNewFunc(config)
+
+	fmt.Fprintf(os.Stderr, "Creating directory %s\n", dst)
+	arg := files.NewCreateFolderArg(dst)
+	if _, mkdirErr := dbx.CreateFolderV2(arg); mkdirErr != nil {
+		if !isConflictError(mkdirErr) {
+			uploadErrors = append(uploadErrors, fmt.Errorf("mkdir %s: %w", dst, mkdirErr))
+		}
+	}
+
+	err = filepath.WalkDir(src, func(dirPath string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if dirsWithFiles[dirPath] {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(src, dirPath)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+
+		remotePath := path.Join(dst, filepath.ToSlash(relPath))
+		fmt.Fprintf(os.Stderr, "Creating directory %s\n", remotePath)
+		arg := files.NewCreateFolderArg(remotePath)
+		if _, mkdirErr := dbx.CreateFolderV2(arg); mkdirErr != nil {
+			if !isConflictError(mkdirErr) {
+				uploadErrors = append(uploadErrors, fmt.Errorf("mkdir %s: %w", remotePath, mkdirErr))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(uploadErrors) > 0 {
+		return fmt.Errorf("failed to upload %d file(s): %v", len(uploadErrors), uploadErrors[0])
+	}
+	return nil
+}
+
 // putCmd represents the put command
 var putCmd = &cobra.Command{
 	Use:   "put [flags] <source> [<target>]",
-	Short: "Upload a single file",
-	Long: `Upload a single file
-	- If target is not provided puts the file in the root of your Dropbox directory.
-	- If target is provided it must be the desired filename in the cloud (and not a directory).
-	`,
-
+	Short: "Upload files or directories",
+	Long: `Upload files or directories to Dropbox.
+  - If target is not provided, uploads to the root of your Dropbox.
+  - Use --recursive (-r) to upload entire directories.
+`,
 	RunE: put,
 }
 
 func init() {
 	RootCmd.AddCommand(putCmd)
+	putCmd.Flags().BoolP("recursive", "r", false, "Recursively upload directories")
 	putCmd.Flags().IntP("workers", "w", 4, "Number of concurrent upload workers to use")
 	putCmd.Flags().Int64P("chunksize", "c", 1<<24, "Chunk size to use (should be multiple of 4MiB)")
 	putCmd.Flags().BoolP("debug", "d", false, "Print debug timing")

--- a/cmd/put_test.go
+++ b/cmd/put_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	dbxauth "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/spf13/cobra"
 )
 
 func TestUploadOneChunk_Success(t *testing.T) {
@@ -231,12 +232,200 @@ func TestUploadSingleShot_RetriesTooManyWriteOperations(t *testing.T) {
 	}
 }
 
+func testConfig() dropbox.Config {
+	return dropbox.Config{Token: "test-token"}
+}
+
+func testPutCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().BoolP("recursive", "r", false, "Recursively upload directories")
+	cmd.Flags().IntP("workers", "w", 4, "Number of concurrent upload workers to use")
+	cmd.Flags().Int64P("chunksize", "c", 1<<24, "Chunk size to use (should be multiple of 4MiB)")
+	cmd.Flags().BoolP("debug", "d", false, "Print debug timing")
+	return cmd
+}
+
 func TestPutArgValidation(t *testing.T) {
-	cmd := putCmd
-	cmd.SetArgs([]string{})
-	err := cmd.RunE(cmd, []string{})
+	err := put(testPutCmd(), []string{})
 	if err == nil {
 		t.Error("expected error for no args")
+	}
+}
+
+func TestPutDirectoryWithoutRecursiveFlag(t *testing.T) {
+	dir := t.TempDir()
+	err := put(testPutCmd(), []string{dir, "/dest"})
+	if err == nil {
+		t.Fatal("expected error when putting directory without --recursive")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("use --recursive")) {
+		t.Errorf("error = %q, want mention of --recursive", err.Error())
+	}
+}
+
+func TestPutRecursive_WalksDirectoryStructure(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "sub", "deep"), 0755)
+	os.WriteFile(filepath.Join(dir, "root.txt"), []byte("root"), 0644)
+	os.WriteFile(filepath.Join(dir, "sub", "mid.txt"), []byte("mid"), 0644)
+	os.WriteFile(filepath.Join(dir, "sub", "deep", "leaf.txt"), []byte("leaf"), 0644)
+
+	var uploaded []string
+	origConfig := config
+	defer func() { config = origConfig }()
+
+	config = testConfig()
+	testClient := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			uploaded = append(uploaded, arg.Path)
+			return &files.FileMetadata{}, nil
+		},
+	}
+	origNew := filesNewFunc
+	filesNewFunc = func(_ dropbox.Config) files.Client { return testClient }
+	defer func() { filesNewFunc = origNew }()
+
+	opts := putOptions{chunkSize: 1 << 24, workers: 4}
+	err := putRecursive(dir, "/backup", opts)
+	if err != nil {
+		t.Fatalf("putRecursive error: %v", err)
+	}
+
+	expected := map[string]bool{
+		"/backup/root.txt":          true,
+		"/backup/sub/mid.txt":       true,
+		"/backup/sub/deep/leaf.txt": true,
+	}
+	if len(uploaded) != len(expected) {
+		t.Fatalf("uploaded %d files, want %d: %v", len(uploaded), len(expected), uploaded)
+	}
+	for _, path := range uploaded {
+		if !expected[path] {
+			t.Errorf("unexpected upload path: %s", path)
+		}
+	}
+}
+
+func TestPutRecursive_CreatesEmptyDirectories(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "has-files"), 0755)
+	os.MkdirAll(filepath.Join(dir, "empty"), 0755)
+	os.MkdirAll(filepath.Join(dir, "empty", "nested"), 0755)
+	os.WriteFile(filepath.Join(dir, "has-files", "a.txt"), []byte("a"), 0644)
+
+	var uploaded []string
+	var createdDirs []string
+	origConfig := config
+	defer func() { config = origConfig }()
+
+	config = testConfig()
+	testClient := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			uploaded = append(uploaded, arg.Path)
+			return &files.FileMetadata{}, nil
+		},
+		createFolderV2Fn: func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error) {
+			createdDirs = append(createdDirs, arg.Path)
+			return &files.CreateFolderResult{}, nil
+		},
+	}
+	origNew := filesNewFunc
+	filesNewFunc = func(_ dropbox.Config) files.Client { return testClient }
+	defer func() { filesNewFunc = origNew }()
+
+	opts := putOptions{chunkSize: 1 << 24, workers: 4}
+	err := putRecursive(dir, "/dest", opts)
+	if err != nil {
+		t.Fatalf("putRecursive error: %v", err)
+	}
+
+	if len(uploaded) != 1 || uploaded[0] != "/dest/has-files/a.txt" {
+		t.Errorf("uploaded = %v, want [/dest/has-files/a.txt]", uploaded)
+	}
+
+	expectedDirs := map[string]bool{
+		"/dest":              true,
+		"/dest/empty":        true,
+		"/dest/empty/nested": true,
+	}
+	if len(createdDirs) != len(expectedDirs) {
+		t.Fatalf("created %d dirs, want %d: %v", len(createdDirs), len(expectedDirs), createdDirs)
+	}
+	for _, d := range createdDirs {
+		if !expectedDirs[d] {
+			t.Errorf("unexpected created dir: %s", d)
+		}
+	}
+}
+
+func TestPutRecursive_CreatesEmptyRootDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	var uploaded []string
+	var createdDirs []string
+	origConfig := config
+	defer func() { config = origConfig }()
+
+	config = testConfig()
+	testClient := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			uploaded = append(uploaded, arg.Path)
+			return &files.FileMetadata{}, nil
+		},
+		createFolderV2Fn: func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error) {
+			createdDirs = append(createdDirs, arg.Path)
+			return &files.CreateFolderResult{}, nil
+		},
+	}
+	origNew := filesNewFunc
+	filesNewFunc = func(_ dropbox.Config) files.Client { return testClient }
+	defer func() { filesNewFunc = origNew }()
+
+	opts := putOptions{chunkSize: 1 << 24, workers: 4}
+	err := putRecursive(dir, "/empty-root", opts)
+	if err != nil {
+		t.Fatalf("putRecursive error: %v", err)
+	}
+
+	if len(uploaded) != 0 {
+		t.Fatalf("uploaded = %v, want no files", uploaded)
+	}
+	if len(createdDirs) != 1 || createdDirs[0] != "/empty-root" {
+		t.Fatalf("createdDirs = %v, want [/empty-root]", createdDirs)
+	}
+}
+
+func TestPutRecursive_SkipsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "real.txt"), []byte("real"), 0644)
+	os.Symlink(filepath.Join(dir, "real.txt"), filepath.Join(dir, "link.txt"))
+
+	var uploaded []string
+	origConfig := config
+	defer func() { config = origConfig }()
+
+	config = testConfig()
+	testClient := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			uploaded = append(uploaded, arg.Path)
+			return &files.FileMetadata{}, nil
+		},
+	}
+	origNew := filesNewFunc
+	filesNewFunc = func(_ dropbox.Config) files.Client { return testClient }
+	defer func() { filesNewFunc = origNew }()
+
+	opts := putOptions{chunkSize: 1 << 24, workers: 4}
+	err := putRecursive(dir, "/dest", opts)
+	if err != nil {
+		t.Fatalf("putRecursive error: %v", err)
+	}
+
+	if len(uploaded) != 1 {
+		t.Fatalf("uploaded %d files, want 1: %v", len(uploaded), uploaded)
+	}
+	if uploaded[0] != "/dest/real.txt" {
+		t.Errorf("uploaded[0] = %q, want /dest/real.txt", uploaded[0])
 	}
 }
 
@@ -246,7 +435,7 @@ func TestPutChunkSizeValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := putCmd
+	cmd := testPutCmd()
 	_ = cmd.Flags().Set("chunksize", "100")
 	err := put(cmd, []string{tmpFile, "/test.txt"})
 	if err == nil || err.Error() != "`put` requires chunk size to be multiple of 4MiB" {


### PR DESCRIPTION
## Summary
- Adds `--recursive` (`-r`) flag to `put` command for uploading entire directories
- Preserves directory structure including empty subdirectories
- Skips symlinks and non-regular files
- Creates destination root directory to handle completely empty source dirs
- Clear error message when attempting to upload a directory without `-r`

Closes #215, #182, #171, #106

## Test plan
- [x] Unit tests: walks directory structure, creates empty dirs, skips symlinks, empty root dir
- [x] Manual test: single file upload still works
- [x] Manual test: large file (40 MiB) chunked upload works
- [x] Manual test: recursive upload of directory with nested files
- [x] Manual test: recursive upload of empty directory
- [x] `go vet`, `go build`, `go test` all pass