### PR TITLE
Support DBXCLI_ACCESS_TOKEN and DBXCLI_AUTH_FILE env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ Flags:
 Use "dbxcli [command] --help" for more information about a command.
 ```
 
+### Authentication
+
+By default, `dbxcli` stores OAuth credentials in `~/.config/dbxcli/auth.json`.
+Set `DBXCLI_AUTH_FILE` to use a different credentials file:
+
+```sh
+$ DBXCLI_AUTH_FILE=/path/to/auth.json dbxcli ls /
+```
+
+For automation with short-lived Dropbox access tokens, set `DBXCLI_ACCESS_TOKEN`.
+This token is used directly and is not saved or refreshed. If it expires, the
+command fails and you must provide a fresh token:
+
+```sh
+$ DBXCLI_ACCESS_TOKEN=sl.xxxxxx dbxcli ls /
+```
+
 ### Listing files
 
 ```sh

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,74 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+const (
+	configFileName = "auth.json"
+	envAccessToken = "DBXCLI_ACCESS_TOKEN"
+	envAuthFile    = "DBXCLI_AUTH_FILE"
+)
+
+// TokenMap maps domains to a map of commands to tokens.
+// For each domain, we want to save different tokens depending on the
+// command type: personal, team access and team manage.
+type TokenMap map[string]map[string]string
+
+func authFilePath() (string, error) {
+	if filePath := os.Getenv(envAuthFile); filePath != "" {
+		return homedir.Expand(filePath)
+	}
+
+	dir, err := homedir.Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".config", "dbxcli", configFileName), nil
+}
+
+func readTokens(filePath string) (TokenMap, error) {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var tokens TokenMap
+	if err := json.Unmarshal(b, &tokens); err != nil {
+		return nil, err
+	}
+
+	return tokens, nil
+}
+
+func writeTokens(filePath string, tokens TokenMap) error {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		if err = os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
+			return err
+		}
+	}
+
+	b, err := json.Marshal(tokens)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, b, 0600)
+}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAuthFilePathUsesEnv(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "custom-auth.json")
+	t.Setenv(envAuthFile, authFile)
+
+	path, err := authFilePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != authFile {
+		t.Fatalf("expected auth file %q, got %q", authFile, path)
+	}
+}
+
+func TestReadTokensReadsTokenMap(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authFile, []byte(`{"":{"personal":"personal-token"},"api.example.com":{"teamManage":"team-token"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tokens, err := readTokens(authFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tokens[""][tokenPersonal] != "personal-token" {
+		t.Fatalf("expected personal token, got %q", tokens[""][tokenPersonal])
+	}
+	if tokens["api.example.com"][tokenTeamManage] != "team-token" {
+		t.Fatalf("expected team token, got %q", tokens["api.example.com"][tokenTeamManage])
+	}
+}
+
+func TestReadTokensReturnsUnmarshalError(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authFile, []byte(`not-json`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := readTokens(authFile); err == nil {
+		t.Fatal("expected invalid JSON to return an error")
+	}
+}
+
+func TestWriteTokensCreatesParentDirectory(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "nested", "auth.json")
+	want := TokenMap{
+		"": {
+			tokenPersonal: "personal-token",
+		},
+		"api.example.com": {
+			tokenTeamAccess: "team-access-token",
+		},
+	}
+
+	if err := writeTokens(authFile, want); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readTokens(authFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got[""][tokenPersonal] != want[""][tokenPersonal] {
+		t.Fatalf("expected personal token %q, got %q", want[""][tokenPersonal], got[""][tokenPersonal])
+	}
+	if got["api.example.com"][tokenTeamAccess] != want["api.example.com"][tokenTeamAccess] {
+		t.Fatalf("expected team access token %q, got %q", want["api.example.com"][tokenTeamAccess], got["api.example.com"][tokenTeamAccess])
+	}
+}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -16,11 +16,9 @@ package cmd
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
@@ -28,11 +26,10 @@ import (
 func logout(cmd *cobra.Command, args []string) error {
 	out := commandOutput(cmd)
 
-	dir, err := homedir.Dir()
+	filePath, err := authFilePath()
 	if err != nil {
 		return err
 	}
-	filePath := filepath.Join(dir, ".config", "dbxcli", configFileName)
 
 	tokMap, err := readTokens(filePath)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,24 +15,19 @@
 package cmd
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
-
-	"context"
 
 	"golang.org/x/oauth2"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
 const (
-	configFileName  = "auth.json"
 	tokenPersonal   = "personal"
 	tokenTeamAccess = "teamAccess"
 	tokenTeamManage = "teamManage"
@@ -54,11 +49,6 @@ var (
 	teamManageAppKey    = "xxe04eai4wmlitv"
 	teamManageAppSecret = "t8ms714yun7nu5s"
 )
-
-// TokenMap maps domains to a map of commands to tokens.
-// For each domain, we want to save different tokens depending on the
-// command type: personal, team access and team manage
-type TokenMap map[string]map[string]string
 
 var config dropbox.Config
 
@@ -105,40 +95,6 @@ func makeRelocationArg(s string, d string) (arg *files.RelocationArg, err error)
 	return
 }
 
-func readTokens(filePath string) (TokenMap, error) {
-	b, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	var tokens TokenMap
-	if json.Unmarshal(b, &tokens) != nil {
-		return nil, err
-	}
-
-	return tokens, nil
-}
-
-func writeTokens(filePath string, tokens TokenMap) {
-	// Check if file exists
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		// Doesn't exist; lets create it
-		err = os.MkdirAll(filepath.Dir(filePath), 0700)
-		if err != nil {
-			return
-		}
-	}
-
-	// At this point, file must exist. Lets (over)write it.
-	b, err := json.Marshal(tokens)
-	if err != nil {
-		return
-	}
-	if err = os.WriteFile(filePath, b, 0600); err != nil {
-		return
-	}
-}
-
 func tokenType(cmd *cobra.Command) string {
 	if cmd.Parent().Name() == "team" {
 		return tokenTeamManage
@@ -149,20 +105,46 @@ func tokenType(cmd *cobra.Command) string {
 	return tokenPersonal
 }
 
+func makeDropboxConfig(token string, verbose bool, asMember string, domain string) dropbox.Config {
+	logLevel := dropbox.LogOff
+	if verbose {
+		logLevel = dropbox.LogInfo
+	}
+
+	return dropbox.Config{
+		Token:           token,
+		LogLevel:        logLevel,
+		Logger:          nil,
+		AsMemberID:      asMember,
+		Domain:          domain,
+		Client:          nil,
+		HeaderGenerator: nil,
+		URLGenerator:    nil,
+	}
+}
+
 func initDbx(cmd *cobra.Command, args []string) (err error) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	asMember, _ := cmd.Flags().GetString("as-member")
 	domain, _ := cmd.Flags().GetString("domain")
 
-	dir, err := homedir.Dir()
-	if err != nil {
-		return
+	if accessToken := os.Getenv(envAccessToken); accessToken != "" {
+		config = makeDropboxConfig(accessToken, verbose, asMember, domain)
+		return nil
 	}
-	filePath := filepath.Join(dir, ".config", "dbxcli", configFileName)
+
+	filePath, err := authFilePath()
+	if err != nil {
+		return err
+	}
+
 	tokType := tokenType(cmd)
 	conf := oauthConfig(tokType, domain)
 
 	tokenMap, err := readTokens(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read auth file %q: %w", filePath, err)
+	}
 	if tokenMap == nil {
 		tokenMap = make(TokenMap)
 	}
@@ -188,23 +170,12 @@ func initDbx(cmd *cobra.Command, args []string) (err error) {
 			return
 		}
 		tokens[tokType] = token.AccessToken
-		writeTokens(filePath, tokenMap)
+		if err = writeTokens(filePath, tokenMap); err != nil {
+			return
+		}
 	}
 
-	logLevel := dropbox.LogOff
-	if verbose {
-		logLevel = dropbox.LogInfo
-	}
-	config = dropbox.Config{
-		Token:           tokens[tokType],
-		LogLevel:        logLevel,
-		Logger:          nil,
-		AsMemberID:      asMember,
-		Domain:          domain,
-		Client:          nil,
-		HeaderGenerator: nil,
-		URLGenerator:    nil,
-	}
+	config = makeDropboxConfig(tokens[tokType], verbose, asMember, domain)
 
 	return
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,13 @@
 package cmd
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/spf13/cobra"
+)
 
 func TestRootCmdUnknownCommandReturnsError(t *testing.T) {
 	RootCmd.SetArgs([]string{"nonexistent-command"})
@@ -15,5 +22,102 @@ func TestRootCmdInvalidFlagReturnsError(t *testing.T) {
 	err := RootCmd.Execute()
 	if err == nil {
 		t.Error("expected error for invalid flag")
+	}
+}
+
+func newAuthTestCommand() *cobra.Command {
+	root := &cobra.Command{Use: "dbxcli"}
+	cmd := &cobra.Command{Use: "ls"}
+	cmd.Flags().BoolP("verbose", "v", false, "")
+	cmd.Flags().String("as-member", "", "")
+	cmd.Flags().String("domain", "", "")
+	root.AddCommand(cmd)
+	return cmd
+}
+
+func TestInitDbxUsesAccessTokenEnv(t *testing.T) {
+	origConfig := config
+	defer func() { config = origConfig }()
+
+	t.Setenv(envAccessToken, "env-token")
+	t.Setenv(envAuthFile, filepath.Join(t.TempDir(), "missing-auth.json"))
+
+	cmd := newAuthTestCommand()
+	if err := cmd.Flags().Set("verbose", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("as-member", "dbmid:member"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("domain", "api.example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initDbx(cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if config.Token != "env-token" {
+		t.Fatalf("expected token from %s, got %q", envAccessToken, config.Token)
+	}
+	if config.AsMemberID != "dbmid:member" {
+		t.Fatalf("expected as-member to be preserved, got %q", config.AsMemberID)
+	}
+	if config.Domain != "api.example.com" {
+		t.Fatalf("expected domain to be preserved, got %q", config.Domain)
+	}
+	if config.LogLevel != dropbox.LogInfo {
+		t.Fatalf("expected verbose log level, got %v", config.LogLevel)
+	}
+}
+
+func TestInitDbxAccessTokenEnvTakesPrecedenceOverAuthFile(t *testing.T) {
+	origConfig := config
+	defer func() { config = origConfig }()
+
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authFile, []byte(`{"":{"personal":"file-token"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(envAccessToken, "env-token")
+	t.Setenv(envAuthFile, authFile)
+
+	cmd := newAuthTestCommand()
+	if err := initDbx(cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if config.Token != "env-token" {
+		t.Fatalf("expected %s to take precedence, got %q", envAccessToken, config.Token)
+	}
+}
+
+func TestInitDbxUsesAuthFileEnv(t *testing.T) {
+	origConfig := config
+	defer func() { config = origConfig }()
+
+	authFile := filepath.Join(t.TempDir(), "custom-auth.json")
+	if err := os.WriteFile(authFile, []byte(`{"api.example.com":{"personal":"file-token"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(envAccessToken, "")
+	t.Setenv(envAuthFile, authFile)
+
+	cmd := newAuthTestCommand()
+	if err := cmd.Flags().Set("domain", "api.example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initDbx(cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if config.Token != "file-token" {
+		t.Fatalf("expected token from %s, got %q", envAuthFile, config.Token)
+	}
+	if config.Domain != "api.example.com" {
+		t.Fatalf("expected domain from flag, got %q", config.Domain)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `DBXCLI_ACCESS_TOKEN` env var to skip file-based auth entirely (useful for CI/Docker)
- Add `DBXCLI_AUTH_FILE` env var to override the default `~/.config/dbxcli/auth.json` location
- Extract auth helpers into `auth.go` for cleaner separation
- `writeTokens` now returns errors instead of silently swallowing them

Closes #117, closes #151

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `DBXCLI_ACCESS_TOKEN=<token> dbxcli ls /` uses env token
- [x] Manual: `DBXCLI_AUTH_FILE=/tmp/auth.json dbxcli ls /` reads from custom file
- [x] Manual: without env vars, falls back to default auth.json