### PR TITLE
Pre-validate put target path to detect folder conflicts early

### DIFF
--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -15,6 +15,7 @@ type mockFilesClient struct {
 	uploadSessionAppendV2Fn func(arg *files.UploadSessionAppendArg, content io.Reader) error
 	uploadSessionFinishFn   func(arg *files.UploadSessionFinishArg, content io.Reader) (*files.FileMetadata, error)
 	createFolderV2Fn        func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error)
+	getMetadataFn           func(arg *files.GetMetadataArg) (files.IsMetadata, error)
 }
 
 func (m *mockFilesClient) Download(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
@@ -118,6 +119,9 @@ func (m *mockFilesClient) GetFileLockBatch(arg *files.LockFileBatchArg) (*files.
 	return nil, nil
 }
 func (m *mockFilesClient) GetMetadata(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+	if m.getMetadataFn != nil {
+		return m.getMetadataFn(arg)
+	}
 	return nil, nil
 }
 func (m *mockFilesClient) GetPreview(arg *files.PreviewArg) (*files.FileMetadata, io.ReadCloser, error) {

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -213,11 +214,17 @@ func put(cmd *cobra.Command, args []string) (err error) {
 
 	// Default `dst` to the base segment of the source path; use the second argument if provided.
 	dst := "/" + path.Base(src)
+	dstIsDir := false
 	if len(args) == 2 {
+		dstIsDir = strings.HasSuffix(args[1], "/")
 		dst, err = validatePath(args[1])
 		if err != nil {
 			return
 		}
+	}
+
+	if !srcInfo.IsDir() {
+		dst = resolveDestination(filesNewFunc(config), src, dst, dstIsDir)
 	}
 
 	if srcInfo.IsDir() {
@@ -225,6 +232,20 @@ func put(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	return putFile(src, dst, opts)
+}
+
+func resolveDestination(dbx files.Client, src, dst string, dstIsDir bool) string {
+	if dstIsDir {
+		return path.Join("/", dst, path.Base(src))
+	}
+	meta, err := dbx.GetMetadata(files.NewGetMetadataArg(dst))
+	if err != nil {
+		return dst
+	}
+	if _, ok := meta.(*files.FolderMetadata); ok {
+		return path.Join("/", dst, path.Base(src))
+	}
+	return dst
 }
 
 func parsePutOptions(cmd *cobra.Command) (putOptions, error) {

--- a/cmd/put_test.go
+++ b/cmd/put_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -243,6 +244,100 @@ func testPutCmd() *cobra.Command {
 	cmd.Flags().Int64P("chunksize", "c", 1<<24, "Chunk size to use (should be multiple of 4MiB)")
 	cmd.Flags().BoolP("debug", "d", false, "Print debug timing")
 	return cmd
+}
+
+func TestResolveDestination_TargetIsFolder(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return &files.FolderMetadata{Metadata: files.Metadata{PathDisplay: arg.Path}}, nil
+		},
+	}
+	got := resolveDestination(mock, "/local/video.mp4", "/Videos", false)
+	if got != "/Videos/video.mp4" {
+		t.Errorf("resolveDestination = %q, want /Videos/video.mp4", got)
+	}
+}
+
+func TestResolveDestination_TargetIsFile(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return &files.FileMetadata{}, nil
+		},
+	}
+	got := resolveDestination(mock, "/local/a.txt", "/existing.txt", false)
+	if got != "/existing.txt" {
+		t.Errorf("resolveDestination = %q, want /existing.txt", got)
+	}
+}
+
+func TestResolveDestination_TargetNotFound(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, fmt.Errorf("path/not_found/")
+		},
+	}
+	got := resolveDestination(mock, "/local/a.txt", "/new-name", false)
+	if got != "/new-name" {
+		t.Errorf("resolveDestination = %q, want /new-name", got)
+	}
+}
+
+func TestResolveDestination_ExplicitDirectory(t *testing.T) {
+	mock := &mockFilesClient{}
+	got := resolveDestination(mock, "/local/a.txt", "/folder", true)
+	if got != "/folder/a.txt" {
+		t.Errorf("resolveDestination = %q, want /folder/a.txt", got)
+	}
+}
+
+func TestResolveDestination_ExplicitRootDirectory(t *testing.T) {
+	mock := &mockFilesClient{}
+	got := resolveDestination(mock, "/local/a.txt", "", true)
+	if got != "/a.txt" {
+		t.Errorf("resolveDestination = %q, want /a.txt", got)
+	}
+}
+
+func TestResolveDestination_MetadataError(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, fmt.Errorf("server error 500")
+		},
+	}
+	got := resolveDestination(mock, "/local/a.txt", "/path", false)
+	if got != "/path" {
+		t.Errorf("resolveDestination = %q, want /path (fallback on error)", got)
+	}
+}
+
+func TestPutFileDestinationTrailingSlash(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "a.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var uploadedPath string
+	origConfig := config
+	defer func() { config = origConfig }()
+
+	config = testConfig()
+	testClient := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			uploadedPath = arg.Path
+			return &files.FileMetadata{}, nil
+		},
+	}
+	origNew := filesNewFunc
+	filesNewFunc = func(_ dropbox.Config) files.Client { return testClient }
+	defer func() { filesNewFunc = origNew }()
+
+	err := put(testPutCmd(), []string{tmpFile, "/folder/"})
+	if err != nil {
+		t.Fatalf("put error: %v", err)
+	}
+	if uploadedPath != "/folder/a.txt" {
+		t.Errorf("uploaded path = %q, want /folder/a.txt", uploadedPath)
+	}
 }
 
 func TestPutArgValidation(t *testing.T) {


### PR DESCRIPTION
Before uploading, call GetMetadata on the destination path. If it's an
existing folder, append the source filename automatically — preventing
wasted uploads that end with path/conflict/folder errors.

Closes #93, closes #174.