### PR TITLE
Add share-link info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ All `--sort`, `--reverse`, `--time`, and `--time-format` flags work with both `l
 
 ```sh
 $ dbxcli share-link create /file.txt # create or return an existing shared link
+$ dbxcli share-link info <url>       # display shared link information
 $ dbxcli share-link list             # list existing shared links
 $ dbxcli share-link list /file.txt   # list direct shared links for a path
 $ dbxcli share-link revoke <url>     # revoke a shared link

--- a/cmd/share_create_link_test.go
+++ b/cmd/share_create_link_test.go
@@ -29,6 +29,7 @@ import (
 
 type mockSharedLinkClient struct {
 	createSharedLinkWithSettingsFn func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error)
+	getSharedLinkMetadataFn        func(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, error)
 	listSharedLinksFn              func(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error)
 	revokeSharedLinkFn             func(arg *sharing.RevokeSharedLinkArg) error
 }
@@ -36,6 +37,13 @@ type mockSharedLinkClient struct {
 func (m *mockSharedLinkClient) CreateSharedLinkWithSettings(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
 	if m.createSharedLinkWithSettingsFn != nil {
 		return m.createSharedLinkWithSettingsFn(arg)
+	}
+	return nil, nil
+}
+
+func (m *mockSharedLinkClient) GetSharedLinkMetadata(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, error) {
+	if m.getSharedLinkMetadataFn != nil {
+		return m.getSharedLinkMetadataFn(arg)
 	}
 	return nil, nil
 }

--- a/cmd/share_link.go
+++ b/cmd/share_link.go
@@ -22,6 +22,7 @@ import (
 
 type sharedLinkClient interface {
 	CreateSharedLinkWithSettings(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error)
+	GetSharedLinkMetadata(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, error)
 	ListSharedLinks(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error)
 	RevokeSharedLink(arg *sharing.RevokeSharedLinkArg) error
 }

--- a/cmd/share_link_info.go
+++ b/cmd/share_link_info.go
@@ -1,0 +1,123 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
+	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+)
+
+func shareLinkInfo(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("`share-link info` requires a `url` argument")
+	}
+
+	url := args[0]
+	if url == "" {
+		return errors.New("`share-link info` requires a non-empty URL")
+	}
+
+	dbx := newSharedLinkClient(config)
+	arg := sharing.NewGetSharedLinkMetadataArg(url)
+	link, err := dbx.GetSharedLinkMetadata(arg)
+	if err != nil {
+		return err
+	}
+
+	return commandOutput(cmd).RenderText(func(w io.Writer) error {
+		return renderSharedLinkInfo(w, link)
+	})
+}
+
+func renderSharedLinkInfo(out io.Writer, link sharing.IsSharedLinkMetadata) error {
+	metadata, linkType, ok := sharedLinkBaseMetadata(link)
+	if !ok {
+		return errors.New("found unknown shared link type")
+	}
+
+	w := new(tabwriter.Writer)
+	w.Init(out, 4, 8, 1, ' ', 0)
+
+	_, _ = fmt.Fprintf(w, "Type:\t%s\n", linkType)
+	_, _ = fmt.Fprintf(w, "Name:\t%s\n", metadata.Name)
+	_, _ = fmt.Fprintf(w, "URL:\t%s\n", metadata.Url)
+	if metadata.PathLower != "" {
+		_, _ = fmt.Fprintf(w, "Path:\t%s\n", metadata.PathLower)
+	}
+	if metadata.Id != "" {
+		_, _ = fmt.Fprintf(w, "ID:\t%s\n", metadata.Id)
+	}
+	if metadata.Expires != nil {
+		_, _ = fmt.Fprintf(w, "Expires:\t%s\n", metadata.Expires.Format(time.RFC3339))
+	}
+	if metadata.LinkPermissions != nil {
+		renderSharedLinkPermissions(w, metadata.LinkPermissions)
+	}
+
+	if file, ok := link.(*sharing.FileLinkMetadata); ok {
+		_, _ = fmt.Fprintf(w, "Revision:\t%s\n", file.Rev)
+		_, _ = fmt.Fprintf(w, "Size:\t%s\n", humanize.IBytes(file.Size))
+		_, _ = fmt.Fprintf(w, "Server Modified:\t%s\n", file.ServerModified.Format(time.RFC3339))
+	}
+
+	return w.Flush()
+}
+
+func renderSharedLinkPermissions(w io.Writer, permissions *sharing.LinkPermissions) {
+	if permissions.ResolvedVisibility != nil {
+		_, _ = fmt.Fprintf(w, "Resolved Visibility:\t%s\n", permissions.ResolvedVisibility.Tag)
+	}
+	if permissions.RequestedVisibility != nil {
+		_, _ = fmt.Fprintf(w, "Requested Visibility:\t%s\n", permissions.RequestedVisibility.Tag)
+	}
+	if permissions.EffectiveAudience != nil {
+		_, _ = fmt.Fprintf(w, "Effective Audience:\t%s\n", permissions.EffectiveAudience.Tag)
+	}
+	if permissions.LinkAccessLevel != nil {
+		_, _ = fmt.Fprintf(w, "Access Level:\t%s\n", permissions.LinkAccessLevel.Tag)
+	}
+	_, _ = fmt.Fprintf(w, "Can Revoke:\t%t\n", permissions.CanRevoke)
+	_, _ = fmt.Fprintf(w, "Allow Download:\t%t\n", permissions.AllowDownload)
+}
+
+func sharedLinkBaseMetadata(link sharing.IsSharedLinkMetadata) (*sharing.SharedLinkMetadata, string, bool) {
+	switch link := link.(type) {
+	case *sharing.FileLinkMetadata:
+		return &link.SharedLinkMetadata, "file", true
+	case *sharing.FolderLinkMetadata:
+		return &link.SharedLinkMetadata, "folder", true
+	case *sharing.SharedLinkMetadata:
+		return link, "link", true
+	default:
+		return nil, "", false
+	}
+}
+
+var shareLinkInfoCmd = &cobra.Command{
+	Use:   "info <url>",
+	Short: "Display shared link information",
+	RunE:  shareLinkInfo,
+}
+
+func init() {
+	shareLinkCmd.AddCommand(shareLinkInfoCmd)
+}

--- a/cmd/share_link_info_test.go
+++ b/cmd/share_link_info_test.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
+	"github.com/spf13/cobra"
+)
+
+func TestShareLinkInfoRequiresExactlyOneURL(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing url", args: nil},
+		{name: "too many urls", args: []string{"http://a", "http://b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			stubSharedLinkClient(t, &mockSharedLinkClient{
+				getSharedLinkMetadataFn: func(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, error) {
+					called = true
+					return nil, nil
+				},
+			})
+
+			err := shareLinkInfo(&cobra.Command{}, tt.args)
+			if err == nil || !strings.Contains(err.Error(), "requires a `url` argument") {
+				t.Fatalf("error = %v, want url argument error", err)
+			}
+			if called {
+				t.Fatal("GetSharedLinkMetadata should not be called")
+			}
+		})
+	}
+}
+
+func TestShareLinkInfoRejectsEmptyURL(t *testing.T) {
+	called := false
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		getSharedLinkMetadataFn: func(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, error) {
+			called = true
+			return nil, nil
+		},
+	})
+
+	err := shareLinkInfo(&cobra.Command{}, []string{""})
+	if err == nil || !strings.Contains(err.Error(), "non-empty URL") {
+		t.Fatalf("error = %v, want non-empty URL error", err)
+	}
+	if called {
+		t.Fatal("GetSharedLinkMetadata should not be called")
+	}
+}
+
+func TestShareLinkInfoCallsAPIWithURLAndPrintsFileInfo(t *testing.T) {
+	serverModified := time.Date(2026, 6, 20, 12, 30, 0, 0, time.UTC)
+	expires := time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC)
+	permissions := sharing.NewLinkPermissions(true, nil, false, false, true, false, false, false, false)
+	permissions.ResolvedVisibility = &sharing.ResolvedVisibility{Tagged: dropbox.Tagged{Tag: sharing.ResolvedVisibilityPublic}}
+
+	link := sharedLinkFile("/docs/report.txt", "https://www.dropbox.com/s/abc123")
+	link.Id = "id:file123"
+	link.Expires = &expires
+	link.LinkPermissions = permissions
+	link.ServerModified = serverModified
+	link.Rev = "rev123"
+	link.Size = 2048
+
+	var requestedURL string
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		getSharedLinkMetadataFn: func(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, error) {
+			requestedURL = arg.Url
+			return link, nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+
+	err := shareLinkInfo(cmd, []string{"https://www.dropbox.com/s/abc123"})
+	if err != nil {
+		t.Fatalf("shareLinkInfo error: %v", err)
+	}
+	if requestedURL != "https://www.dropbox.com/s/abc123" {
+		t.Fatalf("requested URL = %q, want https://www.dropbox.com/s/abc123", requestedURL)
+	}
+
+	got := stdout.String()
+	for _, want := range []string{
+		"Type:                file\n",
+		"Name:                report.txt\n",
+		"URL:                 https://www.dropbox.com/s/abc123\n",
+		"Path:                /docs/report.txt\n",
+		"ID:                  id:file123\n",
+		"Expires:             2026-07-01T08:00:00Z\n",
+		"Resolved Visibility: public\n",
+		"Can Revoke:          true\n",
+		"Allow Download:      true\n",
+		"Revision:            rev123\n",
+		"Size:                2.0 KiB\n",
+		"Server Modified:     2026-06-20T12:30:00Z\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestShareLinkInfoPrintsFolderInfo(t *testing.T) {
+	link := sharedLinkFolder("/docs", "https://www.dropbox.com/s/folder")
+	link.Id = "id:folder123"
+
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		getSharedLinkMetadataFn: func(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, error) {
+			return link, nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+
+	if err := shareLinkInfo(cmd, []string{"https://www.dropbox.com/s/folder"}); err != nil {
+		t.Fatalf("shareLinkInfo error: %v", err)
+	}
+
+	got := stdout.String()
+	for _, want := range []string{
+		"Type: folder\n",
+		"Name: docs\n",
+		"URL:  https://www.dropbox.com/s/folder\n",
+		"Path: /docs\n",
+		"ID:   id:folder123\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestShareLinkInfoReturnsAPIError(t *testing.T) {
+	wantErr := fmt.Errorf("shared_link_not_found")
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		getSharedLinkMetadataFn: func(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, error) {
+			return nil, wantErr
+		},
+	})
+
+	err := shareLinkInfo(&cobra.Command{}, []string{"https://www.dropbox.com/s/abc123"})
+	if err != wantErr {
+		t.Fatalf("error = %v, want API error", err)
+	}
+}
+
+func TestShareLinkInfoDoesNotBreakOtherCommands(t *testing.T) {
+	cmd, _, err := RootCmd.Find([]string{"share-link", "info"})
+	if err != nil {
+		t.Fatalf("find share-link info: %v", err)
+	}
+	if cmd != shareLinkInfoCmd {
+		t.Fatalf("share-link info resolved to %q", cmd.CommandPath())
+	}
+
+	cmd, _, err = RootCmd.Find([]string{"share-link", "create"})
+	if err != nil {
+		t.Fatalf("find share-link create: %v", err)
+	}
+	if cmd != shareLinkCreateCmd {
+		t.Fatalf("share-link create resolved to %q", cmd.CommandPath())
+	}
+
+	cmd, _, err = RootCmd.Find([]string{"share-link", "list"})
+	if err != nil {
+		t.Fatalf("find share-link list: %v", err)
+	}
+	if cmd != shareLinkListCmd {
+		t.Fatalf("share-link list resolved to %q", cmd.CommandPath())
+	}
+
+	cmd, _, err = RootCmd.Find([]string{"share-link", "revoke"})
+	if err != nil {
+		t.Fatalf("find share-link revoke: %v", err)
+	}
+	if cmd != shareLinkRevokeCmd {
+		t.Fatalf("share-link revoke resolved to %q", cmd.CommandPath())
+	}
+}


### PR DESCRIPTION
## Summary

- Add `dbxcli share-link info <url>` to display shared link metadata
- Shows: type, name, URL, path, ID, expiration, visibility, permissions, access level
- File links additionally show: revision, size, server-modified time
- Uses tabwriter for aligned key-value output
- Extends `sharedLinkClient` interface with `GetSharedLinkMetadata`

Depends on #250.

## Test plan

- [x] Requires exactly one URL argument (nil and multi-arg rejected)
- [x] Rejects empty URL with clear error
- [x] File link: renders all fields (type, name, URL, path, ID, expires, visibility, can-revoke, allow-download, revision, size, server-modified)
- [x] Folder link: renders type, name, URL, path, ID
- [x] API errors returned unchanged
- [x] Command registration does not break create, list, or revoke
- [x] golangci-lint clean, all tests pass