### PR TITLE
Add --if-exists flag to put command

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,10 @@ The `--verbose` option will turn on verbose logging and is useful for debugging.
 $ dbxcli put file.txt /destination/file.txt        # upload a single file
 $ dbxcli put -r ./project /backup/project          # recursively upload a directory
 $ dbxcli put -r -w 8 ./large-folder /backup/large  # use 8 workers per large file
+$ dbxcli put --if-exists skip file.txt /dest.txt   # skip if the file already exists
 ```
+
+By default, `put` overwrites existing destination files. Use `--if-exists overwrite|skip|fail` to choose whether existing files are overwritten, skipped, or treated as an error.
 
 ### Downloading files and directories
 

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -47,11 +47,6 @@ func printFolderMetadata(w io.Writer, e *files.FolderMetadata, longFormat bool) 
 	_, _ = fmt.Fprint(w, formatFolderMetadata(e, longFormat))
 }
 
-// Invoked by search.go and revs.go
-func printFileMetadata(w io.Writer, e *files.FileMetadata, longFormat bool) {
-	_, _ = fmt.Fprint(w, formatFileMetadata(e, longFormat))
-}
-
 func formatFolderMetadata(e *files.FolderMetadata, longFormat bool) string {
 	text := fmt.Sprintf("%s\t", e.PathDisplay)
 	if longFormat {

--- a/cmd/pipe_test.go
+++ b/cmd/pipe_test.go
@@ -19,6 +19,15 @@ func testPutCmdWithStdin(stdin io.Reader) *cobra.Command {
 	return cmd
 }
 
+type failReadReader struct {
+	t *testing.T
+}
+
+func (r failReadReader) Read(_ []byte) (int, error) {
+	r.t.Fatal("stdin should not be read")
+	return 0, io.EOF
+}
+
 func TestPutStdin_RequiresTarget(t *testing.T) {
 	cmd := testPutCmdWithStdin(strings.NewReader("data"))
 	err := put(cmd, []string{"-"})
@@ -100,6 +109,32 @@ func TestPutStdin_UploadsContent(t *testing.T) {
 	}
 	if !strings.Contains(string(uploadedContent), content) {
 		t.Errorf("uploaded content = %q, want to contain %q", uploadedContent, content)
+	}
+}
+
+func TestPutStdinIfExistsSkipDoesNotReadStdin(t *testing.T) {
+	cmd := testPutCmdWithStdin(failReadReader{t: t})
+	_ = cmd.Flags().Set("if-exists", "skip")
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return &files.FileMetadata{Metadata: files.Metadata{PathDisplay: arg.Path}}, nil
+		},
+		uploadFn: func(arg *files.UploadArg, r io.Reader) (*files.FileMetadata, error) {
+			t.Fatal("upload should not be called for existing destination with --if-exists skip")
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := put(cmd, []string{"-", "/existing.txt"})
+	if err != nil {
+		t.Fatalf("put stdin error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Skipping /existing.txt") {
+		t.Errorf("stderr = %q, want skip message", stderr.String())
 	}
 }
 

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dropbox/dbxcli/internal/output"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 	"github.com/dustin/go-humanize"
@@ -35,6 +36,12 @@ import (
 )
 
 const singleShotUploadSizeCutoff int64 = 32 * (1 << 20)
+
+const (
+	putIfExistsOverwrite = "overwrite"
+	putIfExistsSkip      = "skip"
+	putIfExistsFail      = "fail"
+)
 
 var filesNewFunc = func(cfg dropbox.Config) files.Client {
 	return files.New(cfg)
@@ -187,7 +194,16 @@ type putOptions struct {
 	chunkSize int64
 	workers   int
 	debug     bool
+	ifExists  string
+	output    *output.Renderer
 }
+
+type putDestinationAction int
+
+const (
+	putDestinationUpload putDestinationAction = iota
+	putDestinationSkip
+)
 
 func put(cmd *cobra.Command, args []string) (err error) {
 	if len(args) == 0 || len(args) > 2 {
@@ -257,8 +273,13 @@ func putStdin(cmd *cobra.Command, args []string, opts putOptions, recursive bool
 	}
 
 	dbx := filesNewFunc(config)
-	if isRemoteFolder(dbx, dstPath) {
-		return fmt.Errorf("cannot upload stdin to folder %q; provide a full Dropbox file path", dstPath)
+	action, err := checkPutStdinDestination(dbx, dstPath, opts.ifExists)
+	if err != nil {
+		return err
+	}
+	if action == putDestinationSkip {
+		reportPutSkipped(opts, dstPath)
+		return nil
 	}
 
 	tmpPath, _, cleanup, err := spoolStdinToTemp(cmd.InOrStdin())
@@ -271,21 +292,21 @@ func putStdin(cmd *cobra.Command, args []string, opts putOptions, recursive bool
 
 	if uploadErr != nil {
 		if cleanupErr != nil {
-			reportStdinCleanupFailure(tmpPath, cleanupErr)
+			reportStdinCleanupFailure(opts, tmpPath, cleanupErr)
 		}
 		return uploadErr
 	}
 
 	if cleanupErr != nil {
-		reportStdinCleanupFailure(tmpPath, cleanupErr)
+		reportStdinCleanupFailure(opts, tmpPath, cleanupErr)
 		return fmt.Errorf("failed to remove temp file %s after upload; sensitive stdin data may remain on disk: %w", tmpPath, cleanupErr)
 	}
 
 	return nil
 }
 
-func reportStdinCleanupFailure(tmpPath string, err error) {
-	fmt.Fprintf(os.Stderr, "error: failed to remove temp file %s: %v; sensitive stdin data may remain on disk\n", tmpPath, err)
+func reportStdinCleanupFailure(opts putOptions, tmpPath string, err error) {
+	putOutput(opts).Status("error: failed to remove temp file %s: %v; sensitive stdin data may remain on disk", tmpPath, err)
 }
 
 func resolveDestination(dbx files.Client, src, dst string, dstIsDir bool) string {
@@ -318,10 +339,55 @@ func parsePutOptions(cmd *cobra.Command) (putOptions, error) {
 		workers = 1
 	}
 	debug, _ := cmd.Flags().GetBool("debug")
-	return putOptions{chunkSize: chunkSize, workers: workers, debug: debug}, nil
+	ifExists, err := parsePutIfExists(cmd)
+	if err != nil {
+		return putOptions{}, err
+	}
+	return putOptions{
+		chunkSize: chunkSize,
+		workers:   workers,
+		debug:     debug,
+		ifExists:  ifExists,
+		output:    commandOutput(cmd),
+	}, nil
+}
+
+func parsePutIfExists(cmd *cobra.Command) (string, error) {
+	ifExists, err := cmd.Flags().GetString("if-exists")
+	if err != nil {
+		return "", err
+	}
+	return normalizePutIfExists(ifExists)
+}
+
+func normalizePutIfExists(ifExists string) (string, error) {
+	if ifExists == "" {
+		return putIfExistsOverwrite, nil
+	}
+	switch ifExists {
+	case putIfExistsOverwrite, putIfExistsSkip, putIfExistsFail:
+		return ifExists, nil
+	default:
+		return "", fmt.Errorf("invalid --if-exists %q (use overwrite, skip, or fail)", ifExists)
+	}
 }
 
 func putFile(src, dst string, opts putOptions) error {
+	ifExists, err := normalizePutIfExists(opts.ifExists)
+	if err != nil {
+		return err
+	}
+
+	dbx := filesNewFunc(config)
+	action, err := checkPutDestination(dbx, dst, ifExists)
+	if err != nil {
+		return err
+	}
+	if action == putDestinationSkip {
+		reportPutSkipped(opts, dst)
+		return nil
+	}
+
 	contents, err := os.Open(src)
 	if err != nil {
 		return err
@@ -334,19 +400,179 @@ func putFile(src, dst string, opts putOptions) error {
 	}
 
 	commitInfo := files.NewCommitInfo(dst)
-	commitInfo.Mode.Tag = "overwrite"
+	commitInfo.Mode.Tag = writeModeForIfExists(ifExists)
+	commitInfo.StrictConflict = ifExists != putIfExistsOverwrite
 
 	// The Dropbox API only accepts timestamps in UTC with second precision.
 	ts := time.Now().UTC().Round(time.Second)
 	commitInfo.ClientModified = &ts
 
-	dbx := filesNewFunc(config)
 	if contentsInfo.Size() > singleShotUploadSizeCutoff {
-		return uploadChunked(dbx, uploadProgressReader(contents, contentsInfo.Size()), commitInfo, contentsInfo.Size(), opts.workers, opts.chunkSize, opts.debug)
+		err = uploadChunked(dbx, uploadProgressReader(contents, contentsInfo.Size()), commitInfo, contentsInfo.Size(), opts.workers, opts.chunkSize, opts.debug)
+		if err != nil && ifExists == putIfExistsSkip && isUploadDestinationFileConflict(err) {
+			reportPutSkipped(opts, dst)
+			return nil
+		}
+		return err
 	}
 
 	uploadArg := &files.UploadArg{CommitInfo: *commitInfo}
-	return uploadSingleShot(dbx, contents, uploadArg, contentsInfo.Size())
+	err = uploadSingleShot(dbx, contents, uploadArg, contentsInfo.Size())
+	if err != nil && ifExists == putIfExistsSkip && isUploadDestinationFileConflict(err) {
+		reportPutSkipped(opts, dst)
+		return nil
+	}
+	return err
+}
+
+func writeModeForIfExists(ifExists string) string {
+	if ifExists == putIfExistsOverwrite {
+		return files.WriteModeOverwrite
+	}
+	return files.WriteModeAdd
+}
+
+func checkPutStdinDestination(dbx files.Client, dst string, ifExists string) (putDestinationAction, error) {
+	ifExists, err := normalizePutIfExists(ifExists)
+	if err != nil {
+		return putDestinationUpload, err
+	}
+
+	meta, exists, err := getDestinationMetadata(dbx, dst)
+	if err != nil {
+		if ifExists == putIfExistsOverwrite {
+			return putDestinationUpload, nil
+		}
+		return putDestinationUpload, err
+	}
+	if !exists {
+		return putDestinationUpload, nil
+	}
+	if _, ok := meta.(*files.FolderMetadata); ok {
+		return putDestinationUpload, fmt.Errorf("cannot upload stdin to folder %q; provide a full Dropbox file path", dst)
+	}
+	return actionForExistingDestination(dst, ifExists)
+}
+
+func checkPutDestination(dbx files.Client, dst string, ifExists string) (putDestinationAction, error) {
+	ifExists, err := normalizePutIfExists(ifExists)
+	if err != nil {
+		return putDestinationUpload, err
+	}
+	if ifExists == putIfExistsOverwrite {
+		return putDestinationUpload, nil
+	}
+
+	meta, exists, err := getDestinationMetadata(dbx, dst)
+	if err != nil {
+		return putDestinationUpload, err
+	}
+	if !exists {
+		return putDestinationUpload, nil
+	}
+	if _, ok := meta.(*files.FolderMetadata); ok {
+		return putDestinationUpload, fmt.Errorf("destination %q is a folder", dst)
+	}
+	return actionForExistingDestination(dst, ifExists)
+}
+
+func actionForExistingDestination(dst string, ifExists string) (putDestinationAction, error) {
+	switch ifExists {
+	case putIfExistsSkip:
+		return putDestinationSkip, nil
+	case putIfExistsFail:
+		return putDestinationUpload, fmt.Errorf("destination %q already exists", dst)
+	default:
+		return putDestinationUpload, nil
+	}
+}
+
+func getDestinationMetadata(dbx files.Client, dst string) (files.IsMetadata, bool, error) {
+	meta, err := dbx.GetMetadata(files.NewGetMetadataArg(dst))
+	if err != nil {
+		if isGetMetadataNotFoundError(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return meta, true, nil
+}
+
+func isGetMetadataNotFoundError(err error) bool {
+	var apiErr files.GetMetadataAPIError
+	if errors.As(err, &apiErr) {
+		return getMetadataAPIErrorIsNotFound(&apiErr)
+	}
+	var apiErrPtr *files.GetMetadataAPIError
+	if errors.As(err, &apiErrPtr) {
+		return getMetadataAPIErrorIsNotFound(apiErrPtr)
+	}
+	return false
+}
+
+func getMetadataAPIErrorIsNotFound(err *files.GetMetadataAPIError) bool {
+	return err != nil &&
+		err.EndpointError != nil &&
+		err.EndpointError.Path != nil &&
+		err.EndpointError.Path.Tag == files.LookupErrorNotFound
+}
+
+func isUploadDestinationFileConflict(err error) bool {
+	var uploadErr files.UploadAPIError
+	if errors.As(err, &uploadErr) &&
+		uploadErr.EndpointError != nil &&
+		uploadErr.EndpointError.Tag == files.UploadErrorPath &&
+		uploadErr.EndpointError.Path != nil &&
+		isWriteFileConflict(uploadErr.EndpointError.Path.Reason) {
+		return true
+	}
+
+	var uploadErrPtr *files.UploadAPIError
+	if errors.As(err, &uploadErrPtr) &&
+		uploadErrPtr != nil &&
+		uploadErrPtr.EndpointError != nil &&
+		uploadErrPtr.EndpointError.Tag == files.UploadErrorPath &&
+		uploadErrPtr.EndpointError.Path != nil &&
+		isWriteFileConflict(uploadErrPtr.EndpointError.Path.Reason) {
+		return true
+	}
+
+	var finishErr files.UploadSessionFinishAPIError
+	if errors.As(err, &finishErr) &&
+		finishErr.EndpointError != nil &&
+		finishErr.EndpointError.Tag == files.UploadSessionFinishErrorPath &&
+		isWriteFileConflict(finishErr.EndpointError.Path) {
+		return true
+	}
+
+	var finishErrPtr *files.UploadSessionFinishAPIError
+	if errors.As(err, &finishErrPtr) &&
+		finishErrPtr != nil &&
+		finishErrPtr.EndpointError != nil &&
+		finishErrPtr.EndpointError.Tag == files.UploadSessionFinishErrorPath &&
+		isWriteFileConflict(finishErrPtr.EndpointError.Path) {
+		return true
+	}
+
+	return false
+}
+
+func isWriteFileConflict(err *files.WriteError) bool {
+	return err != nil &&
+		err.Tag == files.WriteErrorConflict &&
+		err.Conflict != nil &&
+		err.Conflict.Tag == files.WriteConflictErrorFile
+}
+
+func reportPutSkipped(opts putOptions, dst string) {
+	putOutput(opts).Status("Skipping %s (already exists)", dst)
+}
+
+func putOutput(opts putOptions) *output.Renderer {
+	if opts.output != nil {
+		return opts.output
+	}
+	return output.New(nil, nil, output.FormatText)
 }
 
 func putRecursive(src, dst string, opts putOptions) error {
@@ -373,7 +599,7 @@ func putRecursive(src, dst string, opts putOptions) error {
 		dirsWithFiles[filepath.Dir(filePath)] = true
 
 		remotePath := path.Join(dst, filepath.ToSlash(relPath))
-		fmt.Fprintf(os.Stderr, "Uploading %s -> %s\n", filePath, remotePath)
+		putOutput(opts).Status("Processing %s -> %s", filePath, remotePath)
 
 		if err := putFile(filePath, remotePath, opts); err != nil {
 			uploadErrors = append(uploadErrors, fmt.Errorf("%s: %w", filePath, err))
@@ -386,7 +612,7 @@ func putRecursive(src, dst string, opts putOptions) error {
 
 	dbx := filesNewFunc(config)
 
-	fmt.Fprintf(os.Stderr, "Creating directory %s\n", dst)
+	putOutput(opts).Status("Creating directory %s", dst)
 	arg := files.NewCreateFolderArg(dst)
 	if _, mkdirErr := dbx.CreateFolderV2(arg); mkdirErr != nil {
 		if !isConflictError(mkdirErr) {
@@ -414,7 +640,7 @@ func putRecursive(src, dst string, opts putOptions) error {
 		}
 
 		remotePath := path.Join(dst, filepath.ToSlash(relPath))
-		fmt.Fprintf(os.Stderr, "Creating directory %s\n", remotePath)
+		putOutput(opts).Status("Creating directory %s", remotePath)
 		arg := files.NewCreateFolderArg(remotePath)
 		if _, mkdirErr := dbx.CreateFolderV2(arg); mkdirErr != nil {
 			if !isConflictError(mkdirErr) {
@@ -457,4 +683,5 @@ func init() {
 	putCmd.Flags().IntP("workers", "w", 4, "Number of concurrent upload workers to use")
 	putCmd.Flags().Int64P("chunksize", "c", 1<<24, "Chunk size to use (should be multiple of 4MiB)")
 	putCmd.Flags().BoolP("debug", "d", false, "Print debug timing")
+	putCmd.Flags().String("if-exists", putIfExistsOverwrite, "What to do when the destination file exists: overwrite, skip, or fail")
 }

--- a/cmd/put_test.go
+++ b/cmd/put_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -243,7 +244,59 @@ func testPutCmd() *cobra.Command {
 	cmd.Flags().IntP("workers", "w", 4, "Number of concurrent upload workers to use")
 	cmd.Flags().Int64P("chunksize", "c", 1<<24, "Chunk size to use (should be multiple of 4MiB)")
 	cmd.Flags().BoolP("debug", "d", false, "Print debug timing")
+	cmd.Flags().String("if-exists", putIfExistsOverwrite, "What to do when the destination file exists: overwrite, skip, or fail")
 	return cmd
+}
+
+func getMetadataNotFoundError() files.GetMetadataAPIError {
+	return files.GetMetadataAPIError{
+		EndpointError: &files.GetMetadataError{
+			Tagged: dropbox.Tagged{Tag: files.GetMetadataErrorPath},
+			Path: &files.LookupError{
+				Tagged: dropbox.Tagged{Tag: files.LookupErrorNotFound},
+			},
+		},
+	}
+}
+
+func writeConflictError(conflictTag string) *files.WriteError {
+	return &files.WriteError{
+		Tagged: dropbox.Tagged{Tag: files.WriteErrorConflict},
+		Conflict: &files.WriteConflictError{
+			Tagged: dropbox.Tagged{Tag: conflictTag},
+		},
+	}
+}
+
+func uploadPathConflictError(conflictTag string) files.UploadAPIError {
+	return files.UploadAPIError{
+		EndpointError: &files.UploadError{
+			Tagged: dropbox.Tagged{Tag: files.UploadErrorPath},
+			Path: files.NewUploadWriteFailed(
+				writeConflictError(conflictTag),
+				"session123",
+			),
+		},
+	}
+}
+
+func uploadSessionFinishPathConflictError(conflictTag string) files.UploadSessionFinishAPIError {
+	return files.UploadSessionFinishAPIError{
+		EndpointError: &files.UploadSessionFinishError{
+			Tagged: dropbox.Tagged{Tag: files.UploadSessionFinishErrorPath},
+			Path:   writeConflictError(conflictTag),
+		},
+	}
+}
+
+func uploadPathConflictErrorPtr(conflictTag string) *files.UploadAPIError {
+	err := uploadPathConflictError(conflictTag)
+	return &err
+}
+
+func uploadSessionFinishPathConflictErrorPtr(conflictTag string) *files.UploadSessionFinishAPIError {
+	err := uploadSessionFinishPathConflictError(conflictTag)
+	return &err
 }
 
 func TestResolveDestination_TargetIsFolder(t *testing.T) {
@@ -555,6 +608,319 @@ func TestPutChunkSizeValidation(t *testing.T) {
 	err := put(cmd, []string{tmpFile, "/test.txt"})
 	if err == nil || err.Error() != "`put` requires chunk size to be multiple of 4MiB" {
 		t.Errorf("expected chunk size validation error, got %v", err)
+	}
+}
+
+func TestPutIfExistsValidation(t *testing.T) {
+	cmd := testPutCmd()
+	_ = cmd.Flags().Set("if-exists", "replace")
+
+	_, err := parsePutOptions(cmd)
+	if err == nil {
+		t.Fatal("expected invalid --if-exists error")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("overwrite, skip, or fail")) {
+		t.Errorf("error = %q, want valid option list", err.Error())
+	}
+}
+
+func TestPutFileIfExistsSkipSkipsExistingFile(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return &files.FileMetadata{Metadata: files.Metadata{PathDisplay: arg.Path}}, nil
+		},
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			t.Fatal("upload should not be called for existing destination with --if-exists skip")
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	stderr := captureStderr(t, func() {
+		err := putFile(tmpFile, "/existing.txt", putOptions{
+			chunkSize: 1 << 24,
+			workers:   4,
+			ifExists:  putIfExistsSkip,
+		})
+		if err != nil {
+			t.Fatalf("putFile error: %v", err)
+		}
+	})
+	if !bytes.Contains([]byte(stderr), []byte("Skipping /existing.txt")) {
+		t.Errorf("stderr = %q, want skip message", stderr)
+	}
+}
+
+func TestPutFileIfExistsFailFailsExistingFile(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return &files.FileMetadata{Metadata: files.Metadata{PathDisplay: arg.Path}}, nil
+		},
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			t.Fatal("upload should not be called for existing destination with --if-exists fail")
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := putFile(tmpFile, "/existing.txt", putOptions{
+		chunkSize: 1 << 24,
+		workers:   4,
+		ifExists:  putIfExistsFail,
+	})
+	if err == nil {
+		t.Fatal("expected existing destination error")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("already exists")) {
+		t.Errorf("error = %q, want already exists", err.Error())
+	}
+}
+
+func TestPutFileIfExistsFailUploadsMissingFileWithAddMode(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var mode string
+	var strictConflict bool
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, getMetadataNotFoundError()
+		},
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			mode = arg.Mode.Tag
+			strictConflict = arg.StrictConflict
+			return &files.FileMetadata{}, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := putFile(tmpFile, "/new.txt", putOptions{
+		chunkSize: 1 << 24,
+		workers:   4,
+		ifExists:  putIfExistsFail,
+	})
+	if err != nil {
+		t.Fatalf("putFile error: %v", err)
+	}
+	if mode != files.WriteModeAdd {
+		t.Errorf("write mode = %q, want %q", mode, files.WriteModeAdd)
+	}
+	if !strictConflict {
+		t.Error("strict conflict = false, want true")
+	}
+}
+
+func TestPutFileIfExistsOverwriteUsesOverwriteMode(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	metadataCalls := 0
+	var mode string
+	var strictConflict bool
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			metadataCalls++
+			return &files.FileMetadata{}, nil
+		},
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			mode = arg.Mode.Tag
+			strictConflict = arg.StrictConflict
+			return &files.FileMetadata{}, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	err := putFile(tmpFile, "/existing.txt", putOptions{
+		chunkSize: 1 << 24,
+		workers:   4,
+		ifExists:  putIfExistsOverwrite,
+	})
+	if err != nil {
+		t.Fatalf("putFile error: %v", err)
+	}
+	if metadataCalls != 0 {
+		t.Errorf("metadata calls = %d, want 0 for overwrite", metadataCalls)
+	}
+	if mode != files.WriteModeOverwrite {
+		t.Errorf("write mode = %q, want %q", mode, files.WriteModeOverwrite)
+	}
+	if strictConflict {
+		t.Error("strict conflict = true, want false for overwrite")
+	}
+}
+
+func TestPutFileIfExistsSkipTreatsUploadFileConflictAsSkip(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var strictConflict bool
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, getMetadataNotFoundError()
+		},
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			strictConflict = arg.StrictConflict
+			return nil, uploadPathConflictError(files.WriteConflictErrorFile)
+		},
+	}
+	stubFilesClient(t, mock)
+
+	stderr := captureStderr(t, func() {
+		err := putFile(tmpFile, "/race.txt", putOptions{
+			chunkSize: 1 << 24,
+			workers:   4,
+			ifExists:  putIfExistsSkip,
+		})
+		if err != nil {
+			t.Fatalf("putFile error: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "Skipping /race.txt") {
+		t.Fatalf("stderr = %q, want skip message", stderr)
+	}
+	if !strictConflict {
+		t.Error("strict conflict = false, want true")
+	}
+}
+
+func TestPutFileIfExistsSkipReturnsNonFileConflicts(t *testing.T) {
+	tests := []struct {
+		name        string
+		conflictTag string
+	}{
+		{"folder", files.WriteConflictErrorFolder},
+		{"file ancestor", files.WriteConflictErrorFileAncestor},
+		{"other", files.WriteConflictErrorOther},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), "test.txt")
+			if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			mock := &mockFilesClient{
+				getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+					return nil, getMetadataNotFoundError()
+				},
+				uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+					return nil, uploadPathConflictError(tt.conflictTag)
+				},
+			}
+			stubFilesClient(t, mock)
+
+			stderr := captureStderr(t, func() {
+				err := putFile(tmpFile, "/bad-conflict.txt", putOptions{
+					chunkSize: 1 << 24,
+					workers:   4,
+					ifExists:  putIfExistsSkip,
+				})
+				if err == nil {
+					t.Fatal("expected non-file conflict error")
+				}
+			})
+			if strings.Contains(stderr, "Skipping ") {
+				t.Fatalf("stderr = %q, should not skip non-file conflicts", stderr)
+			}
+		})
+	}
+}
+
+func TestIsUploadDestinationFileConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"upload file conflict", uploadPathConflictError(files.WriteConflictErrorFile), true},
+		{"upload folder conflict", uploadPathConflictError(files.WriteConflictErrorFolder), false},
+		{"upload pointer file conflict", uploadPathConflictErrorPtr(files.WriteConflictErrorFile), true},
+		{"finish file conflict", uploadSessionFinishPathConflictError(files.WriteConflictErrorFile), true},
+		{"finish file ancestor conflict", uploadSessionFinishPathConflictError(files.WriteConflictErrorFileAncestor), false},
+		{"finish pointer file conflict", uploadSessionFinishPathConflictErrorPtr(files.WriteConflictErrorFile), true},
+		{"generic write conflict without subtype", uploadWriteConflictError(), false},
+		{"plain conflict string", fmt.Errorf("path/conflict/file/"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isUploadDestinationFileConflict(tt.err)
+			if got != tt.want {
+				t.Fatalf("isUploadDestinationFileConflict() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPutRecursiveIfExistsSkipContinuesPastExistingFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("existing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "new.txt"), []byte("new"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var uploaded []string
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			if arg.Path == "/backup/existing.txt" {
+				return &files.FileMetadata{Metadata: files.Metadata{PathDisplay: arg.Path}}, nil
+			}
+			return nil, getMetadataNotFoundError()
+		},
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			uploaded = append(uploaded, arg.Path)
+			return &files.FileMetadata{}, nil
+		},
+		createFolderV2Fn: func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error) {
+			return &files.CreateFolderResult{}, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stderr bytes.Buffer
+	cmd := testPutCmd()
+	cmd.SetErr(&stderr)
+
+	err := putRecursive(dir, "/backup", putOptions{
+		chunkSize: 1 << 24,
+		workers:   4,
+		ifExists:  putIfExistsSkip,
+		output:    commandOutput(cmd),
+	})
+	if err != nil {
+		t.Fatalf("putRecursive error: %v", err)
+	}
+
+	if len(uploaded) != 1 || uploaded[0] != "/backup/new.txt" {
+		t.Fatalf("uploaded = %v, want [/backup/new.txt]", uploaded)
+	}
+	if strings.Contains(stderr.String(), "Uploading ") {
+		t.Fatalf("stderr = %q, should not print uploading before skip decision", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Processing ") {
+		t.Fatalf("stderr = %q, want processing status", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Skipping /backup/existing.txt") {
+		t.Fatalf("stderr = %q, want skip status", stderr.String())
 	}
 }
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -64,6 +64,10 @@ func (r *Renderer) Error(format string, args ...any) {
 	_, _ = fmt.Fprintf(r.stderr, "Error: "+format+"\n", args...)
 }
 
+func (r *Renderer) Status(format string, args ...any) {
+	_, _ = fmt.Fprintf(r.stderr, format+"\n", args...)
+}
+
 func (r *Renderer) Info(format string, args ...any) {
 	_, _ = fmt.Fprintf(r.stdout, format+"\n", args...)
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -23,6 +23,21 @@ func TestWarnWritesToStderr(t *testing.T) {
 	}
 }
 
+func TestStatusWritesToStderrWithoutPrefix(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	out := New(&stdout, &stderr, FormatText)
+	out.Status("Skipping %s (already exists)", "/file.txt")
+
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	if got, want := stderr.String(), "Skipping /file.txt (already exists)\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
 func TestRenderText(t *testing.T) {
 	var stdout bytes.Buffer
 	out := New(&stdout, nil, FormatText)


### PR DESCRIPTION
## Summary

- Add `--if-exists` flag to `put` with values: `overwrite` (default), `skip`, and `fail`
- When `skip`: existing files are silently skipped (useful for resumable uploads)
- When `fail`: returns an error if the destination already exists
- Uses `WriteModeAdd` for skip/fail to leverage Dropbox conflict detection as a race-condition safety net
- For stdin uploads with `--if-exists skip`, avoids reading stdin entirely when the file exists
- Remove unused `printFileMetadata` from ls.go (resolves golangci-lint warning)

## Test plan

- [x] Unit tests for validation of invalid `--if-exists` values
- [x] Unit tests for skip behavior (no upload called, skip message printed)
- [x] Unit tests for fail behavior (error returned with "already exists")
- [x] Unit tests for fail mode uploading with `WriteModeAdd` when file is missing
- [x] Unit tests for overwrite mode skipping metadata check entirely
- [x] Unit tests for recursive skip continuing past existing files
- [x] Unit tests for stdin skip not reading stdin at all
- [x] All existing tests pass
- [x] golangci-lint clean
