### PR TITLE
Switch OAuth to PKCE with offline refresh tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/dropbox/dbxcli/compare/v2.0.8...HEAD)
 
+**Changed:**
+
+- Saved OAuth credentials now use a refresh-token aware `auth.json` object format. Existing legacy token-string entries are still read, but any credential write rewrites the file in the new format.
+
 **Closed issues:**
 
 - Invalid client\_id when trying to get authorization code [\#79](https://github.com/dropbox/dbxcli/issues/79)

--- a/README.md
+++ b/README.md
@@ -57,11 +57,10 @@ For newcomers the go build process can be a bit arcane, these steps can be follo
 Now we need to pause for a second to get development keys. 
 
 5. Head to `https://www.dropbox.com/developers/apps` (sign in if necessary) and choose "Create app". Use the Dropbox API and give it Full Dropbox access. Name and create the app.
-6. You'll be presented with a dashboard with an "App key" and an "App secret".
-7. Provide the app key and secret when running `dbxcli`:
+6. You'll be presented with a dashboard with an "App key".
+7. Provide the app key when running `dbxcli`:
 ```sh
 $ export DROPBOX_PERSONAL_APP_KEY=your-app-key
-$ export DROPBOX_PERSONAL_APP_SECRET=your-app-secret
 ```
 
 Finally we're ready to build. Run `go build`, and you'll see a `dbxcli` binary has been created in the current directory. Congrats, we're done!
@@ -118,20 +117,23 @@ Commands require saved credentials. If no saved credentials are available, run
 `dbxcli login` first or provide a token with `DBXCLI_ACCESS_TOKEN`.
 
 If the bundled app credentials are still in use, `dbxcli` asks for your Dropbox
-app key and app secret before printing the authorization URL. You can pass the
-app key as an option and enter the app secret at the masked prompt:
+app key before printing the authorization URL. You can pass the app key as an
+option:
 
 ```sh
 $ dbxcli login --app-key=your-app-key
 ```
 
-You can also set both with environment variables to skip the prompts:
+You can also set it with an environment variable to skip the prompt:
 
 ```sh
-$ DROPBOX_PERSONAL_APP_KEY=your-app-key DROPBOX_PERSONAL_APP_SECRET=your-app-secret dbxcli login
+$ DROPBOX_PERSONAL_APP_KEY=your-app-key dbxcli login
 ```
 
-If saved credentials expire or need to be replaced, run `dbxcli login` again.
+Saved login credentials include a Dropbox refresh token and are refreshed
+automatically when the access token expires. If saved credentials are revoked or
+need to be replaced, run `dbxcli login` again.
+
 Set `DBXCLI_AUTH_FILE` to use a different credentials file:
 
 ```sh

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -22,27 +22,37 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/mitchellh/go-homedir"
 	"golang.org/x/oauth2"
-	"golang.org/x/term"
 )
 
 const (
-	configFileName = "auth.json"
-	envAccessToken = "DBXCLI_ACCESS_TOKEN"
-	envAuthFile    = "DBXCLI_AUTH_FILE"
+	configFileName         = "auth.json"
+	envAccessToken         = "DBXCLI_ACCESS_TOKEN"
+	envAuthFile            = "DBXCLI_AUTH_FILE"
+	tokenAccessTypeParam   = "token_access_type"
+	tokenAccessTypeOffline = "offline"
+	tokenRefreshWindow     = 5 * time.Minute
 )
 
-// TokenMap maps domains to a map of commands to tokens.
+// TokenMap maps domains to a map of commands to saved credentials.
 // For each domain, we want to save different tokens depending on the
 // command type: personal, team access and team manage.
-type TokenMap map[string]map[string]string
+type TokenMap map[string]map[string]storedCredential
+
+type storedCredential struct {
+	AccessToken  string     `json:"access_token"`
+	RefreshToken string     `json:"refresh_token,omitempty"`
+	TokenType    string     `json:"token_type,omitempty"`
+	Expiry       *time.Time `json:"expiry,omitempty"`
+	AppKey       string     `json:"app_key,omitempty"`
+}
 
 type appCredentials struct {
-	Key    string
-	Secret string
+	Key string
 }
 
 var readAppKey = func(prompt string) (string, error) {
@@ -54,35 +64,13 @@ var readAppKey = func(prompt string) (string, error) {
 	return value, nil
 }
 
-var readAppSecret = func(prompt string) (string, error) {
-	fmt.Print(prompt)
-	if term.IsTerminal(int(os.Stdin.Fd())) {
-		value, err := term.ReadPassword(int(os.Stdin.Fd()))
-		fmt.Println()
-		if err != nil {
-			return "", err
-		}
-		return string(value), nil
-	}
-
-	var value string
-	if _, err := fmt.Scan(&value); err != nil {
-		return "", err
-	}
-	return value, nil
-}
-
 var readAppCredentials = func(tokType string) (appCredentials, error) {
-	fmt.Printf("Enter Dropbox %s app credentials.\n", appCredentialsName(tokType))
+	fmt.Printf("Enter Dropbox %s app key.\n", appCredentialsName(tokType))
 	appKey, err := readAppKey("Dropbox app key: ")
 	if err != nil {
 		return appCredentials{}, err
 	}
-	appSecret, err := readAppSecret("Dropbox app secret: ")
-	if err != nil {
-		return appCredentials{}, err
-	}
-	return appCredentials{Key: appKey, Secret: appSecret}, nil
+	return appCredentials{Key: appKey}, nil
 }
 
 var readAuthorizationCode = func() (string, error) {
@@ -93,17 +81,86 @@ var readAuthorizationCode = func() (string, error) {
 	return code, nil
 }
 
-var exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
-	return conf.Exchange(ctx, code)
+var generateOAuthVerifier = oauth2.GenerateVerifier
+
+var exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
+	return conf.Exchange(ctx, code, oauth2.VerifierOption(verifier))
+}
+
+var refreshOAuthToken = func(ctx context.Context, conf *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
+	expired := *token
+	expired.Expiry = time.Now().Add(-time.Second)
+	return conf.TokenSource(ctx, &expired).Token()
 }
 
 func oauthConfig(tokenType string, domain string) *oauth2.Config {
-	appKey, appSecret := oauthCredentials(tokenType)
+	appKey := oauthCredentials(tokenType)
+	return oauthConfigWithAppKey(appKey, domain)
+}
+
+func oauthConfigWithAppKey(appKey string, domain string) *oauth2.Config {
+	endpoint := dropbox.OAuthEndpoint(domain)
+	endpoint.AuthStyle = oauth2.AuthStyleInParams
+
 	return &oauth2.Config{
-		ClientID:     appKey,
-		ClientSecret: appSecret,
-		Endpoint:     dropbox.OAuthEndpoint(domain),
+		ClientID: appKey,
+		Endpoint: endpoint,
 	}
+}
+
+func (t *storedCredential) UnmarshalJSON(b []byte) error {
+	var accessToken string
+	if err := json.Unmarshal(b, &accessToken); err == nil {
+		*t = storedCredential{AccessToken: accessToken}
+		return nil
+	}
+
+	type storedCredentialAlias storedCredential
+	var credential storedCredentialAlias
+	if err := json.Unmarshal(b, &credential); err != nil {
+		return err
+	}
+	*t = storedCredential(credential)
+	return nil
+}
+
+func storedCredentialFromOAuthToken(token *oauth2.Token, appKey string) storedCredential {
+	credential := storedCredential{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		TokenType:    token.Type(),
+		AppKey:       appKey,
+	}
+	if !token.Expiry.IsZero() {
+		expiry := token.Expiry
+		credential.Expiry = &expiry
+	}
+	return credential
+}
+
+func (c storedCredential) oauthToken() *oauth2.Token {
+	token := &oauth2.Token{
+		AccessToken:  c.AccessToken,
+		TokenType:    c.TokenType,
+		RefreshToken: c.RefreshToken,
+	}
+	if c.Expiry != nil {
+		token.Expiry = *c.Expiry
+	}
+	return token
+}
+
+func (c storedCredential) shouldRefresh(now time.Time) bool {
+	if c.RefreshToken == "" {
+		return false
+	}
+	if c.AccessToken == "" {
+		return true
+	}
+	if c.Expiry == nil {
+		return false
+	}
+	return !c.Expiry.After(now.Add(tokenRefreshWindow))
 }
 
 func authFilePath() (string, error) {
@@ -160,25 +217,37 @@ func getAccessToken(tokType string, domain string, force bool) (string, string, 
 		tokenMap = make(TokenMap)
 	}
 	if tokenMap[domain] == nil {
-		tokenMap[domain] = make(map[string]string)
+		tokenMap[domain] = make(map[string]storedCredential)
 	}
 	tokens := tokenMap[domain]
+	credential := tokens[tokType]
 
-	if force || tokens[tokType] == "" {
-		if !force && needsOAuthCredentialsOverride(tokType) {
+	if force || (credential.AccessToken == "" && credential.RefreshToken == "") {
+		if !force {
 			return "", "", missingAccessTokenError(tokType)
 		}
-		accessToken, err := requestAccessToken(tokType, domain)
+		credential, err = requestAccessCredential(tokType, domain)
 		if err != nil {
 			return "", "", err
 		}
-		tokens[tokType] = accessToken
+		tokens[tokType] = credential
 		if err = writeTokens(filePath, tokenMap); err != nil {
 			return "", "", err
 		}
 	}
 
-	return tokens[tokType], filePath, nil
+	if !force && credential.shouldRefresh(time.Now()) {
+		credential, err = refreshStoredCredential(tokType, domain, credential)
+		if err != nil {
+			return "", "", fmt.Errorf("refresh saved Dropbox credentials: %w; run %q again", err, loginCommand(tokType))
+		}
+		tokens[tokType] = credential
+		if err = writeTokens(filePath, tokenMap); err != nil {
+			return "", "", err
+		}
+	}
+
+	return credential.AccessToken, filePath, nil
 }
 
 func loginCommand(tokType string) string {
@@ -217,36 +286,82 @@ func ensureOAuthAppCredentials(tokType string) error {
 		return err
 	}
 	creds.Key = strings.TrimSpace(creds.Key)
-	creds.Secret = strings.TrimSpace(creds.Secret)
-	if creds.Key == "" || creds.Secret == "" {
-		return errors.New("Dropbox app key and secret are required")
+	if creds.Key == "" {
+		return errors.New("Dropbox app key is required")
 	}
 
-	setOAuthCredentials(tokType, creds.Key, creds.Secret)
+	setOAuthCredentials(tokType, creds.Key)
 	return nil
 }
 
 func requestAccessToken(tokType string, domain string) (string, error) {
-	if err := ensureOAuthAppCredentials(tokType); err != nil {
+	credential, err := requestAccessCredential(tokType, domain)
+	if err != nil {
 		return "", err
+	}
+	return credential.AccessToken, nil
+}
+
+func requestAccessCredential(tokType string, domain string) (storedCredential, error) {
+	if err := ensureOAuthAppCredentials(tokType); err != nil {
+		return storedCredential{}, err
 	}
 
 	conf := oauthConfig(tokType, domain)
-	fmt.Printf("1. Go to %v\n", conf.AuthCodeURL("state"))
+	verifier := generateOAuthVerifier()
+	authCodeURL := conf.AuthCodeURL("state",
+		oauth2.S256ChallengeOption(verifier),
+		oauth2.SetAuthURLParam(tokenAccessTypeParam, tokenAccessTypeOffline),
+	)
+
+	fmt.Printf("1. Go to %v\n", authCodeURL)
 	fmt.Printf("2. Click \"Allow\" (you might have to log in first).\n")
 	fmt.Printf("3. Copy the authorization code.\n")
 	fmt.Printf("Enter the authorization code here: ")
 
 	code, err := readAuthorizationCode()
 	if err != nil {
-		return "", err
+		return storedCredential{}, err
 	}
-	token, err := exchangeAuthorizationCode(context.Background(), conf, code)
+	token, err := exchangeAuthorizationCode(context.Background(), conf, code, verifier)
 	if err != nil {
-		return "", err
+		return storedCredential{}, err
 	}
 	if token == nil || token.AccessToken == "" {
-		return "", errors.New("authorization did not return an access token")
+		return storedCredential{}, errors.New("authorization did not return an access token")
 	}
-	return token.AccessToken, nil
+	if token.RefreshToken == "" {
+		return storedCredential{}, errors.New("authorization did not return a refresh token")
+	}
+	return storedCredentialFromOAuthToken(token, conf.ClientID), nil
+}
+
+func refreshStoredCredential(tokType string, domain string, credential storedCredential) (storedCredential, error) {
+	appKey := credential.AppKey
+	if appKey == "" {
+		appKey = oauthCredentials(tokType)
+	}
+	if strings.TrimSpace(appKey) == "" {
+		return storedCredential{}, errors.New("saved credentials cannot be refreshed without a Dropbox app key")
+	}
+
+	token, err := refreshOAuthToken(context.Background(), oauthConfigWithAppKey(appKey, domain), credential.oauthToken())
+	if err != nil {
+		return storedCredential{}, err
+	}
+	if token == nil || token.AccessToken == "" {
+		return storedCredential{}, errors.New("token refresh did not return an access token")
+	}
+
+	refreshed := storedCredentialFromOAuthToken(token, appKey)
+	if refreshed.RefreshToken == "" {
+		refreshed.RefreshToken = credential.RefreshToken
+	}
+	if refreshed.TokenType == "" {
+		refreshed.TokenType = credential.TokenType
+	}
+	if refreshed.TokenType == "" {
+		refreshed.TokenType = "Bearer"
+	}
+	return refreshed, nil
 }

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -3,13 +3,40 @@ package cmd
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/oauth2"
 )
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
 
 func TestAuthFilePathUsesEnv(t *testing.T) {
 	authFile := filepath.Join(t.TempDir(), "custom-auth.json")
@@ -35,11 +62,43 @@ func TestReadTokensReadsTokenMap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if tokens[""][tokenPersonal] != "personal-token" {
-		t.Fatalf("expected personal token, got %q", tokens[""][tokenPersonal])
+	if tokens[""][tokenPersonal].AccessToken != "personal-token" {
+		t.Fatalf("expected personal token, got %q", tokens[""][tokenPersonal].AccessToken)
 	}
-	if tokens["api.example.com"][tokenTeamManage] != "team-token" {
-		t.Fatalf("expected team token, got %q", tokens["api.example.com"][tokenTeamManage])
+	if tokens["api.example.com"][tokenTeamManage].AccessToken != "team-token" {
+		t.Fatalf("expected team token, got %q", tokens["api.example.com"][tokenTeamManage].AccessToken)
+	}
+	if tokens[""][tokenPersonal].RefreshToken != "" {
+		t.Fatalf("expected legacy personal token to have no refresh token, got %q", tokens[""][tokenPersonal].RefreshToken)
+	}
+}
+
+func TestReadTokensReadsRefreshableCredentials(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authFile, []byte(`{"":{"personal":{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","expiry":"2030-01-02T03:04:05Z","app_key":"app-key"}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tokens, err := readTokens(authFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	credential := tokens[""][tokenPersonal]
+	if credential.AccessToken != "access-token" {
+		t.Fatalf("expected access token, got %q", credential.AccessToken)
+	}
+	if credential.RefreshToken != "refresh-token" {
+		t.Fatalf("expected refresh token, got %q", credential.RefreshToken)
+	}
+	if credential.TokenType != "Bearer" {
+		t.Fatalf("expected token type, got %q", credential.TokenType)
+	}
+	if credential.AppKey != "app-key" {
+		t.Fatalf("expected app key, got %q", credential.AppKey)
+	}
+	if credential.Expiry == nil || credential.Expiry.Format(time.RFC3339) != "2030-01-02T03:04:05Z" {
+		t.Fatalf("unexpected expiry: %v", credential.Expiry)
 	}
 }
 
@@ -56,12 +115,21 @@ func TestReadTokensReturnsUnmarshalError(t *testing.T) {
 
 func TestWriteTokensCreatesParentDirectory(t *testing.T) {
 	authFile := filepath.Join(t.TempDir(), "nested", "auth.json")
+	expiry := time.Now().Add(time.Hour).UTC()
 	want := TokenMap{
 		"": {
-			tokenPersonal: "personal-token",
+			tokenPersonal: {
+				AccessToken:  "personal-token",
+				RefreshToken: "refresh-token",
+				TokenType:    "Bearer",
+				Expiry:       &expiry,
+				AppKey:       "app-key",
+			},
 		},
 		"api.example.com": {
-			tokenTeamAccess: "team-access-token",
+			tokenTeamAccess: {
+				AccessToken: "team-access-token",
+			},
 		},
 	}
 
@@ -74,11 +142,11 @@ func TestWriteTokensCreatesParentDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got[""][tokenPersonal] != want[""][tokenPersonal] {
-		t.Fatalf("expected personal token %q, got %q", want[""][tokenPersonal], got[""][tokenPersonal])
+	if got[""][tokenPersonal].AccessToken != want[""][tokenPersonal].AccessToken {
+		t.Fatalf("expected personal token %q, got %q", want[""][tokenPersonal].AccessToken, got[""][tokenPersonal].AccessToken)
 	}
-	if got["api.example.com"][tokenTeamAccess] != want["api.example.com"][tokenTeamAccess] {
-		t.Fatalf("expected team access token %q, got %q", want["api.example.com"][tokenTeamAccess], got["api.example.com"][tokenTeamAccess])
+	if got["api.example.com"][tokenTeamAccess].AccessToken != want["api.example.com"][tokenTeamAccess].AccessToken {
+		t.Fatalf("expected team access token %q, got %q", want["api.example.com"][tokenTeamAccess].AccessToken, got["api.example.com"][tokenTeamAccess].AccessToken)
 	}
 }
 
@@ -86,24 +154,20 @@ func restoreOAuthCredentials(t *testing.T) {
 	t.Helper()
 
 	origPersonalAppKey := personalAppKey
-	origPersonalAppSecret := personalAppSecret
 	origTeamAccessAppKey := teamAccessAppKey
-	origTeamAccessAppSecret := teamAccessAppSecret
 	origTeamManageAppKey := teamManageAppKey
-	origTeamManageAppSecret := teamManageAppSecret
 	origReadAppKey := readAppKey
-	origReadAppSecret := readAppSecret
 	origReadAppCredentials := readAppCredentials
+	origGenerateOAuthVerifier := generateOAuthVerifier
+	origRefreshOAuthToken := refreshOAuthToken
 	t.Cleanup(func() {
 		personalAppKey = origPersonalAppKey
-		personalAppSecret = origPersonalAppSecret
 		teamAccessAppKey = origTeamAccessAppKey
-		teamAccessAppSecret = origTeamAccessAppSecret
 		teamManageAppKey = origTeamManageAppKey
-		teamManageAppSecret = origTeamManageAppSecret
 		readAppKey = origReadAppKey
-		readAppSecret = origReadAppSecret
 		readAppCredentials = origReadAppCredentials
+		generateOAuthVerifier = origGenerateOAuthVerifier
+		refreshOAuthToken = origRefreshOAuthToken
 	})
 }
 
@@ -111,9 +175,9 @@ func mockOAuthAppCredentials(t *testing.T) {
 	t.Helper()
 
 	restoreOAuthCredentials(t)
-	setOAuthCredentials(tokenPersonal, "personal-test-key", "personal-test-secret")
-	setOAuthCredentials(tokenTeamAccess, "team-access-test-key", "team-access-test-secret")
-	setOAuthCredentials(tokenTeamManage, "team-manage-test-key", "team-manage-test-secret")
+	setOAuthCredentials(tokenPersonal, "personal-test-key")
+	setOAuthCredentials(tokenTeamAccess, "team-access-test-key")
+	setOAuthCredentials(tokenTeamManage, "team-manage-test-key")
 	readAppCredentials = func(tokType string) (appCredentials, error) {
 		t.Fatal("app credential prompt should not be used")
 		return appCredentials{}, nil
@@ -135,11 +199,19 @@ func mockAuthorization(t *testing.T, code string, accessToken string) {
 	readAuthorizationCode = func() (string, error) {
 		return code, nil
 	}
-	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, gotCode string) (*oauth2.Token, error) {
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, gotCode string, verifier string) (*oauth2.Token, error) {
 		if gotCode != code {
 			t.Fatalf("expected authorization code %q, got %q", code, gotCode)
 		}
-		return &oauth2.Token{AccessToken: accessToken}, nil
+		if verifier == "" {
+			t.Fatal("expected PKCE verifier")
+		}
+		return &oauth2.Token{
+			AccessToken:  accessToken,
+			RefreshToken: "refresh-token",
+			TokenType:    "Bearer",
+			Expiry:       time.Now().Add(time.Hour),
+		}, nil
 	}
 }
 
@@ -160,7 +232,7 @@ func TestGetAccessTokenUsesExistingToken(t *testing.T) {
 		t.Fatal("authorization prompt should not be used for existing token")
 		return "", nil
 	}
-	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
 		t.Fatal("authorization exchange should not be used for existing token")
 		return nil, nil
 	}
@@ -200,14 +272,121 @@ func TestGetAccessTokenForceRefreshesToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tokens[""][tokenPersonal] != "new-token" {
-		t.Fatalf("expected saved token to be refreshed, got %q", tokens[""][tokenPersonal])
+	if tokens[""][tokenPersonal].AccessToken != "new-token" {
+		t.Fatalf("expected saved token to be refreshed, got %q", tokens[""][tokenPersonal].AccessToken)
+	}
+	if tokens[""][tokenPersonal].RefreshToken == "" {
+		t.Fatal("expected saved token to include a refresh token")
+	}
+}
+
+func TestGetAccessTokenRefreshesExpiredCredential(t *testing.T) {
+	expired := time.Now().Add(-time.Hour).UTC()
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	tokens := TokenMap{
+		"": {
+			tokenPersonal: {
+				AccessToken:  "old-access",
+				RefreshToken: "old-refresh",
+				TokenType:    "Bearer",
+				Expiry:       &expired,
+				AppKey:       "stored-app-key",
+			},
+		},
+	}
+	if err := writeTokens(authFile, tokens); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envAuthFile, authFile)
+
+	restoreOAuthCredentials(t)
+	refreshExpiry := time.Now().Add(time.Hour).UTC()
+	refreshOAuthToken = func(ctx context.Context, conf *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
+		if conf.ClientID != "stored-app-key" {
+			t.Fatalf("expected stored app key for refresh, got %q", conf.ClientID)
+		}
+		if token.RefreshToken != "old-refresh" {
+			t.Fatalf("expected old refresh token, got %q", token.RefreshToken)
+		}
+		return &oauth2.Token{
+			AccessToken: "new-access",
+			TokenType:   "Bearer",
+			Expiry:      refreshExpiry,
+		}, nil
+	}
+
+	token, _, err := getAccessToken(tokenPersonal, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "new-access" {
+		t.Fatalf("expected refreshed access token, got %q", token)
+	}
+
+	got, err := readTokens(authFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credential := got[""][tokenPersonal]
+	if credential.AccessToken != "new-access" {
+		t.Fatalf("expected persisted access token, got %q", credential.AccessToken)
+	}
+	if credential.RefreshToken != "old-refresh" {
+		t.Fatalf("expected refresh token to be preserved, got %q", credential.RefreshToken)
+	}
+	if credential.Expiry == nil || !credential.Expiry.Equal(refreshExpiry) {
+		t.Fatalf("expected persisted expiry %v, got %v", refreshExpiry, credential.Expiry)
+	}
+}
+
+func TestGetAccessTokenRefreshFailureLeavesAuthFileUnchanged(t *testing.T) {
+	expired := time.Now().Add(-time.Hour).UTC()
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	tokens := TokenMap{
+		"": {
+			tokenPersonal: {
+				AccessToken:  "old-access",
+				RefreshToken: "old-refresh",
+				TokenType:    "Bearer",
+				Expiry:       &expired,
+				AppKey:       "stored-app-key",
+			},
+		},
+	}
+	if err := writeTokens(authFile, tokens); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(authFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envAuthFile, authFile)
+
+	restoreOAuthCredentials(t)
+	refreshOAuthToken = func(ctx context.Context, conf *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
+		return nil, errors.New("refresh failed")
+	}
+
+	_, _, err = getAccessToken(tokenPersonal, "", false)
+	if err == nil {
+		t.Fatal("expected refresh failure")
+	}
+	if !strings.Contains(err.Error(), "dbxcli login --app-key=<your-app-key>") {
+		t.Fatalf("expected login hint, got %q", err)
+	}
+
+	after, err := os.ReadFile(authFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("expected auth file to remain unchanged\nbefore: %s\nafter:  %s", before, after)
 	}
 }
 
 func TestGetAccessTokenMissingTokenWithBundledCredentialsReturnsLoginError(t *testing.T) {
 	restoreOAuthCredentials(t)
-	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, defaultPersonalAppSecret)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey)
 
 	authFile := filepath.Join(t.TempDir(), "auth.json")
 	t.Setenv(envAuthFile, authFile)
@@ -227,7 +406,7 @@ func TestGetAccessTokenMissingTokenWithBundledCredentialsReturnsLoginError(t *te
 		t.Fatal("authorization prompt should not run when app credentials are missing")
 		return "", nil
 	}
-	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
 		t.Fatal("authorization exchange should not run when app credentials are missing")
 		return nil, nil
 	}
@@ -241,6 +420,42 @@ func TestGetAccessTokenMissingTokenWithBundledCredentialsReturnsLoginError(t *te
 	}
 	if !strings.Contains(err.Error(), envAccessToken) {
 		t.Fatalf("expected %s hint, got %q", envAccessToken, err)
+	}
+}
+
+func TestGetAccessTokenMissingTokenWithConfiguredAppKeyReturnsLoginError(t *testing.T) {
+	restoreOAuthCredentials(t)
+	setOAuthCredentials(tokenPersonal, "configured-key")
+
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	t.Setenv(envAuthFile, authFile)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAppCredentials = func(tokType string) (appCredentials, error) {
+		t.Fatal("app credential prompt should not run for command lazy auth")
+		return appCredentials{}, nil
+	}
+	readAuthorizationCode = func() (string, error) {
+		t.Fatal("authorization prompt should not run for command lazy auth")
+		return "", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
+		t.Fatal("authorization exchange should not run for command lazy auth")
+		return nil, nil
+	}
+
+	_, _, err := getAccessToken(tokenPersonal, "", false)
+	if err == nil {
+		t.Fatal("expected missing credentials error")
+	}
+	if !strings.Contains(err.Error(), "dbxcli login --app-key=<your-app-key>") {
+		t.Fatalf("expected login hint, got %q", err)
 	}
 }
 
@@ -274,12 +489,34 @@ func TestRequestAccessTokenRejectsEmptyToken(t *testing.T) {
 	readAuthorizationCode = func() (string, error) {
 		return "auth-code", nil
 	}
-	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
 		return &oauth2.Token{}, nil
 	}
 
 	if _, err := requestAccessToken(tokenPersonal, ""); err == nil {
 		t.Fatal("expected empty access token to return an error")
+	}
+}
+
+func TestRequestAccessTokenRejectsMissingRefreshToken(t *testing.T) {
+	mockOAuthAppCredentials(t)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	readAuthorizationCode = func() (string, error) {
+		return "auth-code", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
+		return &oauth2.Token{AccessToken: "access-token"}, nil
+	}
+
+	if _, err := requestAccessToken(tokenPersonal, ""); err == nil {
+		t.Fatal("expected missing refresh token to return an error")
 	}
 }
 
@@ -296,7 +533,7 @@ func TestRequestAccessTokenReturnsReadError(t *testing.T) {
 	readAuthorizationCode = func() (string, error) {
 		return "", errors.New("read failed")
 	}
-	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
 		t.Fatal("authorization exchange should not run when reading code fails")
 		return nil, nil
 	}
@@ -306,9 +543,9 @@ func TestRequestAccessTokenReturnsReadError(t *testing.T) {
 	}
 }
 
-func TestRequestAccessTokenPromptsForAppCredentialsWhenUsingBundledDefaults(t *testing.T) {
+func TestRequestAccessTokenPromptsForAppKeyWhenUsingBundledDefaults(t *testing.T) {
 	restoreOAuthCredentials(t)
-	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, defaultPersonalAppSecret)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey)
 
 	origReadAuthorizationCode := readAuthorizationCode
 	origExchangeAuthorizationCode := exchangeAuthorizationCode
@@ -321,19 +558,19 @@ func TestRequestAccessTokenPromptsForAppCredentialsWhenUsingBundledDefaults(t *t
 		if tokType != tokenPersonal {
 			t.Fatalf("expected personal app credentials prompt, got %q", tokType)
 		}
-		return appCredentials{Key: "prompt-key", Secret: "prompt-secret"}, nil
+		return appCredentials{Key: "prompt-key"}, nil
 	}
 	readAuthorizationCode = func() (string, error) {
 		return "auth-code", nil
 	}
-	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
 		if conf.ClientID != "prompt-key" {
 			t.Fatalf("expected prompted app key, got %q", conf.ClientID)
 		}
-		if conf.ClientSecret != "prompt-secret" {
-			t.Fatalf("expected prompted app secret, got %q", conf.ClientSecret)
+		if conf.ClientSecret != "" {
+			t.Fatalf("expected no client secret for PKCE, got %q", conf.ClientSecret)
 		}
-		return &oauth2.Token{AccessToken: "access-token"}, nil
+		return &oauth2.Token{AccessToken: "access-token", RefreshToken: "refresh-token", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}, nil
 	}
 
 	token, err := requestAccessToken(tokenPersonal, "")
@@ -348,19 +585,60 @@ func TestRequestAccessTokenPromptsForAppCredentialsWhenUsingBundledDefaults(t *t
 	}
 }
 
-func TestReadAppCredentialsReadsVisibleKeyAndMaskedSecret(t *testing.T) {
+func TestRequestAccessTokenUsesPKCEOfflineAuthURL(t *testing.T) {
+	mockOAuthAppCredentials(t)
+
+	origReadAuthorizationCode := readAuthorizationCode
+	origExchangeAuthorizationCode := exchangeAuthorizationCode
+	t.Cleanup(func() {
+		readAuthorizationCode = origReadAuthorizationCode
+		exchangeAuthorizationCode = origExchangeAuthorizationCode
+	})
+
+	const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	generateOAuthVerifier = func() string {
+		return verifier
+	}
+	readAuthorizationCode = func() (string, error) {
+		return "auth-code", nil
+	}
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, gotVerifier string) (*oauth2.Token, error) {
+		if gotVerifier != verifier {
+			t.Fatalf("expected verifier %q, got %q", verifier, gotVerifier)
+		}
+		return &oauth2.Token{
+			AccessToken:  "access-token",
+			RefreshToken: "refresh-token",
+			TokenType:    "Bearer",
+			Expiry:       time.Now().Add(time.Hour),
+		}, nil
+	}
+
+	var err error
+	out := captureStdout(t, func() {
+		_, err = requestAccessToken(tokenPersonal, "")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "token_access_type=offline") {
+		t.Fatalf("expected offline token access type in auth URL, got %q", out)
+	}
+	if !strings.Contains(out, "code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM") {
+		t.Fatalf("expected PKCE code challenge in auth URL, got %q", out)
+	}
+	if !strings.Contains(out, "code_challenge_method=S256") {
+		t.Fatalf("expected PKCE S256 method in auth URL, got %q", out)
+	}
+}
+
+func TestReadAppCredentialsReadsVisibleKey(t *testing.T) {
 	restoreOAuthCredentials(t)
 
 	var keyPrompts []string
 	readAppKey = func(prompt string) (string, error) {
 		keyPrompts = append(keyPrompts, prompt)
 		return "visible-key", nil
-	}
-
-	var secretPrompts []string
-	readAppSecret = func(prompt string) (string, error) {
-		secretPrompts = append(secretPrompts, prompt)
-		return "masked-secret", nil
 	}
 
 	creds, err := readAppCredentials(tokenPersonal)
@@ -370,26 +648,17 @@ func TestReadAppCredentialsReadsVisibleKeyAndMaskedSecret(t *testing.T) {
 	if creds.Key != "visible-key" {
 		t.Fatalf("expected app key, got %q", creds.Key)
 	}
-	if creds.Secret != "masked-secret" {
-		t.Fatalf("expected app secret, got %q", creds.Secret)
-	}
 	if len(keyPrompts) != 1 {
 		t.Fatalf("expected one app key prompt, got %d", len(keyPrompts))
 	}
 	if keyPrompts[0] != "Dropbox app key: " {
 		t.Fatalf("unexpected app key prompt %q", keyPrompts[0])
 	}
-	if len(secretPrompts) != 1 {
-		t.Fatalf("expected one app secret prompt, got %d", len(secretPrompts))
-	}
-	if secretPrompts[0] != "Dropbox app secret: " {
-		t.Fatalf("unexpected app secret prompt %q", secretPrompts[0])
-	}
 }
 
 func TestRequestAccessTokenUsesConfiguredAppCredentials(t *testing.T) {
 	restoreOAuthCredentials(t)
-	setOAuthCredentials(tokenPersonal, "configured-key", "configured-secret")
+	setOAuthCredentials(tokenPersonal, "configured-key")
 
 	origReadAuthorizationCode := readAuthorizationCode
 	origExchangeAuthorizationCode := exchangeAuthorizationCode
@@ -405,14 +674,14 @@ func TestRequestAccessTokenUsesConfiguredAppCredentials(t *testing.T) {
 	readAuthorizationCode = func() (string, error) {
 		return "auth-code", nil
 	}
-	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
 		if conf.ClientID != "configured-key" {
 			t.Fatalf("expected configured app key, got %q", conf.ClientID)
 		}
-		if conf.ClientSecret != "configured-secret" {
-			t.Fatalf("expected configured app secret, got %q", conf.ClientSecret)
+		if conf.ClientSecret != "" {
+			t.Fatalf("expected no client secret for PKCE, got %q", conf.ClientSecret)
 		}
-		return &oauth2.Token{AccessToken: "access-token"}, nil
+		return &oauth2.Token{AccessToken: "access-token", RefreshToken: "refresh-token", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}, nil
 	}
 
 	if _, err := requestAccessToken(tokenPersonal, ""); err != nil {
@@ -422,7 +691,7 @@ func TestRequestAccessTokenUsesConfiguredAppCredentials(t *testing.T) {
 
 func TestRequestAccessTokenRejectsEmptyAppCredentials(t *testing.T) {
 	restoreOAuthCredentials(t)
-	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, defaultPersonalAppSecret)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey)
 
 	origReadAuthorizationCode := readAuthorizationCode
 	origExchangeAuthorizationCode := exchangeAuthorizationCode
@@ -432,13 +701,13 @@ func TestRequestAccessTokenRejectsEmptyAppCredentials(t *testing.T) {
 	})
 
 	readAppCredentials = func(tokType string) (appCredentials, error) {
-		return appCredentials{Key: " ", Secret: "secret"}, nil
+		return appCredentials{Key: " "}, nil
 	}
 	readAuthorizationCode = func() (string, error) {
 		t.Fatal("authorization code prompt should not run when app credentials are invalid")
 		return "", nil
 	}
-	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
 		t.Fatal("authorization exchange should not run when app credentials are invalid")
 		return nil, nil
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -35,10 +34,6 @@ func loginTokenType(name string) (string, error) {
 	}
 }
 
-func defaultOAuthCredential(value string, defaultValue string) bool {
-	return defaultValue != "" && value == defaultValue
-}
-
 func loginAppKeyFromFlag(cmd *cobra.Command, tokType string) error {
 	appKey, _ := cmd.Flags().GetString("app-key")
 	appKey = strings.TrimSpace(appKey)
@@ -46,21 +41,7 @@ func loginAppKeyFromFlag(cmd *cobra.Command, tokType string) error {
 		return nil
 	}
 
-	_, currentAppSecret := oauthCredentials(tokType)
-	_, defaultAppSecret := defaultOAuthCredentials(tokType)
-	if currentAppSecret == "" || defaultOAuthCredential(currentAppSecret, defaultAppSecret) {
-		fmt.Printf("Enter Dropbox %s app secret.\n", appCredentialsName(tokType))
-		appSecret, err := readAppSecret("Dropbox app secret: ")
-		if err != nil {
-			return err
-		}
-		currentAppSecret = strings.TrimSpace(appSecret)
-		if currentAppSecret == "" {
-			return errors.New("Dropbox app secret is required")
-		}
-	}
-
-	setOAuthCredentials(tokType, appKey, currentAppSecret)
+	setOAuthCredentials(tokType, appKey)
 	return nil
 }
 

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -67,8 +67,11 @@ func TestLoginWritesCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tokens[""][tokenPersonal] != "login-token" {
-		t.Fatalf("expected login token to be saved, got %q", tokens[""][tokenPersonal])
+	if tokens[""][tokenPersonal].AccessToken != "login-token" {
+		t.Fatalf("expected login token to be saved, got %q", tokens[""][tokenPersonal].AccessToken)
+	}
+	if tokens[""][tokenPersonal].RefreshToken == "" {
+		t.Fatal("expected login credentials to include a refresh token")
 	}
 	if out.String() != "Credentials saved to "+authFile+"\n" {
 		t.Fatalf("unexpected output: %q", out.String())
@@ -90,14 +93,14 @@ func TestLoginWritesSelectedTokenType(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tokens[""][tokenTeamManage] != "team-token" {
-		t.Fatalf("expected team manage token to be saved, got %q", tokens[""][tokenTeamManage])
+	if tokens[""][tokenTeamManage].AccessToken != "team-token" {
+		t.Fatalf("expected team manage token to be saved, got %q", tokens[""][tokenTeamManage].AccessToken)
 	}
 }
 
-func TestLoginUsesAppKeyFlagWithConfiguredSecret(t *testing.T) {
+func TestLoginUsesAppKeyFlag(t *testing.T) {
 	restoreOAuthCredentials(t)
-	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, "configured-secret")
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey)
 
 	authFile := filepath.Join(t.TempDir(), "auth.json")
 	t.Setenv(envAuthFile, authFile)
@@ -110,24 +113,20 @@ func TestLoginUsesAppKeyFlagWithConfiguredSecret(t *testing.T) {
 	})
 
 	readAppCredentials = func(tokType string) (appCredentials, error) {
-		t.Fatal("app credential prompt should not be used when app key flag and configured secret are set")
+		t.Fatal("app credential prompt should not be used when app key flag is set")
 		return appCredentials{}, nil
-	}
-	readAppSecret = func(prompt string) (string, error) {
-		t.Fatal("app secret prompt should not be used when secret is already configured")
-		return "", nil
 	}
 	readAuthorizationCode = func() (string, error) {
 		return "auth-code", nil
 	}
-	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
 		if conf.ClientID != "flag-key" {
 			t.Fatalf("expected flag app key, got %q", conf.ClientID)
 		}
-		if conf.ClientSecret != "configured-secret" {
-			t.Fatalf("expected configured app secret, got %q", conf.ClientSecret)
+		if conf.ClientSecret != "" {
+			t.Fatalf("expected no client secret for PKCE, got %q", conf.ClientSecret)
 		}
-		return &oauth2.Token{AccessToken: "flag-token"}, nil
+		return &oauth2.Token{AccessToken: "flag-token", RefreshToken: "refresh-token"}, nil
 	}
 
 	cmd := newLoginTestCommand()
@@ -143,14 +142,17 @@ func TestLoginUsesAppKeyFlagWithConfiguredSecret(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tokens[""][tokenPersonal] != "flag-token" {
-		t.Fatalf("expected login token to be saved, got %q", tokens[""][tokenPersonal])
+	if tokens[""][tokenPersonal].AccessToken != "flag-token" {
+		t.Fatalf("expected login token to be saved, got %q", tokens[""][tokenPersonal].AccessToken)
+	}
+	if tokens[""][tokenPersonal].AppKey != "flag-key" {
+		t.Fatalf("expected saved app key, got %q", tokens[""][tokenPersonal].AppKey)
 	}
 }
 
-func TestLoginAppKeyFlagPromptsForBundledSecret(t *testing.T) {
+func TestLoginAppKeyFlagUsesBundledDefaultKey(t *testing.T) {
 	restoreOAuthCredentials(t)
-	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, defaultPersonalAppSecret)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey)
 
 	authFile := filepath.Join(t.TempDir(), "auth.json")
 	t.Setenv(envAuthFile, authFile)
@@ -166,20 +168,17 @@ func TestLoginAppKeyFlagPromptsForBundledSecret(t *testing.T) {
 		t.Fatal("full app credential prompt should not be used when app key flag is set")
 		return appCredentials{}, nil
 	}
-	readAppSecret = func(prompt string) (string, error) {
-		return "prompt-secret", nil
-	}
 	readAuthorizationCode = func() (string, error) {
 		return "auth-code", nil
 	}
-	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string) (*oauth2.Token, error) {
+	exchangeAuthorizationCode = func(ctx context.Context, conf *oauth2.Config, code string, verifier string) (*oauth2.Token, error) {
 		if conf.ClientID != "flag-key" {
 			t.Fatalf("expected flag app key, got %q", conf.ClientID)
 		}
-		if conf.ClientSecret != "prompt-secret" {
-			t.Fatalf("expected prompted app secret, got %q", conf.ClientSecret)
+		if conf.ClientSecret != "" {
+			t.Fatalf("expected no client secret for PKCE, got %q", conf.ClientSecret)
 		}
-		return &oauth2.Token{AccessToken: "flag-token"}, nil
+		return &oauth2.Token{AccessToken: "flag-token", RefreshToken: "refresh-token"}, nil
 	}
 
 	cmd := newLoginTestCommand()
@@ -192,20 +191,21 @@ func TestLoginAppKeyFlagPromptsForBundledSecret(t *testing.T) {
 	}
 }
 
-func TestLoginAppKeyFlagRejectsEmptyPromptedSecret(t *testing.T) {
+func TestLoginAppKeyFlagSetsKey(t *testing.T) {
 	restoreOAuthCredentials(t)
-	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey, defaultPersonalAppSecret)
+	setOAuthCredentials(tokenPersonal, defaultPersonalAppKey)
 
 	cmd := newLoginTestCommand()
 	if err := cmd.Flags().Set("app-key", "flag-key"); err != nil {
 		t.Fatal(err)
 	}
-	readAppSecret = func(prompt string) (string, error) {
-		return " ", nil
-	}
 
-	if err := loginAppKeyFromFlag(cmd, tokenPersonal); err == nil {
-		t.Fatal("expected empty prompted app secret to fail")
+	if err := loginAppKeyFromFlag(cmd, tokenPersonal); err != nil {
+		t.Fatal(err)
+	}
+	appKey := oauthCredentials(tokenPersonal)
+	if appKey != "flag-key" {
+		t.Fatalf("expected app key from flag, got %q", appKey)
 	}
 }
 
@@ -224,11 +224,11 @@ func TestLoginAndLogoutSkipRootAuthPreRun(t *testing.T) {
 	}
 }
 
-func TestLoginCommandDefinesAppCredentialFlags(t *testing.T) {
+func TestLoginCommandDefinesAppKeyFlagOnly(t *testing.T) {
 	if loginCmd.Flags().Lookup("app-key") == nil {
 		t.Fatal("login command should define --app-key")
 	}
 	if loginCmd.Flags().Lookup("app-secret") != nil {
-		t.Fatal("login command should not define --app-secret yet")
+		t.Fatal("login command should not define --app-secret")
 	}
 }

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -22,6 +22,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var revokeAccessToken = func(domain string, token string) error {
+	cfg := dropbox.Config{
+		Token:           token,
+		LogLevel:        dropbox.LogOff,
+		Logger:          nil,
+		AsMemberID:      "",
+		Domain:          domain,
+		Client:          nil,
+		HeaderGenerator: nil,
+		URLGenerator:    nil,
+	}
+	client := auth.New(cfg)
+	return client.TokenRevoke()
+}
+
 // Command logout revokes all saved API tokens and deletes auth.json.
 func logout(cmd *cobra.Command, args []string) error {
 	out := commandOutput(cmd)
@@ -38,18 +53,10 @@ func logout(cmd *cobra.Command, args []string) error {
 
 	for domain, tokens := range tokMap {
 		for _, token := range tokens {
-			cfg := dropbox.Config{
-				Token:           token,
-				LogLevel:        dropbox.LogOff,
-				Logger:          nil,
-				AsMemberID:      "",
-				Domain:          domain,
-				Client:          nil,
-				HeaderGenerator: nil,
-				URLGenerator:    nil,
+			if token.AccessToken == "" {
+				continue
 			}
-			client := auth.New(cfg)
-			if err = client.TokenRevoke(); err != nil {
+			if err = revokeAccessToken(domain, token.AccessToken); err != nil {
 				out.Warn("could not revoke token (may be expired): %v", err)
 			}
 		}

--- a/cmd/logout_test.go
+++ b/cmd/logout_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestLogoutRevokesLegacyAndRefreshableCredentials(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authFile, []byte(`{"":{"personal":"legacy-token","teamManage":{"access_token":"refreshable-token","refresh_token":"refresh-token","app_key":"app-key"}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envAuthFile, authFile)
+
+	origRevokeAccessToken := revokeAccessToken
+	t.Cleanup(func() {
+		revokeAccessToken = origRevokeAccessToken
+	})
+
+	revoked := make(map[string]bool)
+	revokeAccessToken = func(domain string, token string) error {
+		revoked[domain+":"+token] = true
+		return nil
+	}
+
+	if err := logout(&cobra.Command{Use: "logout"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if !revoked[":legacy-token"] {
+		t.Fatalf("expected legacy token to be revoked, got %#v", revoked)
+	}
+	if !revoked[":refreshable-token"] {
+		t.Fatalf("expected refreshable token to be revoked, got %#v", revoked)
+	}
+	if _, err := os.Stat(authFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected auth file to be removed, got %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,12 +29,9 @@ const (
 	tokenTeamAccess = "teamAccess"
 	tokenTeamManage = "teamManage"
 
-	defaultPersonalAppKey      = "mvhz183vwqibe7q"
-	defaultPersonalAppSecret   = "q0kquhzgetjwcz1"
-	defaultTeamAccessAppKey    = "zud1va492pnehkc"
-	defaultTeamAccessAppSecret = "p3ginm1gy0kmj54"
-	defaultTeamManageAppKey    = "xxe04eai4wmlitv"
-	defaultTeamManageAppSecret = "t8ms714yun7nu5s"
+	defaultPersonalAppKey   = "mvhz183vwqibe7q"
+	defaultTeamAccessAppKey = "zud1va492pnehkc"
+	defaultTeamManageAppKey = "xxe04eai4wmlitv"
 )
 
 func getEnv(key, fallback string) string {
@@ -46,61 +43,57 @@ func getEnv(key, fallback string) string {
 }
 
 var (
-	personalAppKey      = defaultPersonalAppKey
-	personalAppSecret   = defaultPersonalAppSecret
-	teamAccessAppKey    = defaultTeamAccessAppKey
-	teamAccessAppSecret = defaultTeamAccessAppSecret
-	teamManageAppKey    = defaultTeamManageAppKey
-	teamManageAppSecret = defaultTeamManageAppSecret
+	personalAppKey   = defaultPersonalAppKey
+	teamAccessAppKey = defaultTeamAccessAppKey
+	teamManageAppKey = defaultTeamManageAppKey
 )
 
 var config dropbox.Config
 
-func oauthCredentials(tokenType string) (string, string) {
+func oauthCredentials(tokenType string) string {
 	switch tokenType {
 	case tokenPersonal:
-		return personalAppKey, personalAppSecret
+		return personalAppKey
 	case tokenTeamAccess:
-		return teamAccessAppKey, teamAccessAppSecret
+		return teamAccessAppKey
 	case tokenTeamManage:
-		return teamManageAppKey, teamManageAppSecret
+		return teamManageAppKey
 	default:
-		return "", ""
+		return ""
 	}
 }
 
-func defaultOAuthCredentials(tokenType string) (string, string) {
+func defaultOAuthCredentials(tokenType string) string {
 	switch tokenType {
 	case tokenPersonal:
-		return defaultPersonalAppKey, defaultPersonalAppSecret
+		return defaultPersonalAppKey
 	case tokenTeamAccess:
-		return defaultTeamAccessAppKey, defaultTeamAccessAppSecret
+		return defaultTeamAccessAppKey
 	case tokenTeamManage:
-		return defaultTeamManageAppKey, defaultTeamManageAppSecret
+		return defaultTeamManageAppKey
 	default:
-		return "", ""
+		return ""
 	}
 }
 
-func setOAuthCredentials(tokenType string, appKey string, appSecret string) {
+func setOAuthCredentials(tokenType string, appKey string) {
 	switch tokenType {
 	case tokenPersonal:
-		personalAppKey, personalAppSecret = appKey, appSecret
+		personalAppKey = appKey
 	case tokenTeamAccess:
-		teamAccessAppKey, teamAccessAppSecret = appKey, appSecret
+		teamAccessAppKey = appKey
 	case tokenTeamManage:
-		teamManageAppKey, teamManageAppSecret = appKey, appSecret
+		teamManageAppKey = appKey
 	}
 }
 
 func needsOAuthCredentialsOverride(tokenType string) bool {
-	appKey, appSecret := oauthCredentials(tokenType)
-	defaultAppKey, defaultAppSecret := defaultOAuthCredentials(tokenType)
-	if appKey == "" || appSecret == "" {
+	appKey := oauthCredentials(tokenType)
+	defaultAppKey := defaultOAuthCredentials(tokenType)
+	if appKey == "" {
 		return true
 	}
-	return defaultAppKey != "" && defaultAppSecret != "" &&
-		appKey == defaultAppKey && appSecret == defaultAppSecret
+	return defaultAppKey != "" && appKey == defaultAppKey
 }
 
 func validatePath(p string) (path string, err error) {
@@ -198,11 +191,8 @@ func Execute() {
 
 func loadOAuthCredentialsFromEnv() {
 	personalAppKey = getEnv("DROPBOX_PERSONAL_APP_KEY", personalAppKey)
-	personalAppSecret = getEnv("DROPBOX_PERSONAL_APP_SECRET", personalAppSecret)
 	teamAccessAppKey = getEnv("DROPBOX_TEAM_APP_KEY", teamAccessAppKey)
-	teamAccessAppSecret = getEnv("DROPBOX_TEAM_APP_SECRET", teamAccessAppSecret)
 	teamManageAppKey = getEnv("DROPBOX_MANAGE_APP_KEY", teamManageAppKey)
-	teamManageAppSecret = getEnv("DROPBOX_MANAGE_APP_SECRET", teamManageAppSecret)
 }
 
 func init() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
 )
 
 func TestRootCmdUnknownCommandReturnsError(t *testing.T) {
@@ -93,6 +96,44 @@ func TestInitDbxAccessTokenEnvTakesPrecedenceOverAuthFile(t *testing.T) {
 	}
 }
 
+func TestInitDbxAccessTokenEnvBypassesRefresh(t *testing.T) {
+	origConfig := config
+	defer func() { config = origConfig }()
+	restoreOAuthCredentials(t)
+
+	expired := time.Now().Add(-time.Hour)
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	if err := writeTokens(authFile, TokenMap{
+		"": {
+			tokenPersonal: {
+				AccessToken:  "file-token",
+				RefreshToken: "refresh-token",
+				Expiry:       &expired,
+				AppKey:       "app-key",
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	refreshOAuthToken = func(ctx context.Context, conf *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
+		t.Fatal("refresh should not run when DBXCLI_ACCESS_TOKEN is set")
+		return nil, nil
+	}
+
+	t.Setenv(envAccessToken, "env-token")
+	t.Setenv(envAuthFile, authFile)
+
+	cmd := newAuthTestCommand()
+	if err := initDbx(cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if config.Token != "env-token" {
+		t.Fatalf("expected %s to take precedence, got %q", envAccessToken, config.Token)
+	}
+}
+
 func TestInitDbxUsesAuthFileEnv(t *testing.T) {
 	origConfig := config
 	defer func() { config = origConfig }()
@@ -138,26 +179,26 @@ func unsetEnvForTest(t *testing.T, key string) {
 	})
 }
 
-func TestLoadOAuthCredentialsFromEnvKeepsTeamManageSecretFallback(t *testing.T) {
+func TestLoadOAuthCredentialsFromEnvKeepsAppKeyFallbacks(t *testing.T) {
 	restoreOAuthCredentials(t)
 
 	for _, key := range []string{
 		"DROPBOX_PERSONAL_APP_KEY",
-		"DROPBOX_PERSONAL_APP_SECRET",
 		"DROPBOX_TEAM_APP_KEY",
-		"DROPBOX_TEAM_APP_SECRET",
 		"DROPBOX_MANAGE_APP_KEY",
-		"DROPBOX_MANAGE_APP_SECRET",
 	} {
 		unsetEnvForTest(t, key)
 	}
 
-	teamAccessAppSecret = "team-access-secret"
-	teamManageAppSecret = "team-manage-secret"
+	teamAccessAppKey = "team-access-key"
+	teamManageAppKey = "team-manage-key"
 
 	loadOAuthCredentialsFromEnv()
 
-	if teamManageAppSecret != "team-manage-secret" {
-		t.Fatalf("expected team manage secret fallback, got %q", teamManageAppSecret)
+	if teamManageAppKey != "team-manage-key" {
+		t.Fatalf("expected team manage app key fallback, got %q", teamManageAppKey)
+	}
+	if teamAccessAppKey != "team-access-key" {
+		t.Fatalf("expected team access app key fallback, got %q", teamAccessAppKey)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,9 @@ require (
 	github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/oauth2 v0.36.0
-	golang.org/x/term v0.32.0
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/sys v0.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -234,10 +234,6 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
-golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
-golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
## Summary

- Replace client-secret OAuth flow with PKCE (S256) — app secrets are no longer needed, only the app key
- Request `token_access_type=offline` to obtain refresh tokens from Dropbox
- Automatically refresh expired access tokens using stored refresh tokens (pre-emptive refresh 5 minutes before expiry)
- Stored credentials use a new JSON object format in `auth.json`; legacy bare-string entries are read transparently via custom `UnmarshalJSON`
- Remove `golang.org/x/term` dependency (no longer needed for secret masking)

## Test plan

- [x] `go build` succeeds
- [x] All unit tests pass (`go test ./...`)
- [ ] Manual: `dbxcli login` — verify PKCE auth URL contains `code_challenge` and `token_access_type=offline`
- [ ] Manual: complete login flow, verify `auth.json` contains object with `refresh_token`
- [ ] Manual: wait for token expiry (or manually expire), verify auto-refresh works
- [ ] Manual: `dbxcli logout` — verify tokens are revoked
- [ ] Manual: existing legacy `auth.json` (bare token string) is read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)