### PR TITLE
Add share-link list command and restructure as top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,10 +228,14 @@ All `--sort`, `--reverse`, `--time`, and `--time-format` flags work with both `l
 ### Sharing
 
 ```sh
-$ dbxcli share link create /file.txt # create or return an existing shared link
-$ dbxcli share list link             # list existing shared links
+$ dbxcli share-link create /file.txt # create or return an existing shared link
+$ dbxcli share-link list             # list existing shared links
+$ dbxcli share-link list /file.txt   # list direct shared links for a path
+$ dbxcli share list link             # deprecated compatibility command
 $ dbxcli share list folder           # list shared folders
 ```
+
+New and changed commands should write command results to stdout. Status, progress, warnings, diagnostics, and verbose logs should go to stderr.
 
 ### Team management
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -28,3 +28,25 @@ func commandOutputFormat(cmd *cobra.Command) output.Format {
 	}
 	return output.FormatText
 }
+
+func commandVerbose(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	verbose, err := cmd.Flags().GetBool("verbose")
+	if err == nil {
+		return verbose
+	}
+	verbose, err = cmd.InheritedFlags().GetBool("verbose")
+	if err == nil {
+		return verbose
+	}
+	verbose, err = cmd.PersistentFlags().GetBool("verbose")
+	return err == nil && verbose
+}
+
+func commandVerboseStatus(cmd *cobra.Command, format string, args ...any) {
+	if commandVerbose(cmd) {
+		commandOutput(cmd).Status(format, args...)
+	}
+}

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -73,3 +73,39 @@ func TestCommandOutputHonorsInheritedJSONFlag(t *testing.T) {
 		t.Fatalf("stdout = %q, want %q", got, want)
 	}
 }
+
+func TestCommandVerboseHonorsInheritedVerboseFlag(t *testing.T) {
+	root := &cobra.Command{}
+	root.PersistentFlags().BoolP("verbose", "v", false, "")
+
+	cmd := &cobra.Command{}
+	root.AddCommand(cmd)
+
+	if err := root.PersistentFlags().Set("verbose", "true"); err != nil {
+		t.Fatalf("set verbose: %v", err)
+	}
+
+	if !commandVerbose(cmd) {
+		t.Fatal("commandVerbose = false, want true")
+	}
+}
+
+func TestCommandVerboseStatusWritesOnlyWhenVerbose(t *testing.T) {
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("verbose", false, "")
+	cmd.SetErr(&stderr)
+
+	commandVerboseStatus(cmd, "done %s", "quietly")
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+
+	if err := cmd.Flags().Set("verbose", "true"); err != nil {
+		t.Fatalf("set verbose: %v", err)
+	}
+	commandVerboseStatus(cmd, "done %s", "loudly")
+	if got, want := stderr.String(), "done loudly\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}

--- a/cmd/share-list-links.go
+++ b/cmd/share-list-links.go
@@ -15,61 +15,121 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
 	"github.com/spf13/cobra"
 )
 
 func shareListLinks(cmd *cobra.Command, args []string) (err error) {
-	arg := sharing.NewListSharedLinksArg()
+	return shareLinkList(cmd, args)
+}
 
-	dbx := sharing.New(config)
-	res, err := dbx.ListSharedLinks(arg)
-	if err != nil {
-		return
+func shareLinkList(cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return errors.New("`share-link list` accepts at most one `path` argument")
 	}
 
-	printLinks(res.Links)
+	arg := sharing.NewListSharedLinksArg()
+	if len(args) == 1 {
+		path, err := validatePath(args[0])
+		if err != nil {
+			return err
+		}
+		arg.Path = path
+		arg.DirectOnly = true
+	}
 
-	for res.HasMore {
+	dbx := newSharedLinkClient(config)
+	links, err := listSharedLinks(dbx, arg)
+	if err != nil {
+		return err
+	}
+
+	if arg.Path != "" {
+		commandVerboseStatus(cmd, "Listed %d shared links for %s", len(links), arg.Path)
+	} else {
+		commandVerboseStatus(cmd, "Listed %d shared links", len(links))
+	}
+
+	return commandOutput(cmd).RenderText(func(w io.Writer) error {
+		return renderSharedLinks(w, links)
+	})
+}
+
+func listSharedLinks(dbx sharedLinkClient, arg *sharing.ListSharedLinksArg) ([]sharing.IsSharedLinkMetadata, error) {
+	var links []sharing.IsSharedLinkMetadata
+	for {
+		res, err := dbx.ListSharedLinks(arg)
+		if err != nil {
+			return nil, err
+		}
+		links = append(links, res.Links...)
+
+		if !res.HasMore {
+			break
+		}
+		if res.Cursor == "" {
+			return nil, errors.New("shared link list has more results but no cursor")
+		}
 		arg = sharing.NewListSharedLinksArg()
 		arg.Cursor = res.Cursor
-
-		res, err = dbx.ListSharedLinks(arg)
-		if err != nil {
-			return
-		}
-
-		printLinks(res.Links)
 	}
 
-	return
+	return links, nil
 }
 
-func printLinks(links []sharing.IsSharedLinkMetadata) {
+func renderSharedLinks(out io.Writer, links []sharing.IsSharedLinkMetadata) error {
 	for _, l := range links {
-		switch sl := l.(type) {
-		case *sharing.FileLinkMetadata:
-			printLink(sl.SharedLinkMetadata)
-		case *sharing.FolderLinkMetadata:
-			printLink(sl.SharedLinkMetadata)
-		default:
-			fmt.Printf("found unknown shared link type")
+		name, url, ok := sharedLinkDisplay(l)
+		if !ok {
+			return errors.New("found unknown shared link type")
 		}
+		if _, err := fmt.Fprintf(out, "%s\t%s\n", name, url); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func sharedLinkDisplay(link sharing.IsSharedLinkMetadata) (name string, url string, ok bool) {
+	switch sl := link.(type) {
+	case *sharing.FileLinkMetadata:
+		return sharedLinkMetadataDisplay(sl.SharedLinkMetadata)
+	case *sharing.FolderLinkMetadata:
+		return sharedLinkMetadataDisplay(sl.SharedLinkMetadata)
+	case *sharing.SharedLinkMetadata:
+		return sharedLinkMetadataDisplay(*sl)
+	default:
+		return "", "", false
 	}
 }
 
-func printLink(sl sharing.SharedLinkMetadata) {
-	fmt.Printf("%v\t%v\n", sl.Name, sl.Url)
+func sharedLinkMetadataDisplay(sl sharing.SharedLinkMetadata) (name string, url string, ok bool) {
+	name = sl.Name
+	if name == "" {
+		name = sl.PathLower
+	}
+	return name, sl.Url, sl.Url != ""
+}
+
+var shareLinkListCmd = &cobra.Command{
+	Use:   "list [path]",
+	Short: "List shared links",
+	RunE:  shareLinkList,
 }
 
 var shareListLinksCmd = &cobra.Command{
-	Use:   "link",
-	Short: "List shared links",
-	RunE:  shareListLinks,
+	Use:        "link",
+	Short:      "List shared links",
+	Deprecated: "use `dbxcli share-link list` instead",
+	RunE:       shareListLinks,
 }
 
 func init() {
+	shareLinkCmd.AddCommand(shareLinkListCmd)
 	shareListCmd.AddCommand(shareListLinksCmd)
 }

--- a/cmd/share_create_link_test.go
+++ b/cmd/share_create_link_test.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -73,7 +74,7 @@ func TestSharedLinkCreateRequiresExactlyOnePath(t *testing.T) {
 			})
 
 			err := shareLinkCreate(&cobra.Command{}, tt.args)
-			if err == nil || !strings.Contains(err.Error(), "requires a `path` argument") {
+			if err == nil || !strings.Contains(err.Error(), "`share-link create` requires a `path` argument") {
 				t.Fatalf("error = %v, want path argument error", err)
 			}
 			if called {
@@ -137,9 +138,11 @@ func TestSharedLinkCreateVerboseStillPrintsURLOnly(t *testing.T) {
 	stubSharedLinkClient(t, mock)
 
 	var stdout bytes.Buffer
+	var stderr bytes.Buffer
 	cmd := &cobra.Command{}
 	cmd.Flags().Bool("verbose", true, "")
 	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
 
 	if err := shareLinkCreate(cmd, []string{"/file.txt"}); err != nil {
 		t.Fatalf("shareLinkCreate error: %v", err)
@@ -147,6 +150,9 @@ func TestSharedLinkCreateVerboseStillPrintsURLOnly(t *testing.T) {
 
 	if got := stdout.String(); got != "https://example.com/file\n" {
 		t.Fatalf("stdout = %q, want URL only", got)
+	}
+	if got, want := stderr.String(), "Created shared link for /file.txt\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
 	}
 }
 
@@ -213,6 +219,34 @@ func TestSharedLinkCreateExistingMetadataPrintsURLWithoutList(t *testing.T) {
 
 	if got := stdout.String(); got != "https://example.com/docs\n" {
 		t.Fatalf("stdout = %q, want existing URL only", got)
+	}
+}
+
+func TestSharedLinkCreateVerboseReportsExistingLinkOnStderr(t *testing.T) {
+	existing := sharedLinkFolder("/docs", "https://example.com/docs")
+	mock := &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			return nil, alreadyExistsError(existing)
+		},
+	}
+	stubSharedLinkClient(t, mock)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("verbose", true, "")
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := shareLinkCreate(cmd, []string{"/docs"}); err != nil {
+		t.Fatalf("shareLinkCreate error: %v", err)
+	}
+
+	if got := stdout.String(); got != "https://example.com/docs\n" {
+		t.Fatalf("stdout = %q, want existing URL only", got)
+	}
+	if got, want := stderr.String(), "Using existing shared link for /docs\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
 	}
 }
 
@@ -328,12 +362,12 @@ func TestSharedLinkCreateFallbackPaginationRequiresCursor(t *testing.T) {
 }
 
 func TestShareLinkCreateDoesNotBreakShareListLinkCommand(t *testing.T) {
-	cmd, _, err := RootCmd.Find([]string{"share", "link", "create", "/file.txt"})
+	cmd, _, err := RootCmd.Find([]string{"share-link", "create", "/file.txt"})
 	if err != nil {
-		t.Fatalf("find share link create: %v", err)
+		t.Fatalf("find share-link create: %v", err)
 	}
 	if cmd != shareLinkCreateCmd {
-		t.Fatalf("share link create resolved to %q", cmd.CommandPath())
+		t.Fatalf("share-link create resolved to %q", cmd.CommandPath())
 	}
 
 	cmd, _, err = RootCmd.Find([]string{"share", "list", "link"})
@@ -343,16 +377,170 @@ func TestShareLinkCreateDoesNotBreakShareListLinkCommand(t *testing.T) {
 	if cmd != shareListLinksCmd {
 		t.Fatalf("share list link resolved to %q", cmd.CommandPath())
 	}
+	if shareListLinksCmd.Deprecated == "" {
+		t.Fatal("share list link should be deprecated")
+	}
+	if !strings.Contains(shareListLinksCmd.Deprecated, "share-link list") {
+		t.Fatalf("deprecation message = %q, want share-link list replacement", shareListLinksCmd.Deprecated)
+	}
+}
+
+func TestShareLinkListListsAllLinks(t *testing.T) {
+	var listArg *sharing.ListSharedLinksArg
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		listSharedLinksFn: func(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error) {
+			listArg = arg
+			return sharing.NewListSharedLinksResult([]sharing.IsSharedLinkMetadata{
+				sharedLinkFile("/docs/file.txt", "https://example.com/file"),
+				sharedLinkFolder("/docs", "https://example.com/docs"),
+			}, false), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+
+	if err := shareLinkList(cmd, nil); err != nil {
+		t.Fatalf("shareLinkList error: %v", err)
+	}
+
+	if listArg == nil {
+		t.Fatal("expected ListSharedLinks to be called")
+	}
+	if listArg.Path != "" {
+		t.Fatalf("ListSharedLinks path = %q, want empty", listArg.Path)
+	}
+	if listArg.DirectOnly {
+		t.Fatal("ListSharedLinks DirectOnly = true, want false")
+	}
+	want := "file.txt\thttps://example.com/file\n" +
+		"docs\thttps://example.com/docs\n"
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestShareLinkListVerboseWritesStatusToStderr(t *testing.T) {
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		listSharedLinksFn: func(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error) {
+			return sharing.NewListSharedLinksResult([]sharing.IsSharedLinkMetadata{
+				sharedLinkFile("/docs/file.txt", "https://example.com/file"),
+			}, false), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("verbose", true, "")
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := shareLinkList(cmd, []string{"/docs/file.txt"}); err != nil {
+		t.Fatalf("shareLinkList error: %v", err)
+	}
+
+	if got, want := stdout.String(), "file.txt\thttps://example.com/file\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if got, want := stderr.String(), "Listed 1 shared links for /docs/file.txt\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestShareLinkListPathFilterUsesDirectOnly(t *testing.T) {
+	var listArg *sharing.ListSharedLinksArg
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		listSharedLinksFn: func(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error) {
+			listArg = arg
+			return sharing.NewListSharedLinksResult([]sharing.IsSharedLinkMetadata{
+				sharedLinkFile("/docs/file.txt", "https://example.com/file"),
+			}, false), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+
+	if err := shareLinkList(cmd, []string{"docs/file.txt"}); err != nil {
+		t.Fatalf("shareLinkList error: %v", err)
+	}
+
+	if listArg == nil {
+		t.Fatal("expected ListSharedLinks to be called")
+	}
+	if listArg.Path != "/docs/file.txt" {
+		t.Fatalf("ListSharedLinks path = %q, want /docs/file.txt", listArg.Path)
+	}
+	if !listArg.DirectOnly {
+		t.Fatal("ListSharedLinks DirectOnly = false, want true")
+	}
+	want := "file.txt\thttps://example.com/file\n"
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestShareLinkListFollowsPagination(t *testing.T) {
+	var cursors []string
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		listSharedLinksFn: func(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error) {
+			cursors = append(cursors, arg.Cursor)
+			if arg.Cursor == "" {
+				res := sharing.NewListSharedLinksResult([]sharing.IsSharedLinkMetadata{
+					sharedLinkFile("/docs/one.txt", "https://example.com/one"),
+				}, true)
+				res.Cursor = "next-page"
+				return res, nil
+			}
+			return sharing.NewListSharedLinksResult([]sharing.IsSharedLinkMetadata{
+				sharedLinkFile("/docs/two.txt", "https://example.com/two"),
+			}, false), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+
+	if err := shareLinkList(cmd, nil); err != nil {
+		t.Fatalf("shareLinkList error: %v", err)
+	}
+
+	if got := strings.Join(cursors, ","); got != ",next-page" {
+		t.Fatalf("cursors = %q, want first call then next-page", got)
+	}
+	got := stdout.String()
+	for _, want := range []string{"https://example.com/one", "https://example.com/two"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestShareLinkListPaginationRequiresCursor(t *testing.T) {
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		listSharedLinksFn: func(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error) {
+			return sharing.NewListSharedLinksResult(nil, true), nil
+		},
+	})
+
+	err := shareLinkList(&cobra.Command{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "more results but no cursor") {
+		t.Fatalf("error = %v, want missing cursor error", err)
+	}
 }
 
 func sharedLinkFile(pathLower string, url string) *sharing.FileLinkMetadata {
-	link := sharing.NewFileLinkMetadata(url, strings.TrimPrefix(pathLower, "/"), nil, time.Time{}, time.Time{}, "rev", 1)
+	link := sharing.NewFileLinkMetadata(url, path.Base(pathLower), nil, time.Time{}, time.Time{}, "rev", 1)
 	link.PathLower = strings.ToLower(pathLower)
 	return link
 }
 
 func sharedLinkFolder(pathLower string, url string) *sharing.FolderLinkMetadata {
-	link := sharing.NewFolderLinkMetadata(url, strings.TrimPrefix(pathLower, "/"), nil)
+	link := sharing.NewFolderLinkMetadata(url, path.Base(pathLower), nil)
 	link.PathLower = strings.ToLower(pathLower)
 	return link
 }

--- a/cmd/share_link.go
+++ b/cmd/share_link.go
@@ -30,10 +30,10 @@ var newSharedLinkClient = func(cfg dropbox.Config) sharedLinkClient {
 }
 
 var shareLinkCmd = &cobra.Command{
-	Use:   "link",
+	Use:   "share-link",
 	Short: "Shared link commands",
 }
 
 func init() {
-	shareCmd.AddCommand(shareLinkCmd)
+	RootCmd.AddCommand(shareLinkCmd)
 }

--- a/cmd/share_link_create.go
+++ b/cmd/share_link_create.go
@@ -26,7 +26,7 @@ import (
 
 func shareLinkCreate(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return errors.New("`share link create` requires a `path` argument")
+		return errors.New("`share-link create` requires a `path` argument")
 	}
 
 	path, err := validatePath(args[0])
@@ -40,11 +40,13 @@ func shareLinkCreate(cmd *cobra.Command, args []string) error {
 	dbx := newSharedLinkClient(config)
 	arg := sharing.NewCreateSharedLinkWithSettingsArg(path)
 	link, err := dbx.CreateSharedLinkWithSettings(arg)
+	usedExisting := false
 	if err != nil {
 		link, err = existingSharedLink(dbx, path, err)
 		if err != nil {
 			return err
 		}
+		usedExisting = true
 	}
 
 	url, ok := sharedLinkURL(link)
@@ -52,7 +54,14 @@ func shareLinkCreate(cmd *cobra.Command, args []string) error {
 		return errors.New("shared link response did not include a URL")
 	}
 
-	return commandOutput(cmd).RenderText(func(w io.Writer) error {
+	out := commandOutput(cmd)
+	if usedExisting {
+		commandVerboseStatus(cmd, "Using existing shared link for %s", path)
+	} else {
+		commandVerboseStatus(cmd, "Created shared link for %s", path)
+	}
+
+	return out.RenderText(func(w io.Writer) error {
 		_, err := fmt.Fprintln(w, url)
 		return err
 	})


### PR DESCRIPTION
## Summary

- Restructure `share link` from subcommand of `share` to top-level `share-link` command
- Add `share-link list [path]` with optional path scoping (`DirectOnly=true`)
- Deprecate old `share list link` command (still works, prints deprecation notice)
- Add `commandVerbose` / `commandVerboseStatus` helpers for verbose-only stderr output
- Refactor link rendering from global `fmt.Printf` to writer-based `renderSharedLinks`
- Extract reusable `listSharedLinks` with pagination and cursor guard

Depends on #248.

## Test plan

- [x] `share-link list` lists all links (no path filter, DirectOnly=false)
- [x] `share-link list /path` scopes by path with DirectOnly=true
- [x] Pagination followed correctly with cursor
- [x] Empty cursor with HasMore returns error
- [x] Verbose mode prints link count to stderr
- [x] `share list link` still resolves (backward compat)
- [x] `share list link` marked deprecated with replacement message
- [x] `share-link create` verbose reports "Created" vs "Using existing"
- [x] `commandVerbose` honors inherited/persistent flags
- [x] `commandVerboseStatus` only writes when verbose is true
- [x] golangci-lint clean, all tests pass
