### PR TITLE
Add share-link revoke command

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ All `--sort`, `--reverse`, `--time`, and `--time-format` flags work with both `l
 $ dbxcli share-link create /file.txt # create or return an existing shared link
 $ dbxcli share-link list             # list existing shared links
 $ dbxcli share-link list /file.txt   # list direct shared links for a path
+$ dbxcli share-link revoke <url>     # revoke a shared link
 $ dbxcli share list link             # deprecated compatibility command
 $ dbxcli share list folder           # list shared folders
 ```

--- a/cmd/share_create_link_test.go
+++ b/cmd/share_create_link_test.go
@@ -30,6 +30,7 @@ import (
 type mockSharedLinkClient struct {
 	createSharedLinkWithSettingsFn func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error)
 	listSharedLinksFn              func(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error)
+	revokeSharedLinkFn             func(arg *sharing.RevokeSharedLinkArg) error
 }
 
 func (m *mockSharedLinkClient) CreateSharedLinkWithSettings(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
@@ -44,6 +45,13 @@ func (m *mockSharedLinkClient) ListSharedLinks(arg *sharing.ListSharedLinksArg) 
 		return m.listSharedLinksFn(arg)
 	}
 	return &sharing.ListSharedLinksResult{}, nil
+}
+
+func (m *mockSharedLinkClient) RevokeSharedLink(arg *sharing.RevokeSharedLinkArg) error {
+	if m.revokeSharedLinkFn != nil {
+		return m.revokeSharedLinkFn(arg)
+	}
+	return nil
 }
 
 func stubSharedLinkClient(t *testing.T, client sharedLinkClient) {

--- a/cmd/share_link_revoke.go
+++ b/cmd/share_link_revoke.go
@@ -15,26 +15,38 @@
 package cmd
 
 import (
-	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"errors"
+
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
 	"github.com/spf13/cobra"
 )
 
-type sharedLinkClient interface {
-	CreateSharedLinkWithSettings(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error)
-	ListSharedLinks(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error)
-	RevokeSharedLink(arg *sharing.RevokeSharedLinkArg) error
+func shareLinkRevoke(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("`share-link revoke` requires a `url` argument")
+	}
+
+	url := args[0]
+	if url == "" {
+		return errors.New("`share-link revoke` requires a non-empty URL")
+	}
+
+	dbx := newSharedLinkClient(config)
+	arg := sharing.NewRevokeSharedLinkArg(url)
+	if err := dbx.RevokeSharedLink(arg); err != nil {
+		return err
+	}
+
+	commandVerboseStatus(cmd, "Revoked shared link %s", url)
+	return nil
 }
 
-var newSharedLinkClient = func(cfg dropbox.Config) sharedLinkClient {
-	return sharing.New(cfg)
-}
-
-var shareLinkCmd = &cobra.Command{
-	Use:   "share-link",
-	Short: "Shared link commands",
+var shareLinkRevokeCmd = &cobra.Command{
+	Use:   "revoke <url>",
+	Short: "Revoke a shared link",
+	RunE:  shareLinkRevoke,
 }
 
 func init() {
-	RootCmd.AddCommand(shareLinkCmd)
+	shareLinkCmd.AddCommand(shareLinkRevokeCmd)
 }

--- a/cmd/share_link_revoke_test.go
+++ b/cmd/share_link_revoke_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
+	"github.com/spf13/cobra"
+)
+
+func TestShareLinkRevokeRequiresExactlyOneURL(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing url", args: nil},
+		{name: "too many urls", args: []string{"http://a", "http://b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			stubSharedLinkClient(t, &mockSharedLinkClient{
+				revokeSharedLinkFn: func(arg *sharing.RevokeSharedLinkArg) error {
+					called = true
+					return nil
+				},
+			})
+
+			err := shareLinkRevoke(&cobra.Command{}, tt.args)
+			if err == nil || !strings.Contains(err.Error(), "requires a `url` argument") {
+				t.Fatalf("error = %v, want url argument error", err)
+			}
+			if called {
+				t.Fatal("RevokeSharedLink should not be called")
+			}
+		})
+	}
+}
+
+func TestShareLinkRevokeRejectsEmptyURL(t *testing.T) {
+	called := false
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		revokeSharedLinkFn: func(arg *sharing.RevokeSharedLinkArg) error {
+			called = true
+			return nil
+		},
+	})
+
+	err := shareLinkRevoke(&cobra.Command{}, []string{""})
+	if err == nil || !strings.Contains(err.Error(), "non-empty URL") {
+		t.Fatalf("error = %v, want non-empty URL error", err)
+	}
+	if called {
+		t.Fatal("RevokeSharedLink should not be called")
+	}
+}
+
+func TestShareLinkRevokeCallsAPIWithURL(t *testing.T) {
+	var revokedURL string
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		revokeSharedLinkFn: func(arg *sharing.RevokeSharedLinkArg) error {
+			revokedURL = arg.Url
+			return nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+
+	err := shareLinkRevoke(cmd, []string{"https://www.dropbox.com/s/abc123"})
+	if err != nil {
+		t.Fatalf("shareLinkRevoke error: %v", err)
+	}
+	if revokedURL != "https://www.dropbox.com/s/abc123" {
+		t.Fatalf("revoked URL = %q, want https://www.dropbox.com/s/abc123", revokedURL)
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestShareLinkRevokeVerboseWritesStatusToStderr(t *testing.T) {
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		revokeSharedLinkFn: func(arg *sharing.RevokeSharedLinkArg) error {
+			return nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("verbose", true, "")
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := shareLinkRevoke(cmd, []string{"https://www.dropbox.com/s/abc123"})
+	if err != nil {
+		t.Fatalf("shareLinkRevoke error: %v", err)
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if got, want := stderr.String(), "Revoked shared link https://www.dropbox.com/s/abc123\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestShareLinkRevokeReturnsAPIError(t *testing.T) {
+	wantErr := fmt.Errorf("shared_link_not_found")
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		revokeSharedLinkFn: func(arg *sharing.RevokeSharedLinkArg) error {
+			return wantErr
+		},
+	})
+
+	err := shareLinkRevoke(&cobra.Command{}, []string{"https://www.dropbox.com/s/abc123"})
+	if err != wantErr {
+		t.Fatalf("error = %v, want API error", err)
+	}
+}
+
+func TestShareLinkRevokeDoesNotBreakOtherCommands(t *testing.T) {
+	cmd, _, err := RootCmd.Find([]string{"share-link", "revoke"})
+	if err != nil {
+		t.Fatalf("find share-link revoke: %v", err)
+	}
+	if cmd != shareLinkRevokeCmd {
+		t.Fatalf("share-link revoke resolved to %q", cmd.CommandPath())
+	}
+
+	cmd, _, err = RootCmd.Find([]string{"share-link", "create"})
+	if err != nil {
+		t.Fatalf("find share-link create: %v", err)
+	}
+	if cmd != shareLinkCreateCmd {
+		t.Fatalf("share-link create resolved to %q", cmd.CommandPath())
+	}
+
+	cmd, _, err = RootCmd.Find([]string{"share-link", "list"})
+	if err != nil {
+		t.Fatalf("find share-link list: %v", err)
+	}
+	if cmd != shareLinkListCmd {
+		t.Fatalf("share-link list resolved to %q", cmd.CommandPath())
+	}
+}


### PR DESCRIPTION
## Summary

- Add `dbxcli share-link revoke <url>` to revoke a Dropbox shared link
- Silent on success (no stdout); verbose mode prints "Revoked shared link <url>" to stderr
- Validates exactly one non-empty URL argument; Dropbox validates URL format
- API errors pass through unchanged (e.g., already-revoked link returns Dropbox error)
- Extends `sharedLinkClient` interface with `RevokeSharedLink`

Depends on #249.

## Test plan

- [x] Requires exactly one URL argument (nil and multi-arg rejected)
- [x] Rejects empty URL with clear error
- [x] Calls `RevokeSharedLink` with the supplied URL
- [x] Success produces no stdout output
- [x] Verbose success writes status to stderr
- [x] Dropbox API errors returned unchanged
- [x] Command registration does not break `share-link create` or `share-link list`
- [x] golangci-lint clean, all tests pass