### PR TITLE
Unify cp/mv destination logic and fix local path handling

### DIFF
--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 	"github.com/spf13/cobra"
@@ -40,20 +41,23 @@ func cp(cmd *cobra.Command, args []string) error {
 	var cpErrors []error
 	var relocationArgs []*files.RelocationArg
 
+	dbx := filesNewFunc(config)
+	destIsFolder := len(argsToCopy) > 1 || strings.HasSuffix(destination, "/") || isRemoteFolder(dbx, destination)
+
 	for _, argument := range argsToCopy {
-		arg, err := makeRelocationArg(argument, destination+"/"+argument)
+		dst := relocationDestination(argument, destination, destIsFolder)
+		arg, err := makeRelocationArg(argument, dst)
 		if err != nil {
-			relocationError := fmt.Errorf("Error validating copy for %s to %s: %v", argument, destination, err)
+			relocationError := fmt.Errorf("Error validating copy for %s to %s: %v", argument, dst, err)
 			cpErrors = append(cpErrors, relocationError)
 		} else {
 			relocationArgs = append(relocationArgs, arg)
 		}
 	}
 
-	dbx := files.New(config)
 	for _, arg := range relocationArgs {
 		if _, err := dbx.CopyV2(arg); err != nil {
-			copyError := fmt.Errorf("Copy error: %v", arg)
+			copyError := fmt.Errorf("copy %q to %q: %v", arg.FromPath, arg.ToPath, err)
 			cpErrors = append(cpErrors, copyError)
 		}
 	}

--- a/cmd/cp_test.go
+++ b/cmd/cp_test.go
@@ -1,6 +1,50 @@
 package cmd
 
-import "testing"
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+func stubFilesClient(t *testing.T, client files.Client) {
+	t.Helper()
+
+	origNew := filesNewFunc
+	filesNewFunc = func(_ dropbox.Config) files.Client { return client }
+	t.Cleanup(func() { filesNewFunc = origNew })
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Stderr = w
+	fn()
+	closeErr := w.Close()
+	os.Stderr = oldStderr
+	if closeErr != nil {
+		t.Fatal(closeErr)
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
 
 func TestCpArgValidation(t *testing.T) {
 	err := cp(cpCmd, []string{})
@@ -11,5 +55,142 @@ func TestCpArgValidation(t *testing.T) {
 	err = cp(cpCmd, []string{"/only-one"})
 	if err == nil {
 		t.Error("expected error for single arg")
+	}
+}
+
+func TestCpCopiesIntoExistingRemoteFolder(t *testing.T) {
+	var copied []*files.RelocationArg
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			if arg.Path != "/dest" {
+				t.Errorf("metadata path = %q, want /dest", arg.Path)
+			}
+			return &files.FolderMetadata{}, nil
+		},
+		copyV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			copied = append(copied, arg)
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := cp(cpCmd, []string{"/src/file.txt", "/dest"})
+	if err != nil {
+		t.Fatalf("cp error: %v", err)
+	}
+	if len(copied) != 1 {
+		t.Fatalf("copied %d items, want 1", len(copied))
+	}
+	if copied[0].FromPath != "/src/file.txt" {
+		t.Errorf("FromPath = %q, want /src/file.txt", copied[0].FromPath)
+	}
+	if copied[0].ToPath != "/dest/file.txt" {
+		t.Errorf("ToPath = %q, want /dest/file.txt", copied[0].ToPath)
+	}
+}
+
+func TestCpCopiesIntoTrailingSlashDestination(t *testing.T) {
+	var copied []*files.RelocationArg
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			t.Fatalf("GetMetadata called for trailing slash destination: %v", arg)
+			return nil, nil
+		},
+		copyV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			copied = append(copied, arg)
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := cp(cpCmd, []string{"/src/file.txt", "/dest/"})
+	if err != nil {
+		t.Fatalf("cp error: %v", err)
+	}
+	if len(copied) != 1 {
+		t.Fatalf("copied %d items, want 1", len(copied))
+	}
+	if copied[0].ToPath != "/dest/file.txt" {
+		t.Errorf("ToPath = %q, want /dest/file.txt", copied[0].ToPath)
+	}
+}
+
+func TestCpSingleSourceUsesExactDestinationWhenNotFolder(t *testing.T) {
+	var copied []*files.RelocationArg
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, fmt.Errorf("path/not_found/")
+		},
+		copyV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			copied = append(copied, arg)
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := cp(cpCmd, []string{"/src/file.txt", "/dest/file-copy.txt"})
+	if err != nil {
+		t.Fatalf("cp error: %v", err)
+	}
+	if len(copied) != 1 {
+		t.Fatalf("copied %d items, want 1", len(copied))
+	}
+	if copied[0].ToPath != "/dest/file-copy.txt" {
+		t.Errorf("ToPath = %q, want /dest/file-copy.txt", copied[0].ToPath)
+	}
+}
+
+func TestCpMultipleSourcesTreatsDestinationAsFolder(t *testing.T) {
+	var copied []*files.RelocationArg
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			t.Fatalf("GetMetadata called for multiple sources: %v", arg)
+			return nil, nil
+		},
+		copyV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			copied = append(copied, arg)
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := cp(cpCmd, []string{"/src/a.txt", "/src/b.txt", "/dest"})
+	if err != nil {
+		t.Fatalf("cp error: %v", err)
+	}
+	if len(copied) != 2 {
+		t.Fatalf("copied %d items, want 2", len(copied))
+	}
+	if copied[0].ToPath != "/dest/a.txt" {
+		t.Errorf("first ToPath = %q, want /dest/a.txt", copied[0].ToPath)
+	}
+	if copied[1].ToPath != "/dest/b.txt" {
+		t.Errorf("second ToPath = %q, want /dest/b.txt", copied[1].ToPath)
+	}
+}
+
+func TestCpCopyErrorIncludesAPIError(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, fmt.Errorf("path/not_found/")
+		},
+		copyV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			return nil, fmt.Errorf("path/malformed_path/")
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = cp(cpCmd, []string{"/src/file.txt", "/dest/file.txt"})
+	})
+	if err == nil {
+		t.Fatal("expected cp error")
+	}
+	if !strings.Contains(stderr, `copy "/src/file.txt" to "/dest/file.txt": path/malformed_path/`) {
+		t.Errorf("stderr = %q, want copy path and API error", stderr)
+	}
+	if strings.Contains(stderr, "&{{") {
+		t.Errorf("stderr still contains formatted relocation arg: %q", stderr)
 	}
 }

--- a/cmd/dropbox_path.go
+++ b/cmd/dropbox_path.go
@@ -1,0 +1,51 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"path"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+// Dropbox API paths are slash-separated regardless of the local OS. Use package
+// path for Dropbox paths and filepath only for local filesystem paths.
+func cleanDropboxPath(p string) string {
+	p = path.Clean(p)
+	if p == "/" {
+		return ""
+	}
+	return p
+}
+
+func relocationDestination(source, destination string, destinationIsFolder bool) string {
+	if destinationIsFolder {
+		return path.Join(destination, path.Base(source))
+	}
+	return destination
+}
+
+func isRemoteFolder(dbx files.Client, dst string) bool {
+	p, err := validatePath(dst)
+	if err != nil {
+		return false
+	}
+	meta, err := dbx.GetMetadata(files.NewGetMetadataArg(p))
+	if err != nil {
+		return false
+	}
+	_, ok := meta.(*files.FolderMetadata)
+	return ok
+}

--- a/cmd/dropbox_path_test.go
+++ b/cmd/dropbox_path_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+func TestValidatePath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/", ""},
+		{"/foo", "/foo"},
+		{"foo", "/foo"},
+		{"/foo/", "/foo"},
+		{"/foo/bar", "/foo/bar"},
+		{"foo/bar/", "/foo/bar"},
+		{"/foo//bar", "/foo/bar"},
+		{"foo//bar/", "/foo/bar"},
+	}
+
+	for _, tt := range tests {
+		got, err := validatePath(tt.input)
+		if err != nil {
+			t.Errorf("validatePath(%q) returned error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("validatePath(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestValidatePathRootBecomesEmpty(t *testing.T) {
+	got, err := validatePath("/")
+	if err != nil {
+		t.Fatalf("validatePath('/') error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("validatePath('/') = %q, want empty string for root", got)
+	}
+}
+
+func TestMakeRelocationArg(t *testing.T) {
+	arg, err := makeRelocationArg("src", "dst")
+	if err != nil {
+		t.Fatalf("makeRelocationArg error: %v", err)
+	}
+	if arg.FromPath != "/src" {
+		t.Errorf("FromPath = %q, want %q", arg.FromPath, "/src")
+	}
+	if arg.ToPath != "/dst" {
+		t.Errorf("ToPath = %q, want %q", arg.ToPath, "/dst")
+	}
+}
+
+func TestRelocationDestination(t *testing.T) {
+	tests := []struct {
+		name                string
+		source              string
+		destination         string
+		destinationIsFolder bool
+		want                string
+	}{
+		{
+			name:                "exact destination",
+			source:              "/src/file.txt",
+			destination:         "/dest/file-copy.txt",
+			destinationIsFolder: false,
+			want:                "/dest/file-copy.txt",
+		},
+		{
+			name:                "folder destination",
+			source:              "/src/file.txt",
+			destination:         "/dest",
+			destinationIsFolder: true,
+			want:                "/dest/file.txt",
+		},
+		{
+			name:                "folder destination trailing slash",
+			source:              "/src/file.txt",
+			destination:         "/dest/",
+			destinationIsFolder: true,
+			want:                "/dest/file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		got := relocationDestination(tt.source, tt.destination, tt.destinationIsFolder)
+		if got != tt.want {
+			t.Errorf("%s: relocationDestination() = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestIsRemoteFolder_Folder(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return &files.FolderMetadata{Metadata: files.Metadata{PathDisplay: arg.Path}}, nil
+		},
+	}
+	if !isRemoteFolder(mock, "/Videos") {
+		t.Error("expected true for folder metadata")
+	}
+}
+
+func TestIsRemoteFolder_File(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return &files.FileMetadata{}, nil
+		},
+	}
+	if isRemoteFolder(mock, "/file.txt") {
+		t.Error("expected false for file metadata")
+	}
+}
+
+func TestIsRemoteFolder_NotFound(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, fmt.Errorf("path/not_found/")
+		},
+	}
+	if isRemoteFolder(mock, "/nonexistent") {
+		t.Error("expected false for not found")
+	}
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -51,7 +51,7 @@ func getWithClient(dbx files.Client, args []string) (err error) {
 	}
 	// If `dst` is a directory, append the source filename.
 	if f, err := os.Stat(dst); err == nil && f.IsDir() {
-		dst = path.Join(dst, path.Base(src))
+		dst = filepath.Join(dst, path.Base(src))
 	}
 
 	return downloadFile(dbx, src, dst)

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -16,7 +16,7 @@ package cmd
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
@@ -32,7 +32,7 @@ func logout(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	filePath := path.Join(dir, ".config", "dbxcli", configFileName)
+	filePath := filepath.Join(dir, ".config", "dbxcli", configFileName)
 
 	tokMap, err := readTokens(filePath)
 	if err != nil {

--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -8,31 +8,6 @@ import (
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 )
 
-func TestValidatePath(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"/", ""},
-		{"/foo", "/foo"},
-		{"foo", "/foo"},
-		{"/foo/", "/foo"},
-		{"/foo/bar", "/foo/bar"},
-		{"foo/bar/", "/foo/bar"},
-	}
-
-	for _, tt := range tests {
-		got, err := validatePath(tt.input)
-		if err != nil {
-			t.Errorf("validatePath(%q) returned error: %v", tt.input, err)
-			continue
-		}
-		if got != tt.want {
-			t.Errorf("validatePath(%q) = %q, want %q", tt.input, got, tt.want)
-		}
-	}
-}
-
 func TestFormatFolderMetadata(t *testing.T) {
 	meta := &files.FolderMetadata{
 		Metadata: files.Metadata{
@@ -146,16 +121,6 @@ func TestFormatFileMetadataLongIncludesFields(t *testing.T) {
 	}
 }
 
-func TestValidatePathRootBecomesEmpty(t *testing.T) {
-	got, err := validatePath("/")
-	if err != nil {
-		t.Fatalf("validatePath('/') error: %v", err)
-	}
-	if got != "" {
-		t.Errorf("validatePath('/') = %q, want empty string for root", got)
-	}
-}
-
 func TestGetFileMetadataNotCalledForRoot(t *testing.T) {
 	// This test verifies the ls function logic:
 	// when path is "" (root), getFileMetadata should not be called.
@@ -164,19 +129,6 @@ func TestGetFileMetadataNotCalledForRoot(t *testing.T) {
 	arg := files.NewGetMetadataArg("")
 	if arg.Path != "" {
 		t.Errorf("NewGetMetadataArg('') path = %q, want empty", arg.Path)
-	}
-}
-
-func TestMakeRelocationArg(t *testing.T) {
-	arg, err := makeRelocationArg("src", "dst")
-	if err != nil {
-		t.Fatalf("makeRelocationArg error: %v", err)
-	}
-	if arg.FromPath != "/src" {
-		t.Errorf("FromPath = %q, want %q", arg.FromPath, "/src")
-	}
-	if arg.ToPath != "/dst" {
-		t.Errorf("ToPath = %q, want %q", arg.ToPath, "/dst")
 	}
 }
 

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -14,8 +14,10 @@ type mockFilesClient struct {
 	uploadSessionStartFn    func(arg *files.UploadSessionStartArg, content io.Reader) (*files.UploadSessionStartResult, error)
 	uploadSessionAppendV2Fn func(arg *files.UploadSessionAppendArg, content io.Reader) error
 	uploadSessionFinishFn   func(arg *files.UploadSessionFinishArg, content io.Reader) (*files.FileMetadata, error)
+	copyV2Fn                func(arg *files.RelocationArg) (*files.RelocationResult, error)
 	createFolderV2Fn        func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error)
 	getMetadataFn           func(arg *files.GetMetadataArg) (files.IsMetadata, error)
+	moveV2Fn                func(arg *files.RelocationArg) (*files.RelocationResult, error)
 }
 
 func (m *mockFilesClient) Download(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
@@ -61,6 +63,9 @@ func (m *mockFilesClient) AlphaUpload(arg *files.UploadArg, content io.Reader) (
 	return nil, nil
 }
 func (m *mockFilesClient) CopyV2(arg *files.RelocationArg) (*files.RelocationResult, error) {
+	if m.copyV2Fn != nil {
+		return m.copyV2Fn(arg)
+	}
 	return nil, nil
 }
 func (m *mockFilesClient) Copy(arg *files.RelocationArg) (files.IsMetadata, error) {
@@ -161,6 +166,9 @@ func (m *mockFilesClient) LockFileBatch(arg *files.LockFileBatchArg) (*files.Loc
 	return nil, nil
 }
 func (m *mockFilesClient) MoveV2(arg *files.RelocationArg) (*files.RelocationResult, error) {
+	if m.moveV2Fn != nil {
+		return m.moveV2Fn(arg)
+	}
 	return nil, nil
 }
 func (m *mockFilesClient) Move(arg *files.RelocationArg) (files.IsMetadata, error) {

--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path"
 	"strings"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
@@ -41,17 +40,11 @@ func mv(cmd *cobra.Command, args []string) error {
 	var mvErrors []error
 	var relocationArgs []*files.RelocationArg
 
-	dbx := files.New(config)
-	destIsFolder := strings.HasSuffix(destination, "/") || isRemoteFolder(dbx, destination)
+	dbx := filesNewFunc(config)
+	destIsFolder := len(argsToMove) > 1 || strings.HasSuffix(destination, "/") || isRemoteFolder(dbx, destination)
 
 	for _, argument := range argsToMove {
-		var dst string
-		if destIsFolder {
-			dst = path.Join(destination, path.Base(argument))
-		} else {
-			dst = destination
-		}
-
+		dst := relocationDestination(argument, destination, destIsFolder)
 		arg, err := makeRelocationArg(argument, dst)
 		if err != nil {
 			mvErrors = append(mvErrors, fmt.Errorf("Error validating move for %s to %s: %v", argument, dst, err))
@@ -62,7 +55,7 @@ func mv(cmd *cobra.Command, args []string) error {
 
 	for _, arg := range relocationArgs {
 		if _, err := dbx.MoveV2(arg); err != nil {
-			moveError := fmt.Errorf("Move error: %v", arg)
+			moveError := fmt.Errorf("move %q to %q: %v", arg.FromPath, arg.ToPath, err)
 			mvErrors = append(mvErrors, moveError)
 		}
 	}
@@ -75,19 +68,6 @@ func mv(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func isRemoteFolder(dbx files.Client, dst string) bool {
-	p, err := validatePath(dst)
-	if err != nil {
-		return false
-	}
-	meta, err := dbx.GetMetadata(files.NewGetMetadataArg(p))
-	if err != nil {
-		return false
-	}
-	_, ok := meta.(*files.FolderMetadata)
-	return ok
 }
 
 // mvCmd represents the mv command

--- a/cmd/mv_test.go
+++ b/cmd/mv_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
@@ -19,35 +20,57 @@ func TestMvArgValidation(t *testing.T) {
 	}
 }
 
-func TestIsRemoteFolder_Folder(t *testing.T) {
+func TestMvMultipleSourcesTreatsDestinationAsFolder(t *testing.T) {
+	var moved []*files.RelocationArg
 	mock := &mockFilesClient{
 		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
-			return &files.FolderMetadata{Metadata: files.Metadata{PathDisplay: arg.Path}}, nil
+			t.Fatalf("GetMetadata called for multiple sources: %v", arg)
+			return nil, nil
+		},
+		moveV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			moved = append(moved, arg)
+			return nil, nil
 		},
 	}
-	if !isRemoteFolder(mock, "/Videos") {
-		t.Error("expected true for folder metadata")
+	stubFilesClient(t, mock)
+
+	err := mv(mvCmd, []string{"/src/a.txt", "/src/b.txt", "/dest"})
+	if err != nil {
+		t.Fatalf("mv error: %v", err)
+	}
+	if len(moved) != 2 {
+		t.Fatalf("moved %d items, want 2", len(moved))
+	}
+	if moved[0].ToPath != "/dest/a.txt" {
+		t.Errorf("first ToPath = %q, want /dest/a.txt", moved[0].ToPath)
+	}
+	if moved[1].ToPath != "/dest/b.txt" {
+		t.Errorf("second ToPath = %q, want /dest/b.txt", moved[1].ToPath)
 	}
 }
 
-func TestIsRemoteFolder_File(t *testing.T) {
-	mock := &mockFilesClient{
-		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
-			return &files.FileMetadata{}, nil
-		},
-	}
-	if isRemoteFolder(mock, "/file.txt") {
-		t.Error("expected false for file metadata")
-	}
-}
-
-func TestIsRemoteFolder_NotFound(t *testing.T) {
+func TestMvMoveErrorIncludesAPIError(t *testing.T) {
 	mock := &mockFilesClient{
 		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
 			return nil, fmt.Errorf("path/not_found/")
 		},
+		moveV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			return nil, fmt.Errorf("path/malformed_path/")
+		},
 	}
-	if isRemoteFolder(mock, "/nonexistent") {
-		t.Error("expected false for not found")
+	stubFilesClient(t, mock)
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = mv(mvCmd, []string{"/src/file.txt", "/dest/file.txt"})
+	})
+	if err == nil {
+		t.Fatal("expected mv error")
+	}
+	if !strings.Contains(stderr, `move "/src/file.txt" to "/dest/file.txt": path/malformed_path/`) {
+		t.Errorf("stderr = %q, want move path and API error", stderr)
+	}
+	if strings.Contains(stderr, "&{{") {
+		t.Errorf("stderr still contains formatted relocation arg: %q", stderr)
 	}
 }

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -213,7 +213,7 @@ func put(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Default `dst` to the base segment of the source path; use the second argument if provided.
-	dst := "/" + path.Base(src)
+	dst := "/" + filepath.Base(src)
 	dstIsDir := false
 	if len(args) == 2 {
 		dstIsDir = strings.HasSuffix(args[1], "/")
@@ -236,14 +236,14 @@ func put(cmd *cobra.Command, args []string) (err error) {
 
 func resolveDestination(dbx files.Client, src, dst string, dstIsDir bool) string {
 	if dstIsDir {
-		return path.Join("/", dst, path.Base(src))
+		return path.Join("/", dst, filepath.Base(src))
 	}
 	meta, err := dbx.GetMetadata(files.NewGetMetadataArg(dst))
 	if err != nil {
 		return dst
 	}
 	if _, ok := meta.(*files.FolderMetadata); ok {
-		return path.Join("/", dst, path.Base(src))
+		return path.Join("/", dst, filepath.Base(src))
 	}
 	return dst
 }

--- a/cmd/put_test.go
+++ b/cmd/put_test.go
@@ -360,10 +360,18 @@ func TestPutDirectoryWithoutRecursiveFlag(t *testing.T) {
 
 func TestPutRecursive_WalksDirectoryStructure(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "sub", "deep"), 0755)
-	os.WriteFile(filepath.Join(dir, "root.txt"), []byte("root"), 0644)
-	os.WriteFile(filepath.Join(dir, "sub", "mid.txt"), []byte("mid"), 0644)
-	os.WriteFile(filepath.Join(dir, "sub", "deep", "leaf.txt"), []byte("leaf"), 0644)
+	if err := os.MkdirAll(filepath.Join(dir, "sub", "deep"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "root.txt"), []byte("root"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub", "mid.txt"), []byte("mid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub", "deep", "leaf.txt"), []byte("leaf"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	var uploaded []string
 	origConfig := config
@@ -403,10 +411,18 @@ func TestPutRecursive_WalksDirectoryStructure(t *testing.T) {
 
 func TestPutRecursive_CreatesEmptyDirectories(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "has-files"), 0755)
-	os.MkdirAll(filepath.Join(dir, "empty"), 0755)
-	os.MkdirAll(filepath.Join(dir, "empty", "nested"), 0755)
-	os.WriteFile(filepath.Join(dir, "has-files", "a.txt"), []byte("a"), 0644)
+	if err := os.MkdirAll(filepath.Join(dir, "has-files"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "empty"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "empty", "nested"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "has-files", "a.txt"), []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	var uploaded []string
 	var createdDirs []string
@@ -492,8 +508,12 @@ func TestPutRecursive_CreatesEmptyRootDirectory(t *testing.T) {
 
 func TestPutRecursive_SkipsSymlinks(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "real.txt"), []byte("real"), 0644)
-	os.Symlink(filepath.Join(dir, "real.txt"), filepath.Join(dir, "link.txt"))
+	if err := os.WriteFile(filepath.Join(dir, "real.txt"), []byte("real"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "real.txt"), filepath.Join(dir, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
 
 	var uploaded []string
 	origConfig := config

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -82,12 +81,11 @@ func oauthConfig(tokenType string, domain string) *oauth2.Config {
 
 func validatePath(p string) (path string, err error) {
 	path = p
-
 	if !strings.HasPrefix(path, "/") {
 		path = fmt.Sprintf("/%s", path)
 	}
 
-	path = strings.TrimSuffix(path, "/")
+	path = cleanDropboxPath(path)
 
 	return
 }
@@ -160,7 +158,7 @@ func initDbx(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		return
 	}
-	filePath := path.Join(dir, ".config", "dbxcli", configFileName)
+	filePath := filepath.Join(dir, ".config", "dbxcli", configFileName)
 	tokType := tokenType(cmd)
 	conf := oauthConfig(tokType, domain)
 


### PR DESCRIPTION
## Summary
- Extract shared helpers (`cleanDropboxPath`, `relocationDestination`, `isRemoteFolder`) into `dropbox_path.go` to unify folder-detection logic across `cp` and `mv`
- Apply consistent destination resolution: multiple sources, trailing slash, or `GetMetadata` folder check all correctly infer the target filename
- Fix `path.Join` misuse for local filesystem paths in `get.go`, `logout.go`, and `root.go` (now uses `filepath.Join`)
- Improve error messages to include quoted paths and actual API error text instead of dumping struct literals

## Test plan
- [x] `go test ./cmd/` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `dbxcli cp /file.txt /existing-folder` appends filename
- [x] Manual: `dbxcli mv /a.txt /b.txt /folder` moves both into folder
- [x] Manual: `dbxcli cp /file.txt /new-name.txt` uses exact destination when target doesn't exist