### PR TITLE
Add --recursive, --permanent flags to rm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ $ dbxcli get /remote/file.txt ./local-file.txt     # download a single file
 $ dbxcli get -r /remote/folder ./local-folder      # recursively download a folder
 ```
 
+### Removing files and folders
+
+```sh
+$ dbxcli rm /remote/file.txt                       # move a file to Dropbox trash
+$ dbxcli rm -r /remote/folder                      # remove a non-empty folder
+$ dbxcli rm --permanent /remote/file.txt           # permanently delete when Dropbox permits it
+```
+
 ### Creating directories
 
 ```sh

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -16,10 +16,12 @@ type mockFilesClient struct {
 	uploadSessionFinishFn   func(arg *files.UploadSessionFinishArg, content io.Reader) (*files.FileMetadata, error)
 	copyV2Fn                func(arg *files.RelocationArg) (*files.RelocationResult, error)
 	createFolderV2Fn        func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error)
+	deleteV2Fn              func(arg *files.DeleteArg) (*files.DeleteResult, error)
 	getMetadataFn           func(arg *files.GetMetadataArg) (files.IsMetadata, error)
 	listFolderFn            func(arg *files.ListFolderArg) (*files.ListFolderResult, error)
 	listFolderContinueFn    func(arg *files.ListFolderContinueArg) (*files.ListFolderResult, error)
 	moveV2Fn                func(arg *files.RelocationArg) (*files.RelocationResult, error)
+	permanentlyDeleteFn     func(arg *files.DeleteArg) error
 }
 
 func (m *mockFilesClient) Download(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
@@ -107,6 +109,9 @@ func (m *mockFilesClient) CreateFolderBatchCheck(arg *async.PollArg) (*files.Cre
 	return nil, nil
 }
 func (m *mockFilesClient) DeleteV2(arg *files.DeleteArg) (*files.DeleteResult, error) {
+	if m.deleteV2Fn != nil {
+		return m.deleteV2Fn(arg)
+	}
 	return nil, nil
 }
 func (m *mockFilesClient) Delete(arg *files.DeleteArg) (files.IsMetadata, error) { return nil, nil }
@@ -200,7 +205,12 @@ func (m *mockFilesClient) PaperCreate(arg *files.PaperCreateArg, content io.Read
 func (m *mockFilesClient) PaperUpdate(arg *files.PaperUpdateArg, content io.Reader) (*files.PaperUpdateResult, error) {
 	return nil, nil
 }
-func (m *mockFilesClient) PermanentlyDelete(arg *files.DeleteArg) error { return nil }
+func (m *mockFilesClient) PermanentlyDelete(arg *files.DeleteArg) error {
+	if m.permanentlyDeleteFn != nil {
+		return m.permanentlyDeleteFn(arg)
+	}
+	return nil
+}
 func (m *mockFilesClient) PropertiesAdd(arg *file_properties.AddPropertiesArg) error {
 	return nil
 }

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -23,64 +23,226 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type removeOptions struct {
+	force     bool
+	recursive bool
+	permanent bool
+	verbose   bool
+}
+
+type removeTarget struct {
+	path     string
+	metadata files.IsMetadata
+}
+
+type removeInput struct {
+	Path      string `json:"path"`
+	Permanent bool   `json:"permanent"`
+	Recursive bool   `json:"recursive"`
+	Force     bool   `json:"force"`
+}
+
+type removeMetadata struct {
+	Type        string `json:"type"`
+	PathDisplay string `json:"path_display,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Rev         string `json:"rev,omitempty"`
+	Size        uint64 `json:"size,omitempty"`
+}
+
+type removeResult struct {
+	Input  removeInput    `json:"input"`
+	Result removeMetadata `json:"result"`
+}
+
 func rm(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("rm: missing operand")
 	}
 
-	force, err := cmd.Flags().GetBool("force")
+	opts, err := parseRemoveOptions(cmd)
 	if err != nil {
 		return err
 	}
 
-	var deletePaths []string
-	dbx := files.New(config)
+	dbx := filesNewFunc(config)
 
-	// Validate remove paths before executing removal
-	for i := range args {
-		path, err := validatePath(args[i])
-		if err != nil {
-			return err
-		}
-
-		pathMetaData, err := getFileMetadata(dbx, path)
-		if err != nil {
-			return err
-		}
-
-		if _, ok := pathMetaData.(*files.FileMetadata); !ok {
-			folderArg := files.NewListFolderArg(path)
-			res, err := dbx.ListFolder(folderArg)
-			if err != nil {
-				return err
-			}
-			if len(res.Entries) != 0 && !force {
-				return fmt.Errorf("rm: cannot remove ‘%s’: Directory not empty, use `--force` or `-f` to proceed", path)
-			}
-		}
-		deletePaths = append(deletePaths, path)
+	targets, err := validateRemoveTargets(dbx, args, opts)
+	if err != nil {
+		return err
 	}
 
-	// Execute removals
-	for _, path := range deletePaths {
-		arg := files.NewDeleteArg(path)
+	results, err := removeTargets(dbx, targets, opts)
+	if err != nil {
+		return err
+	}
 
-		if _, err = dbx.DeleteV2(arg); err != nil {
-			return err
-		}
+	if opts.verbose {
+		printRemoveResults(cmd, results)
 	}
 
 	return nil
 }
 
+func parseRemoveOptions(cmd *cobra.Command) (removeOptions, error) {
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return removeOptions{}, err
+	}
+
+	recursive, err := cmd.Flags().GetBool("recursive")
+	if err != nil {
+		return removeOptions{}, err
+	}
+
+	permanent, err := cmd.Flags().GetBool("permanent")
+	if err != nil {
+		return removeOptions{}, err
+	}
+
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	return removeOptions{
+		force:     force,
+		recursive: recursive,
+		permanent: permanent,
+		verbose:   verbose,
+	}, nil
+}
+
+func validateRemoveTargets(dbx files.Client, args []string, opts removeOptions) ([]removeTarget, error) {
+	var targets []removeTarget
+
+	// Validate remove paths before executing removal
+	for i := range args {
+		path, err := validatePath(args[i])
+		if err != nil {
+			return nil, err
+		}
+
+		pathMetaData, err := getFileMetadata(dbx, path)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, ok := pathMetaData.(*files.FileMetadata); !ok && !opts.allowNonEmptyFolder() {
+			folderArg := files.NewListFolderArg(path)
+			res, err := dbx.ListFolder(folderArg)
+			if err != nil {
+				return nil, err
+			}
+			if len(res.Entries) != 0 {
+				return nil, fmt.Errorf("rm: cannot remove ‘%s’: Directory not empty, use `--force`/`-f` or `--recursive`/`-r` to proceed", path)
+			}
+		}
+		targets = append(targets, removeTarget{path: path, metadata: pathMetaData})
+	}
+
+	return targets, nil
+}
+
+func removeTargets(dbx files.Client, targets []removeTarget, opts removeOptions) ([]removeResult, error) {
+	results := make([]removeResult, 0, len(targets))
+
+	for _, target := range targets {
+		arg := files.NewDeleteArg(target.path)
+		metadata := target.metadata
+
+		if opts.permanent {
+			if err := dbx.PermanentlyDelete(arg); err != nil {
+				return nil, err
+			}
+		} else {
+			res, err := dbx.DeleteV2(arg)
+			if err != nil {
+				return nil, err
+			}
+			if res != nil && res.Metadata != nil {
+				metadata = res.Metadata
+			}
+		}
+
+		results = append(results, newRemoveResult(target.path, metadata, opts))
+	}
+
+	return results, nil
+}
+
+func newRemoveResult(path string, metadata files.IsMetadata, opts removeOptions) removeResult {
+	return removeResult{
+		Input: removeInput{
+			Path:      path,
+			Permanent: opts.permanent,
+			Recursive: opts.recursive,
+			Force:     opts.force,
+		},
+		Result: removeMetadataFromDropbox(path, metadata),
+	}
+}
+
+func removeMetadataFromDropbox(path string, metadata files.IsMetadata) removeMetadata {
+	switch m := metadata.(type) {
+	case *files.FileMetadata:
+		return removeMetadata{
+			Type:        "file",
+			PathDisplay: metadataDisplayPath(path, m.PathDisplay),
+			ID:          m.Id,
+			Rev:         m.Rev,
+			Size:        m.Size,
+		}
+	case *files.FolderMetadata:
+		return removeMetadata{
+			Type:        "folder",
+			PathDisplay: metadataDisplayPath(path, m.PathDisplay),
+			ID:          m.Id,
+		}
+	default:
+		return removeMetadata{
+			Type:        "unknown",
+			PathDisplay: path,
+		}
+	}
+}
+
+func metadataDisplayPath(inputPath, metadataPath string) string {
+	if metadataPath != "" {
+		return metadataPath
+	}
+	return inputPath
+}
+
+func printRemoveResults(cmd *cobra.Command, results []removeResult) {
+	out := commandOutput(cmd)
+	for _, result := range results {
+		if result.Input.Permanent {
+			out.Info("Permanently deleted %s", result.displayPath())
+			continue
+		}
+		out.Info("Deleted %s", result.displayPath())
+	}
+}
+
+func (r removeResult) displayPath() string {
+	if r.Result.PathDisplay != "" {
+		return r.Result.PathDisplay
+	}
+	return r.Input.Path
+}
+
+func (o removeOptions) allowNonEmptyFolder() bool {
+	return o.force || o.recursive
+}
+
 // rmCmd represents the rm command
 var rmCmd = &cobra.Command{
 	Use:   "rm [flags] <file>",
-	Short: "Remove files",
+	Short: "Remove files or folders",
 	RunE:  rm,
 }
 
 func init() {
 	RootCmd.AddCommand(rmCmd)
-	rmCmd.Flags().BoolP("force", "f", false, "Force removal")
+	rmCmd.Flags().BoolP("force", "f", false, "Allow removing non-empty folders; same as --recursive")
+	rmCmd.Flags().BoolP("recursive", "r", false, "Recursively remove folders")
+	rmCmd.Flags().Bool("permanent", false, "Permanently delete instead of moving to Dropbox trash")
 }

--- a/cmd/rm_test.go
+++ b/cmd/rm_test.go
@@ -1,0 +1,382 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/spf13/cobra"
+)
+
+func testRmCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{Use: "rm"}
+	cmd.SetOut(&stdout)
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().BoolP("recursive", "r", false, "")
+	cmd.Flags().Bool("permanent", false, "")
+	cmd.Flags().BoolP("verbose", "v", false, "")
+	return cmd, &stdout
+}
+
+func setRmFlag(t *testing.T, cmd *cobra.Command, name string) {
+	t.Helper()
+
+	if err := cmd.Flags().Set(name, "true"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func rmFileMetadata(path string) *files.FileMetadata {
+	return &files.FileMetadata{
+		Metadata: files.Metadata{
+			Name:        strings.TrimPrefix(path, "/"),
+			PathDisplay: path,
+		},
+		Id:   "id:file",
+		Rev:  "rev",
+		Size: 123,
+	}
+}
+
+func rmFolderMetadata(path string) *files.FolderMetadata {
+	return &files.FolderMetadata{
+		Metadata: files.Metadata{
+			Name:        strings.TrimPrefix(path, "/"),
+			PathDisplay: path,
+		},
+		Id: "id:folder",
+	}
+}
+
+func rmNonEmptyFolderResult() *files.ListFolderResult {
+	return &files.ListFolderResult{
+		Entries: []files.IsMetadata{rmFileMetadata("/folder/file.txt")},
+	}
+}
+
+func TestRmFileDeletesWithDeleteV2(t *testing.T) {
+	cmd, stdout := testRmCmd(t)
+	file := rmFileMetadata("/file.txt")
+	var deleted []string
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return file, nil
+		},
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			t.Fatalf("ListFolder called for file: %v", arg)
+			return nil, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			deleted = append(deleted, arg.Path)
+			return files.NewDeleteResult(file), nil
+		},
+		permanentlyDeleteFn: func(arg *files.DeleteArg) error {
+			t.Fatalf("PermanentlyDelete called for normal delete: %v", arg)
+			return nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/file.txt"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	if len(deleted) != 1 || deleted[0] != "/file.txt" {
+		t.Fatalf("deleted = %v, want [/file.txt]", deleted)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want quiet success", got)
+	}
+}
+
+func TestRmNonEmptyFolderRequiresRecursiveOrForce(t *testing.T) {
+	cmd, _ := testRmCmd(t)
+	deleteCalled := false
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return rmFolderMetadata("/folder"), nil
+		},
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			return rmNonEmptyFolderResult(), nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			deleteCalled = true
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := rm(cmd, []string{"/folder"})
+	if err == nil {
+		t.Fatal("expected error for non-empty folder without recursive or force")
+	}
+	if !strings.Contains(err.Error(), "--recursive") || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("error = %q, want recursive and force guidance", err.Error())
+	}
+	if deleteCalled {
+		t.Fatal("delete called after validation failure")
+	}
+}
+
+func TestRmRecursiveDeletesNonEmptyFolder(t *testing.T) {
+	cmd, _ := testRmCmd(t)
+	setRmFlag(t, cmd, "recursive")
+	var deleted []string
+	folder := rmFolderMetadata("/folder")
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return folder, nil
+		},
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			t.Fatalf("ListFolder called when --recursive already allows folder removal: %v", arg)
+			return nil, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			deleted = append(deleted, arg.Path)
+			return files.NewDeleteResult(folder), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/folder"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	if len(deleted) != 1 || deleted[0] != "/folder" {
+		t.Fatalf("deleted = %v, want [/folder]", deleted)
+	}
+}
+
+func TestRmForceStillDeletesNonEmptyFolder(t *testing.T) {
+	cmd, _ := testRmCmd(t)
+	setRmFlag(t, cmd, "force")
+	var deleted []string
+	folder := rmFolderMetadata("/folder")
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return folder, nil
+		},
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			t.Fatalf("ListFolder called when --force already allows folder removal: %v", arg)
+			return nil, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			deleted = append(deleted, arg.Path)
+			return files.NewDeleteResult(folder), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/folder"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	if len(deleted) != 1 || deleted[0] != "/folder" {
+		t.Fatalf("deleted = %v, want [/folder]", deleted)
+	}
+}
+
+func TestRemoveResultInputKeepsForceAndRecursiveSeparate(t *testing.T) {
+	result := newRemoveResult("/folder", rmFolderMetadata("/folder"), removeOptions{force: true})
+	if !result.Input.Force {
+		t.Fatal("Force = false, want true")
+	}
+	if result.Input.Recursive {
+		t.Fatal("Recursive = true for force-only delete, want false")
+	}
+
+	result = newRemoveResult("/folder", rmFolderMetadata("/folder"), removeOptions{recursive: true})
+	if result.Input.Force {
+		t.Fatal("Force = true for recursive-only delete, want false")
+	}
+	if !result.Input.Recursive {
+		t.Fatal("Recursive = false, want true")
+	}
+}
+
+func TestRmPermanentCallsPermanentlyDelete(t *testing.T) {
+	cmd, stdout := testRmCmd(t)
+	setRmFlag(t, cmd, "permanent")
+	file := rmFileMetadata("/file.txt")
+	var permanentlyDeleted []string
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return file, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			t.Fatalf("DeleteV2 called for permanent delete: %v", arg)
+			return nil, nil
+		},
+		permanentlyDeleteFn: func(arg *files.DeleteArg) error {
+			permanentlyDeleted = append(permanentlyDeleted, arg.Path)
+			return nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/file.txt"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	if len(permanentlyDeleted) != 1 || permanentlyDeleted[0] != "/file.txt" {
+		t.Fatalf("permanentlyDeleted = %v, want [/file.txt]", permanentlyDeleted)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want quiet success", got)
+	}
+}
+
+func TestRmPermanentRecursiveDeletesNonEmptyFolder(t *testing.T) {
+	cmd, _ := testRmCmd(t)
+	setRmFlag(t, cmd, "permanent")
+	setRmFlag(t, cmd, "recursive")
+	folder := rmFolderMetadata("/folder")
+	var permanentlyDeleted []string
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return folder, nil
+		},
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			t.Fatalf("ListFolder called when --recursive already allows folder removal: %v", arg)
+			return nil, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			t.Fatalf("DeleteV2 called for permanent delete: %v", arg)
+			return nil, nil
+		},
+		permanentlyDeleteFn: func(arg *files.DeleteArg) error {
+			permanentlyDeleted = append(permanentlyDeleted, arg.Path)
+			return nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/folder"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	if len(permanentlyDeleted) != 1 || permanentlyDeleted[0] != "/folder" {
+		t.Fatalf("permanentlyDeleted = %v, want [/folder]", permanentlyDeleted)
+	}
+}
+
+func TestRmValidatesAllTargetsBeforeDeleting(t *testing.T) {
+	cmd, _ := testRmCmd(t)
+	deleted := false
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			switch arg.Path {
+			case "/file.txt":
+				return rmFileMetadata("/file.txt"), nil
+			case "/folder":
+				return rmFolderMetadata("/folder"), nil
+			default:
+				return nil, fmt.Errorf("unexpected metadata path %q", arg.Path)
+			}
+		},
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			return rmNonEmptyFolderResult(), nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			deleted = true
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := rm(cmd, []string{"/file.txt", "/folder"})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if deleted {
+		t.Fatal("deleted first target before validating later target")
+	}
+}
+
+func TestRmVerbosePrintsDeleteResults(t *testing.T) {
+	cmd, stdout := testRmCmd(t)
+	setRmFlag(t, cmd, "verbose")
+	file := rmFileMetadata("/File.txt")
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return file, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			return files.NewDeleteResult(file), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/file.txt"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	if got, want := stdout.String(), "Deleted /File.txt\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRmVerboseUsesInheritedFlag(t *testing.T) {
+	var stdout bytes.Buffer
+	root := &cobra.Command{Use: "dbxcli"}
+	root.PersistentFlags().BoolP("verbose", "v", false, "")
+	cmd := &cobra.Command{
+		Use:  "rm",
+		RunE: rm,
+	}
+	cmd.SetOut(&stdout)
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().BoolP("recursive", "r", false, "")
+	cmd.Flags().Bool("permanent", false, "")
+	root.AddCommand(cmd)
+	root.SetArgs([]string{"rm", "--verbose", "/file.txt"})
+
+	file := rmFileMetadata("/File.txt")
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return file, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			return files.NewDeleteResult(file), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	if got, want := stdout.String(), "Deleted /File.txt\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRmVerbosePrintsPermanentDeleteResults(t *testing.T) {
+	cmd, stdout := testRmCmd(t)
+	setRmFlag(t, cmd, "permanent")
+	setRmFlag(t, cmd, "verbose")
+	file := rmFileMetadata("/File.txt")
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return file, nil
+		},
+		permanentlyDeleteFn: func(arg *files.DeleteArg) error {
+			return nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/file.txt"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	if got, want := stdout.String(), "Permanently deleted /File.txt\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `--recursive`/`-r` as the explicit flag for removing non-empty folders
- Keep `--force`/`-f` as a backwards-compatible equivalent
- Add `--permanent` to permanently delete instead of moving to Dropbox trash
- With `-v`/`--verbose`, print what was deleted
- Refactor rm into validate-then-execute phases; skip unnecessary `ListFolder` API call when recursive/force is set
- Use `filesNewFunc` for testability with mock client

## Test plan

- [x] `go vet ./...` passes
- [x] All unit tests pass (`go test ./...`)
- [x] Manual: `dbxcli rm /file.txt` — deletes file (trash)
- [x] Manual: `dbxcli rm /non-empty-folder` — fails with guidance message
- [x] Manual: `dbxcli rm -r /non-empty-folder` — deletes folder
- [x] Manual: `dbxcli rm -f /non-empty-folder` — deletes folder (backwards compat)
- [x] Manual: `dbxcli rm --permanent /file.txt` — permanently deletes
- [x] Manual: `dbxcli rm -v /file.txt` — prints "Deleted /file.txt"
- [x] Manual: `dbxcli rm -v --permanent /file.txt` — prints "Permanently deleted /file.txt"
