### PR TITLE
Add login command with OAuth flow and app credential prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ Now we need to pause for a second to get development keys.
 
 5. Head to `https://www.dropbox.com/developers/apps` (sign in if necessary) and choose "Create app". Use the Dropbox API and give it Full Dropbox access. Name and create the app.
 6. You'll be presented with a dashboard with an "App key" and an "App secret".
-7. Replace the value for `personalAppKey` in  `root.go` with the key from the webpage.
-8. Replace the value for `personalAppSecret` with the secret from the webpage.
+7. Provide the app key and secret when running `dbxcli`:
+```sh
+$ export DROPBOX_PERSONAL_APP_KEY=your-app-key
+$ export DROPBOX_PERSONAL_APP_SECRET=your-app-secret
+```
 
 Finally we're ready to build. Run `go build`, and you'll see a `dbxcli` binary has been created in the current directory. Congrats, we're done!
 
@@ -81,6 +84,7 @@ Available Commands:
   cp          Copy a file or folder to a different location
   du          Display usage information
   get         Download a file or folder
+  login       Log in and save Dropbox credentials
   logout      Log out of the current session
   ls          List files and folders
   mkdir       Create a new directory
@@ -104,10 +108,34 @@ Use "dbxcli [command] --help" for more information about a command.
 ### Authentication
 
 By default, `dbxcli` stores OAuth credentials in `~/.config/dbxcli/auth.json`.
+Run `dbxcli login` to authorize dbxcli and save credentials:
+
+```sh
+$ dbxcli login
+```
+
+Commands require saved credentials. If no saved credentials are available, run
+`dbxcli login` first or provide a token with `DBXCLI_ACCESS_TOKEN`.
+
+If the bundled app credentials are still in use, `dbxcli` asks for your Dropbox
+app key and app secret before printing the authorization URL. You can pass the
+app key as an option and enter the app secret at the masked prompt:
+
+```sh
+$ dbxcli login --app-key=your-app-key
+```
+
+You can also set both with environment variables to skip the prompts:
+
+```sh
+$ DROPBOX_PERSONAL_APP_KEY=your-app-key DROPBOX_PERSONAL_APP_SECRET=your-app-secret dbxcli login
+```
+
+If saved credentials expire or need to be replaced, run `dbxcli login` again.
 Set `DBXCLI_AUTH_FILE` to use a different credentials file:
 
 ```sh
-$ DBXCLI_AUTH_FILE=/path/to/auth.json dbxcli ls /
+$ DBXCLI_AUTH_FILE=/path/to/auth.json dbxcli login
 ```
 
 For automation with short-lived Dropbox access tokens, set `DBXCLI_ACCESS_TOKEN`.

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -15,11 +15,18 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/mitchellh/go-homedir"
+	"golang.org/x/oauth2"
+	"golang.org/x/term"
 )
 
 const (
@@ -32,6 +39,72 @@ const (
 // For each domain, we want to save different tokens depending on the
 // command type: personal, team access and team manage.
 type TokenMap map[string]map[string]string
+
+type appCredentials struct {
+	Key    string
+	Secret string
+}
+
+var readAppKey = func(prompt string) (string, error) {
+	fmt.Print(prompt)
+	var value string
+	if _, err := fmt.Scan(&value); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+var readAppSecret = func(prompt string) (string, error) {
+	fmt.Print(prompt)
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		value, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Println()
+		if err != nil {
+			return "", err
+		}
+		return string(value), nil
+	}
+
+	var value string
+	if _, err := fmt.Scan(&value); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+var readAppCredentials = func(tokType string) (appCredentials, error) {
+	fmt.Printf("Enter Dropbox %s app credentials.\n", appCredentialsName(tokType))
+	appKey, err := readAppKey("Dropbox app key: ")
+	if err != nil {
+		return appCredentials{}, err
+	}
+	appSecret, err := readAppSecret("Dropbox app secret: ")
+	if err != nil {
+		return appCredentials{}, err
+	}
+	return appCredentials{Key: appKey, Secret: appSecret}, nil
+}
+
+var readAuthorizationCode = func() (string, error) {
+	var code string
+	if _, err := fmt.Scan(&code); err != nil {
+		return "", err
+	}
+	return code, nil
+}
+
+var exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+	return conf.Exchange(ctx, code)
+}
+
+func oauthConfig(tokenType string, domain string) *oauth2.Config {
+	appKey, appSecret := oauthCredentials(tokenType)
+	return &oauth2.Config{
+		ClientID:     appKey,
+		ClientSecret: appSecret,
+		Endpoint:     dropbox.OAuthEndpoint(domain),
+	}
+}
 
 func authFilePath() (string, error) {
 	if filePath := os.Getenv(envAuthFile); filePath != "" {
@@ -71,4 +144,109 @@ func writeTokens(filePath string, tokens TokenMap) error {
 		return err
 	}
 	return os.WriteFile(filePath, b, 0600)
+}
+
+func getAccessToken(tokType string, domain string, force bool) (string, string, error) {
+	filePath, err := authFilePath()
+	if err != nil {
+		return "", "", err
+	}
+
+	tokenMap, err := readTokens(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return "", "", fmt.Errorf("read auth file %q: %w", filePath, err)
+	}
+	if tokenMap == nil {
+		tokenMap = make(TokenMap)
+	}
+	if tokenMap[domain] == nil {
+		tokenMap[domain] = make(map[string]string)
+	}
+	tokens := tokenMap[domain]
+
+	if force || tokens[tokType] == "" {
+		if !force && needsOAuthCredentialsOverride(tokType) {
+			return "", "", missingAccessTokenError(tokType)
+		}
+		accessToken, err := requestAccessToken(tokType, domain)
+		if err != nil {
+			return "", "", err
+		}
+		tokens[tokType] = accessToken
+		if err = writeTokens(filePath, tokenMap); err != nil {
+			return "", "", err
+		}
+	}
+
+	return tokens[tokType], filePath, nil
+}
+
+func loginCommand(tokType string) string {
+	switch tokType {
+	case tokenTeamAccess:
+		return "dbxcli login team-access --app-key=<your-app-key>"
+	case tokenTeamManage:
+		return "dbxcli login team-manage --app-key=<your-app-key>"
+	default:
+		return "dbxcli login --app-key=<your-app-key>"
+	}
+}
+
+func missingAccessTokenError(tokType string) error {
+	return fmt.Errorf("no saved Dropbox credentials; run %q first or set %s", loginCommand(tokType), envAccessToken)
+}
+
+func appCredentialsName(tokType string) string {
+	switch tokType {
+	case tokenTeamAccess:
+		return "team access"
+	case tokenTeamManage:
+		return "team manage"
+	default:
+		return "personal"
+	}
+}
+
+func ensureOAuthAppCredentials(tokType string) error {
+	if !needsOAuthCredentialsOverride(tokType) {
+		return nil
+	}
+
+	creds, err := readAppCredentials(tokType)
+	if err != nil {
+		return err
+	}
+	creds.Key = strings.TrimSpace(creds.Key)
+	creds.Secret = strings.TrimSpace(creds.Secret)
+	if creds.Key == "" || creds.Secret == "" {
+		return errors.New("Dropbox app key and secret are required")
+	}
+
+	setOAuthCredentials(tokType, creds.Key, creds.Secret)
+	return nil
+}
+
+func requestAccessToken(tokType string, domain string) (string, error) {
+	if err := ensureOAuthAppCredentials(tokType); err != nil {
+		return "", err
+	}
+
+	conf := oauthConfig(tokType, domain)
+	fmt.Printf("1. Go to %v\n", conf.AuthCodeURL("state"))
+	fmt.Printf("2. Click \"Allow\" (you might have to log in first).\n")
+	fmt.Printf("3. Copy the authorization code.\n")
+	fmt.Printf("Enter the authorization code here: ")
+
+	code, err := readAuthorizationCode()
+	if err != nil {
+		return "", err
+	}
+	token, err := exchangeAuthorizationCode(context.Background(), conf, code)
+	if err != nil {
+		return "", err
+	}
+	if token == nil || token.AccessToken == "" {
+		return "", errors.New("authorization did not return an access token")
+	}
+	return token.AccessToken, nil
 }

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"golang.org/x/oauth2"
 )
 
 func TestAuthFilePathUsesEnv(t *testing.T) {
@@ -74,5 +79,371 @@ func TestWriteTokensCreatesParentDirectory(t *testing.T) {
 	}
 	if got["api.example.com"][tokenTeamAccess] != want["api.example.com"][tokenTeamAccess] {
 		t.Fatalf("expected team access token %q, got %q", want["api.example.com"][tokenTeamAccess], got["api.example.com"][tokenTeamAccess])
+	}
+}
+
+func restoreOAuthCredentials(t *testing.T) {
+	t.Helper()
+
+	origPersonalAppKey := personalAppKey
+	origPersonalAppSecret := personalAppSecret
+	origTeamAccessAppKey := teamAccessAppKey
+	origTeamAccessAppSecret := teamAccessAppSecret
+	origTeamManageAppKey := teamManageAppKey
+	origTeamManageAppSecret := teamManageAppSecret
+	origReadAppKey := readAppKey
+	origReadAppSecret := readAppSecret
+	origReadAppCredentials := readAppCredentials
+	t.Cleanup(func() {
+		personalAppKey = origPersonalAppKey
+		personalAppSecret = origPersonalAppSecret
+		teamAccessAppKey = origTeamAccessAppKey
+		teamAccessAppSecret = origTeamAccessAppSecret
+		teamManageAppKey = origTeamManageAppKey
+		teamManageAppSecret = origTeamManageAppSecret
+		readAppKey = origReadAppKey
+		readAppSecret = origReadAppSecret
+		readAppCredentials = origReadAppCredentials
+	})
+}
+
+func mockOAuthAppCredentials(t *testing.T) {
+	t.Helper()
+
+	restoreOAuthCredentials(t)
+	setOAuthCredentials(tokenPersonal, "personal-test-key", "personal-test-secret")
+	setOAuthCredentials(tokenTeamAccess, "team-access-test-key", "team-access-test-secret")
+	setOAuthCredentials(tokenTeamManage, "team-manage-test-key", "team-manage-test-secret")
+	readAppCredentials = func(tokType string) (appCredentials, error) {
+		t.Fatal("app credential prompt should not be used")
+		return appCredentials{}, nil
+	}
+}
+
+func mockAuthorization(t *testing.T, code string, accessToken string) {
+	t.Helper()
+
+	mockOAuthAppCredentials(t)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAuthorizationCode = func() (string, error) {
+		return code, nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, gotCode string) (*oauth2.Token, error) {
+		if gotCode != code {
+			t.Fatalf("expected authorization code %q, got %q", code, gotCode)
+		}
+		return &oauth2.Token{AccessToken: accessToken}, nil
+	}
+}
+
+func TestGetAccessTokenUsesExistingToken(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authFile, []byte(`{"":{"personal":"existing-token"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envAuthFile, authFile)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+	readAuthorizationCode = func() (string, error) {
+		t.Fatal("authorization prompt should not be used for existing token")
+		return "", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+		t.Fatal("authorization exchange should not be used for existing token")
+		return nil, nil
+	}
+
+	token, filePath, err := getAccessToken(tokenPersonal, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "existing-token" {
+		t.Fatalf("expected existing token, got %q", token)
+	}
+	if filePath != authFile {
+		t.Fatalf("expected auth file %q, got %q", authFile, filePath)
+	}
+}
+
+func TestGetAccessTokenForceRefreshesToken(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authFile, []byte(`{"":{"personal":"old-token"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envAuthFile, authFile)
+	mockAuthorization(t, "auth-code", "new-token")
+
+	token, filePath, err := getAccessToken(tokenPersonal, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "new-token" {
+		t.Fatalf("expected new token, got %q", token)
+	}
+	if filePath != authFile {
+		t.Fatalf("expected auth file %q, got %q", authFile, filePath)
+	}
+
+	tokens, err := readTokens(authFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokens[""][tokenPersonal] != "new-token" {
+		t.Fatalf("expected saved token to be refreshed, got %q", tokens[""][tokenPersonal])
+	}
+}
+
+func TestGetAccessTokenMissingTokenWithBundledCredentialsReturnsLoginError(t *testing.T) {
+	restoreOAuthCredentials(t)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, defaultPersonalAppSecret)
+
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	t.Setenv(envAuthFile, authFile)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAppCredentials = func(tokType string) (appCredentials, error) {
+		t.Fatal("app credential prompt should not run for command lazy auth")
+		return appCredentials{}, nil
+	}
+	readAuthorizationCode = func() (string, error) {
+		t.Fatal("authorization prompt should not run when app credentials are missing")
+		return "", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+		t.Fatal("authorization exchange should not run when app credentials are missing")
+		return nil, nil
+	}
+
+	_, _, err := getAccessToken(tokenPersonal, "", false)
+	if err == nil {
+		t.Fatal("expected missing credentials error")
+	}
+	if !strings.Contains(err.Error(), "dbxcli login --app-key=<your-app-key>") {
+		t.Fatalf("expected login hint, got %q", err)
+	}
+	if !strings.Contains(err.Error(), envAccessToken) {
+		t.Fatalf("expected %s hint, got %q", envAccessToken, err)
+	}
+}
+
+func TestLoginCommandForTokenType(t *testing.T) {
+	tests := []struct {
+		tokType string
+		want    string
+	}{
+		{tokenPersonal, "dbxcli login --app-key=<your-app-key>"},
+		{tokenTeamAccess, "dbxcli login team-access --app-key=<your-app-key>"},
+		{tokenTeamManage, "dbxcli login team-manage --app-key=<your-app-key>"},
+	}
+
+	for _, tt := range tests {
+		if got := loginCommand(tt.tokType); got != tt.want {
+			t.Fatalf("loginCommand(%q) = %q, want %q", tt.tokType, got, tt.want)
+		}
+	}
+}
+
+func TestRequestAccessTokenRejectsEmptyToken(t *testing.T) {
+	mockOAuthAppCredentials(t)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAuthorizationCode = func() (string, error) {
+		return "auth-code", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+		return &oauth2.Token{}, nil
+	}
+
+	if _, err := requestAccessToken(tokenPersonal, ""); err == nil {
+		t.Fatal("expected empty access token to return an error")
+	}
+}
+
+func TestRequestAccessTokenReturnsReadError(t *testing.T) {
+	mockOAuthAppCredentials(t)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAuthorizationCode = func() (string, error) {
+		return "", errors.New("read failed")
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+		t.Fatal("authorization exchange should not run when reading code fails")
+		return nil, nil
+	}
+
+	if _, err := requestAccessToken(tokenPersonal, ""); err == nil {
+		t.Fatal("expected authorization code read error")
+	}
+}
+
+func TestRequestAccessTokenPromptsForAppCredentialsWhenUsingBundledDefaults(t *testing.T) {
+	restoreOAuthCredentials(t)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, defaultPersonalAppSecret)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAppCredentials = func(tokType string) (appCredentials, error) {
+		if tokType != tokenPersonal {
+			t.Fatalf("expected personal app credentials prompt, got %q", tokType)
+		}
+		return appCredentials{Key: "prompt-key", Secret: "prompt-secret"}, nil
+	}
+	readAuthorizationCode = func() (string, error) {
+		return "auth-code", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+		if conf.ClientID != "prompt-key" {
+			t.Fatalf("expected prompted app key, got %q", conf.ClientID)
+		}
+		if conf.ClientSecret != "prompt-secret" {
+			t.Fatalf("expected prompted app secret, got %q", conf.ClientSecret)
+		}
+		return &oauth2.Token{AccessToken: "access-token"}, nil
+	}
+
+	token, err := requestAccessToken(tokenPersonal, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "access-token" {
+		t.Fatalf("expected access token, got %q", token)
+	}
+	if personalAppKey != "prompt-key" {
+		t.Fatalf("expected prompted app key to be saved for this process, got %q", personalAppKey)
+	}
+}
+
+func TestReadAppCredentialsReadsVisibleKeyAndMaskedSecret(t *testing.T) {
+	restoreOAuthCredentials(t)
+
+	var keyPrompts []string
+	readAppKey = func(prompt string) (string, error) {
+		keyPrompts = append(keyPrompts, prompt)
+		return "visible-key", nil
+	}
+
+	var secretPrompts []string
+	readAppSecret = func(prompt string) (string, error) {
+		secretPrompts = append(secretPrompts, prompt)
+		return "masked-secret", nil
+	}
+
+	creds, err := readAppCredentials(tokenPersonal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if creds.Key != "visible-key" {
+		t.Fatalf("expected app key, got %q", creds.Key)
+	}
+	if creds.Secret != "masked-secret" {
+		t.Fatalf("expected app secret, got %q", creds.Secret)
+	}
+	if len(keyPrompts) != 1 {
+		t.Fatalf("expected one app key prompt, got %d", len(keyPrompts))
+	}
+	if keyPrompts[0] != "Dropbox app key: " {
+		t.Fatalf("unexpected app key prompt %q", keyPrompts[0])
+	}
+	if len(secretPrompts) != 1 {
+		t.Fatalf("expected one app secret prompt, got %d", len(secretPrompts))
+	}
+	if secretPrompts[0] != "Dropbox app secret: " {
+		t.Fatalf("unexpected app secret prompt %q", secretPrompts[0])
+	}
+}
+
+func TestRequestAccessTokenUsesConfiguredAppCredentials(t *testing.T) {
+	restoreOAuthCredentials(t)
+	setOAuthCredentials(tokenPersonal, "configured-key", "configured-secret")
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAppCredentials = func(tokType string) (appCredentials, error) {
+		t.Fatal("app credential prompt should not be used")
+		return appCredentials{}, nil
+	}
+	readAuthorizationCode = func() (string, error) {
+		return "auth-code", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+		if conf.ClientID != "configured-key" {
+			t.Fatalf("expected configured app key, got %q", conf.ClientID)
+		}
+		if conf.ClientSecret != "configured-secret" {
+			t.Fatalf("expected configured app secret, got %q", conf.ClientSecret)
+		}
+		return &oauth2.Token{AccessToken: "access-token"}, nil
+	}
+
+	if _, err := requestAccessToken(tokenPersonal, ""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestAccessTokenRejectsEmptyAppCredentials(t *testing.T) {
+	restoreOAuthCredentials(t)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, defaultPersonalAppSecret)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAppCredentials = func(tokType string) (appCredentials, error) {
+		return appCredentials{Key: " ", Secret: "secret"}, nil
+	}
+	readAuthorizationCode = func() (string, error) {
+		t.Fatal("authorization code prompt should not run when app credentials are invalid")
+		return "", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+		t.Fatal("authorization exchange should not run when app credentials are invalid")
+		return nil, nil
+	}
+
+	if _, err := requestAccessToken(tokenPersonal, ""); err == nil {
+		t.Fatal("expected empty app credentials to fail")
 	}
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,0 +1,108 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func loginTokenType(name string) (string, error) {
+	switch name {
+	case "", tokenPersonal:
+		return tokenPersonal, nil
+	case tokenTeamAccess, "team-access", "team_access":
+		return tokenTeamAccess, nil
+	case tokenTeamManage, "team-manage", "team_manage":
+		return tokenTeamManage, nil
+	default:
+		return "", fmt.Errorf("unknown login token type %q; expected personal, team-access, or team-manage", name)
+	}
+}
+
+func defaultOAuthCredential(value string, defaultValue string) bool {
+	return defaultValue != "" && value == defaultValue
+}
+
+func loginAppKeyFromFlag(cmd *cobra.Command, tokType string) error {
+	appKey, _ := cmd.Flags().GetString("app-key")
+	appKey = strings.TrimSpace(appKey)
+	if appKey == "" {
+		return nil
+	}
+
+	_, currentAppSecret := oauthCredentials(tokType)
+	_, defaultAppSecret := defaultOAuthCredentials(tokType)
+	if currentAppSecret == "" || defaultOAuthCredential(currentAppSecret, defaultAppSecret) {
+		fmt.Printf("Enter Dropbox %s app secret.\n", appCredentialsName(tokType))
+		appSecret, err := readAppSecret("Dropbox app secret: ")
+		if err != nil {
+			return err
+		}
+		currentAppSecret = strings.TrimSpace(appSecret)
+		if currentAppSecret == "" {
+			return errors.New("Dropbox app secret is required")
+		}
+	}
+
+	setOAuthCredentials(tokType, appKey, currentAppSecret)
+	return nil
+}
+
+func login(cmd *cobra.Command, args []string) error {
+	domain, _ := cmd.Flags().GetString("domain")
+
+	tokenName := ""
+	if len(args) > 0 {
+		tokenName = args[0]
+	}
+	tokType, err := loginTokenType(tokenName)
+	if err != nil {
+		return err
+	}
+	if err := loginAppKeyFromFlag(cmd, tokType); err != nil {
+		return err
+	}
+
+	_, filePath, err := getAccessToken(tokType, domain, true)
+	if err != nil {
+		return err
+	}
+
+	commandOutput(cmd).Info("Credentials saved to %s", filePath)
+	return nil
+}
+
+var loginCmd = &cobra.Command{
+	Use:   "login [personal|team-access|team-manage]",
+	Short: "Log in and save Dropbox credentials",
+	Long: `Log in and save Dropbox credentials.
+
+By default, login stores credentials for regular Dropbox user commands.
+Use "team-access" for --as-member commands or "team-manage" for team commands.`,
+	Args: cobra.MaximumNArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	RunE: login,
+}
+
+func init() {
+	loginCmd.Flags().String("app-key", "", "Dropbox app key to use for this login")
+	RootCmd.AddCommand(loginCmd)
+}

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -1,0 +1,234 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/oauth2"
+
+	"github.com/spf13/cobra"
+)
+
+func newLoginTestCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "login"}
+	cmd.Flags().String("domain", "", "")
+	cmd.Flags().String("app-key", "", "")
+	return cmd
+}
+
+func TestLoginTokenType(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"", tokenPersonal},
+		{"personal", tokenPersonal},
+		{"team-access", tokenTeamAccess},
+		{"team_access", tokenTeamAccess},
+		{"teamAccess", tokenTeamAccess},
+		{"team-manage", tokenTeamManage},
+		{"team_manage", tokenTeamManage},
+		{"teamManage", tokenTeamManage},
+	}
+
+	for _, tt := range tests {
+		got, err := loginTokenType(tt.name)
+		if err != nil {
+			t.Fatalf("loginTokenType(%q): %v", tt.name, err)
+		}
+		if got != tt.want {
+			t.Fatalf("loginTokenType(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestLoginTokenTypeRejectsUnknown(t *testing.T) {
+	if _, err := loginTokenType("unknown"); err == nil {
+		t.Fatal("expected unknown token type to fail")
+	}
+}
+
+func TestLoginWritesCredentials(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	t.Setenv(envAuthFile, authFile)
+	mockAuthorization(t, "auth-code", "login-token")
+
+	cmd := newLoginTestCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := login(cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	tokens, err := readTokens(authFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokens[""][tokenPersonal] != "login-token" {
+		t.Fatalf("expected login token to be saved, got %q", tokens[""][tokenPersonal])
+	}
+	if out.String() != "Credentials saved to "+authFile+"\n" {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestLoginWritesSelectedTokenType(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	t.Setenv(envAuthFile, authFile)
+	mockAuthorization(t, "auth-code", "team-token")
+
+	cmd := newLoginTestCommand()
+
+	if err := login(cmd, []string{"team-manage"}); err != nil {
+		t.Fatal(err)
+	}
+
+	tokens, err := readTokens(authFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokens[""][tokenTeamManage] != "team-token" {
+		t.Fatalf("expected team manage token to be saved, got %q", tokens[""][tokenTeamManage])
+	}
+}
+
+func TestLoginUsesAppKeyFlagWithConfiguredSecret(t *testing.T) {
+	restoreOAuthCredentials(t)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, "configured-secret")
+
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	t.Setenv(envAuthFile, authFile)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAppCredentials = func(tokType string) (appCredentials, error) {
+		t.Fatal("app credential prompt should not be used when app key flag and configured secret are set")
+		return appCredentials{}, nil
+	}
+	readAppSecret = func(prompt string) (string, error) {
+		t.Fatal("app secret prompt should not be used when secret is already configured")
+		return "", nil
+	}
+	readAuthorizationCode = func() (string, error) {
+		return "auth-code", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+		if conf.ClientID != "flag-key" {
+			t.Fatalf("expected flag app key, got %q", conf.ClientID)
+		}
+		if conf.ClientSecret != "configured-secret" {
+			t.Fatalf("expected configured app secret, got %q", conf.ClientSecret)
+		}
+		return &oauth2.Token{AccessToken: "flag-token"}, nil
+	}
+
+	cmd := newLoginTestCommand()
+	if err := cmd.Flags().Set("app-key", "flag-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := login(cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	tokens, err := readTokens(authFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokens[""][tokenPersonal] != "flag-token" {
+		t.Fatalf("expected login token to be saved, got %q", tokens[""][tokenPersonal])
+	}
+}
+
+func TestLoginAppKeyFlagPromptsForBundledSecret(t *testing.T) {
+	restoreOAuthCredentials(t)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, defaultPersonalAppSecret)
+
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	t.Setenv(envAuthFile, authFile)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAppCredentials = func(tokType string) (appCredentials, error) {
+		t.Fatal("full app credential prompt should not be used when app key flag is set")
+		return appCredentials{}, nil
+	}
+	readAppSecret = func(prompt string) (string, error) {
+		return "prompt-secret", nil
+	}
+	readAuthorizationCode = func() (string, error) {
+		return "auth-code", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+		if conf.ClientID != "flag-key" {
+			t.Fatalf("expected flag app key, got %q", conf.ClientID)
+		}
+		if conf.ClientSecret != "prompt-secret" {
+			t.Fatalf("expected prompted app secret, got %q", conf.ClientSecret)
+		}
+		return &oauth2.Token{AccessToken: "flag-token"}, nil
+	}
+
+	cmd := newLoginTestCommand()
+	if err := cmd.Flags().Set("app-key", "flag-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := login(cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoginAppKeyFlagRejectsEmptyPromptedSecret(t *testing.T) {
+	restoreOAuthCredentials(t)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, defaultPersonalAppSecret)
+
+	cmd := newLoginTestCommand()
+	if err := cmd.Flags().Set("app-key", "flag-key"); err != nil {
+		t.Fatal(err)
+	}
+	readAppSecret = func(prompt string) (string, error) {
+		return " ", nil
+	}
+
+	if err := loginAppKeyFromFlag(cmd, tokenPersonal); err == nil {
+		t.Fatal("expected empty prompted app secret to fail")
+	}
+}
+
+func TestLoginAndLogoutSkipRootAuthPreRun(t *testing.T) {
+	if loginCmd.PersistentPreRunE == nil {
+		t.Fatal("login command should override root auth pre-run")
+	}
+	if logoutCmd.PersistentPreRunE == nil {
+		t.Fatal("logout command should override root auth pre-run")
+	}
+	if err := loginCmd.PersistentPreRunE(loginCmd, nil); err != nil {
+		t.Fatalf("login pre-run returned error: %v", err)
+	}
+	if err := logoutCmd.PersistentPreRunE(logoutCmd, nil); err != nil {
+		t.Fatalf("logout pre-run returned error: %v", err)
+	}
+}
+
+func TestLoginCommandDefinesAppCredentialFlags(t *testing.T) {
+	if loginCmd.Flags().Lookup("app-key") == nil {
+		t.Fatal("login command should define --app-key")
+	}
+	if loginCmd.Flags().Lookup("app-secret") != nil {
+		t.Fatal("login command should not define --app-secret yet")
+	}
+}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -62,7 +62,10 @@ func logout(cmd *cobra.Command, args []string) error {
 var logoutCmd = &cobra.Command{
 	Use:   "logout [flags]",
 	Short: "Log out of the current session",
-	RunE:  logout,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	RunE: logout,
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,12 +15,9 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/oauth2"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
@@ -31,6 +28,13 @@ const (
 	tokenPersonal   = "personal"
 	tokenTeamAccess = "teamAccess"
 	tokenTeamManage = "teamManage"
+
+	defaultPersonalAppKey      = "mvhz183vwqibe7q"
+	defaultPersonalAppSecret   = "q0kquhzgetjwcz1"
+	defaultTeamAccessAppKey    = "zud1va492pnehkc"
+	defaultTeamAccessAppSecret = "p3ginm1gy0kmj54"
+	defaultTeamManageAppKey    = "xxe04eai4wmlitv"
+	defaultTeamManageAppSecret = "t8ms714yun7nu5s"
 )
 
 func getEnv(key, fallback string) string {
@@ -42,31 +46,61 @@ func getEnv(key, fallback string) string {
 }
 
 var (
-	personalAppKey      = "mvhz183vwqibe7q"
-	personalAppSecret   = "q0kquhzgetjwcz1"
-	teamAccessAppKey    = "zud1va492pnehkc"
-	teamAccessAppSecret = "p3ginm1gy0kmj54"
-	teamManageAppKey    = "xxe04eai4wmlitv"
-	teamManageAppSecret = "t8ms714yun7nu5s"
+	personalAppKey      = defaultPersonalAppKey
+	personalAppSecret   = defaultPersonalAppSecret
+	teamAccessAppKey    = defaultTeamAccessAppKey
+	teamAccessAppSecret = defaultTeamAccessAppSecret
+	teamManageAppKey    = defaultTeamManageAppKey
+	teamManageAppSecret = defaultTeamManageAppSecret
 )
 
 var config dropbox.Config
 
-func oauthConfig(tokenType string, domain string) *oauth2.Config {
-	var appKey, appSecret string
+func oauthCredentials(tokenType string) (string, string) {
 	switch tokenType {
-	case "personal":
-		appKey, appSecret = personalAppKey, personalAppSecret
-	case "teamAccess":
-		appKey, appSecret = teamAccessAppKey, teamAccessAppSecret
-	case "teamManage":
-		appKey, appSecret = teamManageAppKey, teamManageAppSecret
+	case tokenPersonal:
+		return personalAppKey, personalAppSecret
+	case tokenTeamAccess:
+		return teamAccessAppKey, teamAccessAppSecret
+	case tokenTeamManage:
+		return teamManageAppKey, teamManageAppSecret
+	default:
+		return "", ""
 	}
-	return &oauth2.Config{
-		ClientID:     appKey,
-		ClientSecret: appSecret,
-		Endpoint:     dropbox.OAuthEndpoint(domain),
+}
+
+func defaultOAuthCredentials(tokenType string) (string, string) {
+	switch tokenType {
+	case tokenPersonal:
+		return defaultPersonalAppKey, defaultPersonalAppSecret
+	case tokenTeamAccess:
+		return defaultTeamAccessAppKey, defaultTeamAccessAppSecret
+	case tokenTeamManage:
+		return defaultTeamManageAppKey, defaultTeamManageAppSecret
+	default:
+		return "", ""
 	}
+}
+
+func setOAuthCredentials(tokenType string, appKey string, appSecret string) {
+	switch tokenType {
+	case tokenPersonal:
+		personalAppKey, personalAppSecret = appKey, appSecret
+	case tokenTeamAccess:
+		teamAccessAppKey, teamAccessAppSecret = appKey, appSecret
+	case tokenTeamManage:
+		teamManageAppKey, teamManageAppSecret = appKey, appSecret
+	}
+}
+
+func needsOAuthCredentialsOverride(tokenType string) bool {
+	appKey, appSecret := oauthCredentials(tokenType)
+	defaultAppKey, defaultAppSecret := defaultOAuthCredentials(tokenType)
+	if appKey == "" || appSecret == "" {
+		return true
+	}
+	return defaultAppKey != "" && defaultAppSecret != "" &&
+		appKey == defaultAppKey && appSecret == defaultAppSecret
 }
 
 func validatePath(p string) (path string, err error) {
@@ -133,49 +167,13 @@ func initDbx(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	}
 
-	filePath, err := authFilePath()
+	tokType := tokenType(cmd)
+	accessToken, _, err := getAccessToken(tokType, domain, false)
 	if err != nil {
 		return err
 	}
 
-	tokType := tokenType(cmd)
-	conf := oauthConfig(tokType, domain)
-
-	tokenMap, err := readTokens(filePath)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("read auth file %q: %w", filePath, err)
-	}
-	if tokenMap == nil {
-		tokenMap = make(TokenMap)
-	}
-	if tokenMap[domain] == nil {
-		tokenMap[domain] = make(map[string]string)
-	}
-	tokens := tokenMap[domain]
-
-	if err != nil || tokens[tokType] == "" {
-		fmt.Printf("1. Go to %v\n", conf.AuthCodeURL("state"))
-		fmt.Printf("2. Click \"Allow\" (you might have to log in first).\n")
-		fmt.Printf("3. Copy the authorization code.\n")
-		fmt.Printf("Enter the authorization code here: ")
-
-		var code string
-		if _, err = fmt.Scan(&code); err != nil {
-			return
-		}
-		var token *oauth2.Token
-		ctx := context.Background()
-		token, err = conf.Exchange(ctx, code)
-		if err != nil {
-			return
-		}
-		tokens[tokType] = token.AccessToken
-		if err = writeTokens(filePath, tokenMap); err != nil {
-			return
-		}
-	}
-
-	config = makeDropboxConfig(tokens[tokType], verbose, asMember, domain)
+	config = makeDropboxConfig(accessToken, verbose, asMember, domain)
 
 	return
 }
@@ -198,6 +196,15 @@ func Execute() {
 	}
 }
 
+func loadOAuthCredentialsFromEnv() {
+	personalAppKey = getEnv("DROPBOX_PERSONAL_APP_KEY", personalAppKey)
+	personalAppSecret = getEnv("DROPBOX_PERSONAL_APP_SECRET", personalAppSecret)
+	teamAccessAppKey = getEnv("DROPBOX_TEAM_APP_KEY", teamAccessAppKey)
+	teamAccessAppSecret = getEnv("DROPBOX_TEAM_APP_SECRET", teamAccessAppSecret)
+	teamManageAppKey = getEnv("DROPBOX_MANAGE_APP_KEY", teamManageAppKey)
+	teamManageAppSecret = getEnv("DROPBOX_MANAGE_APP_SECRET", teamManageAppSecret)
+}
+
 func init() {
 	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose logging")
 	RootCmd.PersistentFlags().String("as-member", "", "Member ID to perform action as")
@@ -205,10 +212,5 @@ func init() {
 	RootCmd.PersistentFlags().String("domain", "", "Override default Dropbox domain, useful for testing")
 	_ = RootCmd.PersistentFlags().MarkHidden("domain")
 
-	personalAppKey = getEnv("DROPBOX_PERSONAL_APP_KEY", personalAppKey)
-	personalAppSecret = getEnv("DROPBOX_PERSONAL_APP_SECRET", personalAppSecret)
-	teamAccessAppKey = getEnv("DROPBOX_TEAM_APP_KEY", teamAccessAppKey)
-	teamAccessAppSecret = getEnv("DROPBOX_TEAM_APP_SECRET", teamAccessAppSecret)
-	teamManageAppKey = getEnv("DROPBOX_MANAGE_APP_KEY", teamManageAppKey)
-	teamManageAppSecret = getEnv("DROPBOX_MANAGE_APP_SECRET", teamAccessAppSecret)
+	loadOAuthCredentialsFromEnv()
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -121,3 +121,43 @@ func TestInitDbxUsesAuthFileEnv(t *testing.T) {
 		t.Fatalf("expected domain from flag, got %q", config.Domain)
 	}
 }
+
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+
+	old, exists := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if exists {
+			_ = os.Setenv(key, old)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+func TestLoadOAuthCredentialsFromEnvKeepsTeamManageSecretFallback(t *testing.T) {
+	restoreOAuthCredentials(t)
+
+	for _, key := range []string{
+		"DROPBOX_PERSONAL_APP_KEY",
+		"DROPBOX_PERSONAL_APP_SECRET",
+		"DROPBOX_TEAM_APP_KEY",
+		"DROPBOX_TEAM_APP_SECRET",
+		"DROPBOX_MANAGE_APP_KEY",
+		"DROPBOX_MANAGE_APP_SECRET",
+	} {
+		unsetEnvForTest(t, key)
+	}
+
+	teamAccessAppSecret = "team-access-secret"
+	teamManageAppSecret = "team-manage-secret"
+
+	loadOAuthCredentialsFromEnv()
+
+	if teamManageAppSecret != "team-manage-secret" {
+		t.Fatalf("expected team manage secret fallback, got %q", teamManageAppSecret)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,11 @@ require (
 	github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/term v0.32.0
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	golang.org/x/sys v0.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,10 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
+golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
## Summary
- Adds `dbxcli login [personal|team-access|team-manage]` command with `--app-key` flag
- Refactors OAuth flow into auth.go with injectable functions for testability
- Commands without saved credentials now return a clear error pointing to `dbxcli login` instead of silently prompting for auth code
- App key is read with visible input, app secret is masked via `golang.org/x/term`
- Fixes bug where `teamManageAppSecret` env fallback incorrectly used `teamAccessAppSecret`
- Adds `PersistentPreRunE` bypass on logout so it doesn't require existing auth
- Updates README with new authentication documentation

## Test plan
- [x] `go test ./cmd/...` passes (30+ new tests covering token reuse, force refresh, credential prompting, flag handling, error paths)
- [x] `go vet ./...` passes
- [x] Manual test: `dbxcli login --app-key=<key>` prompts for masked secret, completes OAuth flow
- [x] Manual test: `dbxcli ls /` without credentials returns login hint error
- [x] Manual test: `DBXCLI_ACCESS_TOKEN=<token> dbxcli ls /` bypasses login