### PR TITLE
Add --expires, --allow-download, --remove-expiration to share-link create

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ All `--sort`, `--reverse`, `--time`, and `--time-format` flags work with both `l
 
 ```sh
 $ dbxcli share-link create /file.txt # create or return an existing shared link
+$ dbxcli share-link create /file.txt --allow-download # create a downloadable shared link
+$ dbxcli share-link create /file.txt --expires 2026-07-01T00:00:00Z # create an expiring shared link
+$ dbxcli share-link create /file.txt --remove-expiration # remove expiration when returning an existing link
 $ dbxcli share-link download <url> [target] # download a shared-link file
 $ dbxcli share-link info <url>       # display shared link information
 $ dbxcli share-link list             # list existing shared links

--- a/cmd/share_create_link_test.go
+++ b/cmd/share_create_link_test.go
@@ -162,6 +162,155 @@ func TestSharedLinkCreatePrintsURLAndUsesDefaultSettings(t *testing.T) {
 	}
 }
 
+func TestSharedLinkCreateWithExpiresSetsExpiration(t *testing.T) {
+	wantExpires := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	mock := &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			if arg.Settings == nil {
+				t.Fatal("settings = nil, want expiration settings")
+			}
+			if arg.Settings.Expires == nil {
+				t.Fatal("expires = nil, want expiration time")
+			}
+			if !arg.Settings.Expires.Equal(wantExpires) {
+				t.Fatalf("expires = %s, want %s", arg.Settings.Expires.Format(time.RFC3339), wantExpires.Format(time.RFC3339))
+			}
+			return sharedLinkFile("/file.txt", "https://example.com/file"), nil
+		},
+	}
+	stubSharedLinkClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().String("expires", "", "")
+	cmd.SetOut(&stdout)
+	if err := cmd.Flags().Set("expires", wantExpires.Format(time.RFC3339)); err != nil {
+		t.Fatalf("set expires: %v", err)
+	}
+
+	if err := shareLinkCreate(cmd, []string{"/file.txt"}); err != nil {
+		t.Fatalf("shareLinkCreate error: %v", err)
+	}
+
+	if got := stdout.String(); got != "https://example.com/file\n" {
+		t.Fatalf("stdout = %q, want URL only", got)
+	}
+}
+
+func TestSharedLinkCreateWithAllowDownloadSetsAllowDownload(t *testing.T) {
+	mock := &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			if arg.Settings == nil {
+				t.Fatal("settings = nil, want allow-download settings")
+			}
+			if !arg.Settings.AllowDownload {
+				t.Fatal("AllowDownload = false, want true")
+			}
+			return sharedLinkFile("/file.txt", "https://example.com/file"), nil
+		},
+	}
+	stubSharedLinkClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("allow-download", false, "")
+	cmd.SetOut(&stdout)
+	if err := cmd.Flags().Set("allow-download", "true"); err != nil {
+		t.Fatalf("set allow-download: %v", err)
+	}
+
+	if err := shareLinkCreate(cmd, []string{"/file.txt"}); err != nil {
+		t.Fatalf("shareLinkCreate error: %v", err)
+	}
+
+	if got := stdout.String(); got != "https://example.com/file\n" {
+		t.Fatalf("stdout = %q, want URL only", got)
+	}
+}
+
+func TestSharedLinkCreateWithInvalidExpiresReturnsError(t *testing.T) {
+	called := false
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			called = true
+			return nil, nil
+		},
+	})
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("expires", "", "")
+	if err := cmd.Flags().Set("expires", "tomorrow"); err != nil {
+		t.Fatalf("set expires: %v", err)
+	}
+
+	err := shareLinkCreate(cmd, []string{"/file.txt"})
+	if err == nil || !strings.Contains(err.Error(), `invalid --expires "tomorrow": use RFC3339 timestamp`) {
+		t.Fatalf("error = %v, want invalid expires error", err)
+	}
+	if called {
+		t.Fatal("CreateSharedLinkWithSettings should not be called")
+	}
+}
+
+func TestSharedLinkCreateRejectsExpiresWithRemoveExpiration(t *testing.T) {
+	called := false
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			called = true
+			return nil, nil
+		},
+	})
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("expires", "", "")
+	cmd.Flags().Bool("remove-expiration", false, "")
+	if err := cmd.Flags().Set("expires", "2026-07-01T00:00:00Z"); err != nil {
+		t.Fatalf("set expires: %v", err)
+	}
+	if err := cmd.Flags().Set("remove-expiration", "true"); err != nil {
+		t.Fatalf("set remove-expiration: %v", err)
+	}
+
+	err := shareLinkCreate(cmd, []string{"/file.txt"})
+	if err == nil || !strings.Contains(err.Error(), "`--expires` and `--remove-expiration` cannot be used together") {
+		t.Fatalf("error = %v, want mutually exclusive error", err)
+	}
+	if called {
+		t.Fatal("CreateSharedLinkWithSettings should not be called")
+	}
+}
+
+func TestSharedLinkCreateWithRemoveExpirationUsesDefaultCreateSettings(t *testing.T) {
+	mock := &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			if arg.Settings != nil {
+				t.Fatalf("settings = %#v, want nil for new link with remove-expiration", arg.Settings)
+			}
+			return sharedLinkFile("/file.txt", "https://example.com/file"), nil
+		},
+		modifySharedLinkSettingsFn: func(arg *sharing.ModifySharedLinkSettingsArgs) (sharing.IsSharedLinkMetadata, error) {
+			t.Fatal("ModifySharedLinkSettings should not be called for a newly created link")
+			return nil, nil
+		},
+	}
+	stubSharedLinkClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("remove-expiration", false, "")
+	cmd.SetOut(&stdout)
+	if err := cmd.Flags().Set("remove-expiration", "true"); err != nil {
+		t.Fatalf("set remove-expiration: %v", err)
+	}
+
+	if err := shareLinkCreate(cmd, []string{"/file.txt"}); err != nil {
+		t.Fatalf("shareLinkCreate error: %v", err)
+	}
+	if got := stdout.String(); got != "https://example.com/file\n" {
+		t.Fatalf("stdout = %q, want URL only", got)
+	}
+}
+
 func TestSharedLinkCreateVerboseStillPrintsURLOnly(t *testing.T) {
 	mock := &mockSharedLinkClient{
 		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
@@ -283,6 +432,127 @@ func TestSharedLinkCreateVerboseReportsExistingLinkOnStderr(t *testing.T) {
 	}
 }
 
+func TestSharedLinkCreateWithExpiresUpdatesExistingLink(t *testing.T) {
+	wantExpires := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	existing := sharedLinkFile("/file.txt", "https://example.com/file-old")
+	mock := &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			if arg.Settings == nil || arg.Settings.Expires == nil || !arg.Settings.Expires.Equal(wantExpires) {
+				t.Fatalf("create settings = %#v, want expires %s", arg.Settings, wantExpires.Format(time.RFC3339))
+			}
+			return nil, alreadyExistsError(existing)
+		},
+		modifySharedLinkSettingsFn: func(arg *sharing.ModifySharedLinkSettingsArgs) (sharing.IsSharedLinkMetadata, error) {
+			if arg.Url != "https://example.com/file-old" {
+				t.Fatalf("modify URL = %q, want existing URL", arg.Url)
+			}
+			if arg.RemoveExpiration {
+				t.Fatal("RemoveExpiration = true, want false")
+			}
+			if arg.Settings == nil || arg.Settings.Expires == nil || !arg.Settings.Expires.Equal(wantExpires) {
+				t.Fatalf("modify settings = %#v, want expires %s", arg.Settings, wantExpires.Format(time.RFC3339))
+			}
+			return sharedLinkFile("/file.txt", "https://example.com/file-new"), nil
+		},
+	}
+	stubSharedLinkClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().String("expires", "", "")
+	cmd.SetOut(&stdout)
+	if err := cmd.Flags().Set("expires", wantExpires.Format(time.RFC3339)); err != nil {
+		t.Fatalf("set expires: %v", err)
+	}
+
+	if err := shareLinkCreate(cmd, []string{"/file.txt"}); err != nil {
+		t.Fatalf("shareLinkCreate error: %v", err)
+	}
+	if got := stdout.String(); got != "https://example.com/file-new\n" {
+		t.Fatalf("stdout = %q, want updated URL", got)
+	}
+}
+
+func TestSharedLinkCreateWithRemoveExpirationUpdatesExistingLink(t *testing.T) {
+	existing := sharedLinkFile("/file.txt", "https://example.com/file-old")
+	mock := &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			if arg.Settings != nil {
+				t.Fatalf("create settings = %#v, want nil", arg.Settings)
+			}
+			return nil, alreadyExistsError(existing)
+		},
+		modifySharedLinkSettingsFn: func(arg *sharing.ModifySharedLinkSettingsArgs) (sharing.IsSharedLinkMetadata, error) {
+			if arg.Url != "https://example.com/file-old" {
+				t.Fatalf("modify URL = %q, want existing URL", arg.Url)
+			}
+			if !arg.RemoveExpiration {
+				t.Fatal("RemoveExpiration = false, want true")
+			}
+			if arg.Settings == nil {
+				t.Fatal("settings = nil, want empty settings object")
+			}
+			return sharedLinkFile("/file.txt", "https://example.com/file-new"), nil
+		},
+	}
+	stubSharedLinkClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("remove-expiration", false, "")
+	cmd.SetOut(&stdout)
+	if err := cmd.Flags().Set("remove-expiration", "true"); err != nil {
+		t.Fatalf("set remove-expiration: %v", err)
+	}
+
+	if err := shareLinkCreate(cmd, []string{"/file.txt"}); err != nil {
+		t.Fatalf("shareLinkCreate error: %v", err)
+	}
+	if got := stdout.String(); got != "https://example.com/file-new\n" {
+		t.Fatalf("stdout = %q, want updated URL", got)
+	}
+}
+
+func TestSharedLinkCreateWithAllowDownloadUpdatesExistingLink(t *testing.T) {
+	existing := sharedLinkFile("/file.txt", "https://example.com/file-old")
+	mock := &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			if arg.Settings == nil || !arg.Settings.AllowDownload {
+				t.Fatalf("create settings = %#v, want allow download", arg.Settings)
+			}
+			return nil, alreadyExistsError(existing)
+		},
+		modifySharedLinkSettingsFn: func(arg *sharing.ModifySharedLinkSettingsArgs) (sharing.IsSharedLinkMetadata, error) {
+			if arg.Url != "https://example.com/file-old" {
+				t.Fatalf("modify URL = %q, want existing URL", arg.Url)
+			}
+			if arg.RemoveExpiration {
+				t.Fatal("RemoveExpiration = true, want false")
+			}
+			if arg.Settings == nil || !arg.Settings.AllowDownload {
+				t.Fatalf("modify settings = %#v, want allow download", arg.Settings)
+			}
+			return sharedLinkFile("/file.txt", "https://example.com/file-new"), nil
+		},
+	}
+	stubSharedLinkClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("allow-download", false, "")
+	cmd.SetOut(&stdout)
+	if err := cmd.Flags().Set("allow-download", "true"); err != nil {
+		t.Fatalf("set allow-download: %v", err)
+	}
+
+	if err := shareLinkCreate(cmd, []string{"/file.txt"}); err != nil {
+		t.Fatalf("shareLinkCreate error: %v", err)
+	}
+	if got := stdout.String(); got != "https://example.com/file-new\n" {
+		t.Fatalf("stdout = %q, want updated URL", got)
+	}
+}
+
 func TestSharedLinkCreateFallbackPrefersExactPathLower(t *testing.T) {
 	var listArg *sharing.ListSharedLinksArg
 	mock := &mockSharedLinkClient{
@@ -401,6 +671,15 @@ func TestShareLinkCreateDoesNotBreakShareListLinkCommand(t *testing.T) {
 	}
 	if cmd != shareLinkCreateCmd {
 		t.Fatalf("share-link create resolved to %q", cmd.CommandPath())
+	}
+	if shareLinkCreateCmd.Flags().Lookup("allow-download") == nil {
+		t.Fatal("share-link create should define --allow-download")
+	}
+	if shareLinkCreateCmd.Flags().Lookup("expires") == nil {
+		t.Fatal("share-link create should define --expires")
+	}
+	if shareLinkCreateCmd.Flags().Lookup("remove-expiration") == nil {
+		t.Fatal("share-link create should define --remove-expiration")
 	}
 
 	cmd, _, err = RootCmd.Find([]string{"share", "list", "link"})

--- a/cmd/share_link_create.go
+++ b/cmd/share_link_create.go
@@ -19,10 +19,17 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
 	"github.com/spf13/cobra"
 )
+
+type shareLinkCreateOptions struct {
+	expires          *time.Time
+	removeExpiration bool
+	allowDownload    bool
+}
 
 func shareLinkCreate(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
@@ -37,12 +44,25 @@ func shareLinkCreate(cmd *cobra.Command, args []string) error {
 		return errors.New("cannot create a shared link for Dropbox root")
 	}
 
+	opts, err := parseShareLinkCreateOptions(cmd)
+	if err != nil {
+		return err
+	}
+
 	dbx := newSharedLinkClient(config)
 	arg := sharing.NewCreateSharedLinkWithSettingsArg(path)
+	if opts.expires != nil || opts.allowDownload {
+		arg.Settings = sharing.NewSharedLinkSettings()
+		applySharedLinkCreateSettings(arg.Settings, opts)
+	}
 	link, err := dbx.CreateSharedLinkWithSettings(arg)
 	usedExisting := false
 	if err != nil {
 		link, err = existingSharedLink(dbx, path, err)
+		if err != nil {
+			return err
+		}
+		link, err = applyExistingSharedLinkCreateOptions(dbx, link, opts)
 		if err != nil {
 			return err
 		}
@@ -65,6 +85,68 @@ func shareLinkCreate(cmd *cobra.Command, args []string) error {
 		_, err := fmt.Fprintln(w, url)
 		return err
 	})
+}
+
+func parseShareLinkCreateOptions(cmd *cobra.Command) (shareLinkCreateOptions, error) {
+	var opts shareLinkCreateOptions
+
+	if cmd.Flags().Changed("expires") {
+		expires, err := shareLinkExpiresFlag(cmd)
+		if err != nil {
+			return opts, err
+		}
+		opts.expires = expires
+	}
+
+	if cmd.Flags().Changed("remove-expiration") {
+		removeExpiration, err := cmd.Flags().GetBool("remove-expiration")
+		if err != nil {
+			return opts, err
+		}
+		opts.removeExpiration = removeExpiration
+	}
+
+	if cmd.Flags().Changed("allow-download") {
+		allowDownload, err := cmd.Flags().GetBool("allow-download")
+		if err != nil {
+			return opts, err
+		}
+		opts.allowDownload = allowDownload
+	}
+
+	if opts.expires != nil && opts.removeExpiration {
+		return opts, errors.New("`--expires` and `--remove-expiration` cannot be used together")
+	}
+
+	return opts, nil
+}
+
+func applyExistingSharedLinkCreateOptions(dbx sharedLinkClient, link sharing.IsSharedLinkMetadata, opts shareLinkCreateOptions) (sharing.IsSharedLinkMetadata, error) {
+	if opts.expires == nil && !opts.removeExpiration && !opts.allowDownload {
+		return link, nil
+	}
+
+	url, ok := sharedLinkURL(link)
+	if !ok {
+		return nil, errors.New("existing shared link response did not include a URL")
+	}
+
+	settings := sharing.NewSharedLinkSettings()
+	applySharedLinkCreateSettings(settings, opts)
+
+	arg := sharing.NewModifySharedLinkSettingsArgs(url, settings)
+	arg.RemoveExpiration = opts.removeExpiration
+
+	return dbx.ModifySharedLinkSettings(arg)
+}
+
+func applySharedLinkCreateSettings(settings *sharing.SharedLinkSettings, opts shareLinkCreateOptions) {
+	if opts.expires != nil {
+		settings.Expires = opts.expires
+	}
+	if opts.allowDownload {
+		settings.AllowDownload = true
+	}
 }
 
 func existingSharedLink(dbx sharedLinkClient, path string, err error) (sharing.IsSharedLinkMetadata, error) {
@@ -179,6 +261,18 @@ func sameDropboxPath(a string, b string) bool {
 	return strings.EqualFold(cleanDropboxPath(a), cleanDropboxPath(b))
 }
 
+func shareLinkExpiresFlag(cmd *cobra.Command) (*time.Time, error) {
+	value, err := cmd.Flags().GetString("expires")
+	if err != nil {
+		return nil, err
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --expires %q: use RFC3339 timestamp", value)
+	}
+	return &parsed, nil
+}
+
 var shareLinkCreateCmd = &cobra.Command{
 	Use:   "create <path>",
 	Short: "Create a shared link",
@@ -186,5 +280,8 @@ var shareLinkCreateCmd = &cobra.Command{
 }
 
 func init() {
+	shareLinkCreateCmd.Flags().Bool("allow-download", false, "Allow downloads from the shared link")
+	shareLinkCreateCmd.Flags().String("expires", "", "Set shared link expiration time as an RFC3339 timestamp")
+	shareLinkCreateCmd.Flags().Bool("remove-expiration", false, "Remove expiration when returning an existing shared link")
 	shareLinkCmd.AddCommand(shareLinkCreateCmd)
 }


### PR DESCRIPTION
## Summary

- Add `--expires` flag to set expiration on created shared links (RFC3339 timestamp)
- Add `--allow-download` flag to enable downloads on created shared links
- Add `--remove-expiration` flag to remove expiration when returning an existing link
- When the link already exists, flags are applied via `ModifySharedLinkSettings`
- `--expires` and `--remove-expiration` are mutually exclusive

## Test plan

- [x] `--expires` sets expiration on new link creation
- [x] `--allow-download` sets allow-download on new link creation
- [x] Invalid `--expires` value returns clear error before API call
- [x] `--expires` + `--remove-expiration` rejected as mutually exclusive
- [x] `--remove-expiration` is a no-op for freshly created links
- [x] `--expires` calls ModifySharedLinkSettings on existing links
- [x] `--remove-expiration` calls ModifySharedLinkSettings on existing links
- [x] `--allow-download` calls ModifySharedLinkSettings on existing links
- [x] Flags are registered on the command
- [x] golangci-lint clean, all tests pass