### PR TITLE
Add recursive folder download (get -r)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   * Supports search with sorting and flexible time formatting
   * Supports file revisions and file restore
   * Chunked uploads for large files, paginated listing for large directories
-  * Recursive directory uploads (`put -r`)
+  * Recursive directory uploads (`put -r`) and downloads (`get -r`)
   * Retry with exponential backoff for uploads and downloads
   * Supports a growing set of Team operations
 
@@ -80,7 +80,7 @@ Available Commands:
   completion  Generate the autocompletion script for the specified shell
   cp          Copy a file or folder to a different location
   du          Display usage information
-  get         Download a file
+  get         Download a file or folder
   logout      Log out of the current session
   ls          List files and folders
   mkdir       Create a new directory
@@ -181,6 +181,13 @@ The `--verbose` option will turn on verbose logging and is useful for debugging.
 $ dbxcli put file.txt /destination/file.txt        # upload a single file
 $ dbxcli put -r ./project /backup/project          # recursively upload a directory
 $ dbxcli put -r -w 8 ./large-folder /backup/large  # use 8 workers per large file
+```
+
+### Downloading files and directories
+
+```sh
+$ dbxcli get /remote/file.txt ./local-file.txt     # download a single file
+$ dbxcli get -r /remote/folder ./local-folder      # recursively download a folder
 ```
 
 ### Creating directories

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
@@ -30,8 +31,51 @@ import (
 )
 
 func get(cmd *cobra.Command, args []string) (err error) {
-	dbx := files.New(config)
-	return getWithClient(dbx, args)
+	if len(args) == 0 || len(args) > 2 {
+		return errors.New("`get` requires `src` and/or `dst` arguments")
+	}
+
+	src, err := validatePath(args[0])
+	if err != nil {
+		return
+	}
+
+	dst := path.Base(src)
+	if len(args) == 2 {
+		dst = args[1]
+	}
+
+	recursive, _ := cmd.Flags().GetBool("recursive")
+
+	dbx := filesNewFunc(config)
+
+	meta, err := dbx.GetMetadata(files.NewGetMetadataArg(src))
+	if err != nil {
+		if recursive {
+			return fmt.Errorf("get metadata for %s: %v", src, err)
+		}
+		// For non-recursive, fall through to download (will fail with proper error)
+		if f, statErr := os.Stat(dst); statErr == nil && f.IsDir() {
+			dst = filepath.Join(dst, path.Base(src))
+		}
+		return downloadFile(dbx, src, dst)
+	}
+
+	if _, ok := meta.(*files.FolderMetadata); ok {
+		if !recursive {
+			return fmt.Errorf("%s is a folder (use --recursive to download folders)", src)
+		}
+		if f, statErr := os.Stat(dst); statErr == nil && f.IsDir() {
+			dst = filepath.Join(dst, path.Base(src))
+		}
+		return getRecursive(dbx, src, dst)
+	}
+
+	if f, statErr := os.Stat(dst); statErr == nil && f.IsDir() {
+		dst = filepath.Join(dst, path.Base(src))
+	}
+
+	return downloadFile(dbx, src, dst)
 }
 
 func getWithClient(dbx files.Client, args []string) (err error) {
@@ -44,17 +88,92 @@ func getWithClient(dbx files.Client, args []string) (err error) {
 		return
 	}
 
-	// Default `dst` to the base segment of the source path; use the second argument if provided.
 	dst := path.Base(src)
 	if len(args) == 2 {
 		dst = args[1]
 	}
-	// If `dst` is a directory, append the source filename.
 	if f, err := os.Stat(dst); err == nil && f.IsDir() {
 		dst = filepath.Join(dst, path.Base(src))
 	}
 
 	return downloadFile(dbx, src, dst)
+}
+
+func getRecursive(dbx files.Client, src, dst string) error {
+	arg := files.NewListFolderArg(src)
+	arg.Recursive = true
+
+	res, err := dbx.ListFolder(arg)
+	if err != nil {
+		return fmt.Errorf("list folder %s: %v", src, err)
+	}
+
+	var entries []files.IsMetadata
+	entries = append(entries, res.Entries...)
+	for res.HasMore {
+		cont := files.NewListFolderContinueArg(res.Cursor)
+		res, err = dbx.ListFolderContinue(cont)
+		if err != nil {
+			return fmt.Errorf("list folder continue: %v", err)
+		}
+		entries = append(entries, res.Entries...)
+	}
+
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return err
+	}
+
+	var downloadErrors []error
+
+	for _, entry := range entries {
+		switch f := entry.(type) {
+		case *files.FolderMetadata:
+			relPath, err := relativeTo(src, f.PathDisplay)
+			if err != nil {
+				downloadErrors = append(downloadErrors, err)
+				continue
+			}
+			localDir := filepath.Join(dst, filepath.FromSlash(relPath))
+			if err := os.MkdirAll(localDir, 0755); err != nil {
+				downloadErrors = append(downloadErrors, fmt.Errorf("mkdir %s: %w", localDir, err))
+			}
+		case *files.FileMetadata:
+			relPath, err := relativeTo(src, f.PathDisplay)
+			if err != nil {
+				downloadErrors = append(downloadErrors, err)
+				continue
+			}
+			localPath := filepath.Join(dst, filepath.FromSlash(relPath))
+			if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
+				downloadErrors = append(downloadErrors, fmt.Errorf("mkdir %s: %w", filepath.Dir(localPath), err))
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "Downloading %s -> %s\n", f.PathDisplay, localPath)
+			if err := downloadFile(dbx, f.PathDisplay, localPath); err != nil {
+				downloadErrors = append(downloadErrors, fmt.Errorf("%s: %w", f.PathDisplay, err))
+			}
+		}
+	}
+
+	if len(downloadErrors) > 0 {
+		for _, e := range downloadErrors {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", e)
+		}
+		return fmt.Errorf("get: %d error(s)", len(downloadErrors))
+	}
+
+	return nil
+}
+
+func relativeTo(base, full string) (string, error) {
+	baseLower := strings.ToLower(base)
+	fullLower := strings.ToLower(full)
+	if fullLower != baseLower && !strings.HasPrefix(fullLower, baseLower+"/") {
+		return "", fmt.Errorf("path %q is not under %q", full, base)
+	}
+	rel := full[len(base):]
+	rel = strings.TrimPrefix(rel, "/")
+	return rel, nil
 }
 
 func downloadFile(dbx files.Client, src string, dst string) error {
@@ -155,10 +274,11 @@ func downloadFileOnce(dbx files.Client, arg *files.DownloadArg, dst string) erro
 // getCmd represents the get command
 var getCmd = &cobra.Command{
 	Use:   "get [flags] <source> [<target>]",
-	Short: "Download a file",
+	Short: "Download a file or folder",
 	RunE:  get,
 }
 
 func init() {
 	RootCmd.AddCommand(getCmd)
+	getCmd.Flags().BoolP("recursive", "r", false, "Recursively download a folder")
 }

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -4,12 +4,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	dbxauth "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/spf13/cobra"
 )
 
 type failingReadCloser struct {
@@ -247,5 +249,357 @@ func TestGetDownloadPermanentError(t *testing.T) {
 	err := downloadFile(mock, "/nonexistent.txt", dst)
 	if err == nil {
 		t.Error("expected error for permanent failure, got nil")
+	}
+}
+
+func TestGetRecursive_DownloadsDirectoryStructure(t *testing.T) {
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "output")
+
+	mock := &mockFilesClient{
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			if arg.Path != "/remote" {
+				t.Errorf("ListFolder path = %q, want /remote", arg.Path)
+			}
+			if !arg.Recursive {
+				t.Error("expected Recursive = true")
+			}
+			return &files.ListFolderResult{
+				Entries: []files.IsMetadata{
+					&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/remote/sub"}},
+					&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/remote/root.txt"}, Size: 4},
+					&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/remote/sub/deep.txt"}, Size: 4},
+				},
+				HasMore: false,
+			}, nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			meta := &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: arg.Path},
+				Size:     4,
+			}
+			return meta, io.NopCloser(strings.NewReader("data")), nil
+		},
+	}
+
+	err := getRecursive(mock, "/remote", dst)
+	if err != nil {
+		t.Fatalf("getRecursive error: %v", err)
+	}
+
+	for _, rel := range []string{"root.txt", "sub/deep.txt"} {
+		p := filepath.Join(dst, filepath.FromSlash(rel))
+		got, err := os.ReadFile(p)
+		if err != nil {
+			t.Errorf("failed to read %s: %v", rel, err)
+			continue
+		}
+		if string(got) != "data" {
+			t.Errorf("%s content = %q, want %q", rel, string(got), "data")
+		}
+	}
+
+	info, err := os.Stat(filepath.Join(dst, "sub"))
+	if err != nil {
+		t.Fatalf("sub directory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("sub is not a directory")
+	}
+}
+
+func TestGetRecursive_CreatesEmptyDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "output")
+
+	mock := &mockFilesClient{
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			return &files.ListFolderResult{
+				Entries: []files.IsMetadata{
+					&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/remote/empty"}},
+					&files.FolderMetadata{Metadata: files.Metadata{PathDisplay: "/remote/empty/nested"}},
+				},
+				HasMore: false,
+			}, nil
+		},
+	}
+
+	err := getRecursive(mock, "/remote", dst)
+	if err != nil {
+		t.Fatalf("getRecursive error: %v", err)
+	}
+
+	for _, dir := range []string{"empty", "empty/nested"} {
+		p := filepath.Join(dst, filepath.FromSlash(dir))
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Errorf("directory %s not created: %v", dir, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%s is not a directory", dir)
+		}
+	}
+}
+
+func TestGetRecursive_HandlesPagination(t *testing.T) {
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "output")
+
+	mock := &mockFilesClient{
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			return &files.ListFolderResult{
+				Entries: []files.IsMetadata{
+					&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/remote/a.txt"}, Size: 1},
+				},
+				HasMore: true,
+				Cursor:  "page2",
+			}, nil
+		},
+		listFolderContinueFn: func(arg *files.ListFolderContinueArg) (*files.ListFolderResult, error) {
+			if arg.Cursor != "page2" {
+				t.Errorf("cursor = %q, want page2", arg.Cursor)
+			}
+			return &files.ListFolderResult{
+				Entries: []files.IsMetadata{
+					&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/remote/b.txt"}, Size: 1},
+				},
+				HasMore: false,
+			}, nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			meta := &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: arg.Path},
+				Size:     1,
+			}
+			return meta, io.NopCloser(strings.NewReader("x")), nil
+		},
+	}
+
+	err := getRecursive(mock, "/remote", dst)
+	if err != nil {
+		t.Fatalf("getRecursive error: %v", err)
+	}
+
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if _, err := os.Stat(filepath.Join(dst, name)); err != nil {
+			t.Errorf("file %s not downloaded: %v", name, err)
+		}
+	}
+}
+
+func TestGetRecursive_ReportsDownloadErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "output")
+
+	mock := &mockFilesClient{
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			return &files.ListFolderResult{
+				Entries: []files.IsMetadata{
+					&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/remote/good.txt"}, Size: 4},
+					&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/remote/bad.txt"}, Size: 4},
+				},
+				HasMore: false,
+			}, nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			if strings.Contains(arg.Path, "bad.txt") {
+				return nil, nil, &files.DownloadAPIError{}
+			}
+			meta := &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: arg.Path},
+				Size:     4,
+			}
+			return meta, io.NopCloser(strings.NewReader("data")), nil
+		},
+	}
+
+	var err error
+	captureStderr(t, func() {
+		err = getRecursive(mock, "/remote", dst)
+	})
+	if err == nil {
+		t.Fatal("expected error for failed downloads")
+	}
+	if !strings.Contains(err.Error(), "1 error") {
+		t.Errorf("error = %q, want mention of 1 error", err.Error())
+	}
+
+	// Good file should still have been downloaded
+	if _, statErr := os.Stat(filepath.Join(dst, "good.txt")); statErr != nil {
+		t.Errorf("good.txt not downloaded: %v", statErr)
+	}
+}
+
+func TestGetFolderWithoutRecursiveFlag(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return &files.FolderMetadata{Metadata: files.Metadata{PathDisplay: arg.Path}}, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := get(getCmd, []string{"/remote-folder"})
+	if err == nil {
+		t.Fatal("expected error for folder without --recursive")
+	}
+	if !strings.Contains(err.Error(), "--recursive") {
+		t.Errorf("error = %q, want mention of --recursive", err.Error())
+	}
+}
+
+func TestGetRecursiveCommandGetsMetadataThenListsFolder(t *testing.T) {
+	tmpDir := t.TempDir()
+	var calls []string
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			calls = append(calls, "metadata:"+arg.Path)
+			return &files.FolderMetadata{Metadata: files.Metadata{PathDisplay: arg.Path}}, nil
+		},
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			calls = append(calls, "list:"+arg.Path)
+			if !arg.Recursive {
+				t.Error("expected Recursive = true")
+			}
+			return &files.ListFolderResult{HasMore: false}, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().BoolP("recursive", "r", true, "")
+
+	err := get(cmd, []string{"/remote-folder", filepath.Join(tmpDir, "out")})
+	if err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+
+	want := []string{"metadata:/remote-folder", "list:/remote-folder"}
+	if !reflect.DeepEqual(calls, want) {
+		t.Errorf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestGetFileCommandDownloadsAfterMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "file.txt")
+	var calls []string
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			calls = append(calls, "metadata:"+arg.Path)
+			return &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: arg.Path},
+				Size:     4,
+			}, nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			calls = append(calls, "download:"+arg.Path)
+			return &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: arg.Path},
+				Size:     4,
+			}, io.NopCloser(strings.NewReader("data")), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().BoolP("recursive", "r", false, "")
+
+	err := get(cmd, []string{"/remote-file.txt", dst})
+	if err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+
+	want := []string{"metadata:/remote-file.txt", "download:/remote-file.txt"}
+	if !reflect.DeepEqual(calls, want) {
+		t.Errorf("calls = %v, want %v", calls, want)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read downloaded file: %v", err)
+	}
+	if string(got) != "data" {
+		t.Errorf("downloaded file = %q, want data", got)
+	}
+}
+
+func TestGetRecursive_AppendsSourceBaseWhenDstIsDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	var listPath string
+	var downloadPath string
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return &files.FolderMetadata{Metadata: files.Metadata{PathDisplay: arg.Path}}, nil
+		},
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			listPath = arg.Path
+			return &files.ListFolderResult{
+				Entries: []files.IsMetadata{
+					&files.FileMetadata{Metadata: files.Metadata{PathDisplay: "/remote/folder/file.txt"}, Size: 4},
+				},
+				HasMore: false,
+			}, nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			downloadPath = arg.Path
+			return &files.FileMetadata{
+				Metadata: files.Metadata{PathDisplay: arg.Path},
+				Size:     4,
+			}, io.NopCloser(strings.NewReader("data")), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().BoolP("recursive", "r", true, "")
+
+	err := get(cmd, []string{"/remote/folder", tmpDir})
+	if err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+	if listPath != "/remote/folder" {
+		t.Errorf("ListFolder path = %q, want /remote/folder", listPath)
+	}
+	if downloadPath != "/remote/folder/file.txt" {
+		t.Errorf("Download path = %q, want /remote/folder/file.txt", downloadPath)
+	}
+	got, err := os.ReadFile(filepath.Join(tmpDir, "folder", "file.txt"))
+	if err != nil {
+		t.Fatalf("failed to read downloaded file: %v", err)
+	}
+	if string(got) != "data" {
+		t.Errorf("downloaded file = %q, want data", got)
+	}
+}
+
+func TestRelativeTo(t *testing.T) {
+	tests := []struct {
+		base, full, want string
+	}{
+		{"/remote", "/remote", ""},
+		{"/remote", "/remote/file.txt", "file.txt"},
+		{"/remote", "/remote/sub/deep.txt", "sub/deep.txt"},
+		{"/Remote", "/remote/file.txt", "file.txt"},
+		{"/remote", "/Remote/File.TXT", "File.TXT"},
+	}
+	for _, tt := range tests {
+		got, err := relativeTo(tt.base, tt.full)
+		if err != nil {
+			t.Errorf("relativeTo(%q, %q) error: %v", tt.base, tt.full, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("relativeTo(%q, %q) = %q, want %q", tt.base, tt.full, got, tt.want)
+		}
+	}
+}
+
+func TestRelativeToRejectsSiblingPrefix(t *testing.T) {
+	_, err := relativeTo("/remote", "/remote2/file.txt")
+	if err == nil {
+		t.Fatal("expected error for sibling path with shared prefix")
 	}
 }

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -17,6 +17,8 @@ type mockFilesClient struct {
 	copyV2Fn                func(arg *files.RelocationArg) (*files.RelocationResult, error)
 	createFolderV2Fn        func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error)
 	getMetadataFn           func(arg *files.GetMetadataArg) (files.IsMetadata, error)
+	listFolderFn            func(arg *files.ListFolderArg) (*files.ListFolderResult, error)
+	listFolderContinueFn    func(arg *files.ListFolderContinueArg) (*files.ListFolderResult, error)
 	moveV2Fn                func(arg *files.RelocationArg) (*files.RelocationResult, error)
 }
 
@@ -148,9 +150,15 @@ func (m *mockFilesClient) GetThumbnailBatch(arg *files.GetThumbnailBatchArg) (*f
 	return nil, nil
 }
 func (m *mockFilesClient) ListFolder(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+	if m.listFolderFn != nil {
+		return m.listFolderFn(arg)
+	}
 	return nil, nil
 }
 func (m *mockFilesClient) ListFolderContinue(arg *files.ListFolderContinueArg) (*files.ListFolderResult, error) {
+	if m.listFolderContinueFn != nil {
+		return m.listFolderContinueFn(arg)
+	}
 	return nil, nil
 }
 func (m *mockFilesClient) ListFolderGetLatestCursor(arg *files.ListFolderArg) (*files.ListFolderGetLatestCursorResult, error) {


### PR DESCRIPTION
## Summary
- Implement `get --recursive` / `get -r` to download entire folder trees from Dropbox
- Uses `ListFolder` with `Recursive=true` and paginates with `ListFolderContinue`
- Creates local directory structure including empty directories
- Downloads files with retry and progress output; errors are collected without aborting
- When destination is an existing directory, nests the source folder inside (like `cp -r`)

Closes #60, closes #176, closes #144

## Test plan
- [x] `go test ./cmd/` passes (8 new tests)
- [x] `golangci-lint run ./...` clean
- [x] Manual: `dbxcli get /folder /tmp/out` shows "use --recursive" error
- [x] Manual: `dbxcli get -r /folder /tmp/out` downloads full tree with correct structure
- [x] Manual: `dbxcli get -r /folder /tmp/existing-dir` nests folder inside
- [x] Manual: single file `dbxcli get /file.txt /tmp/f.txt` still works