### PR TITLE
Add long descriptions and examples to share-link commands

### DIFF
--- a/cmd/share-list-links.go
+++ b/cmd/share-list-links.go
@@ -119,7 +119,11 @@ func sharedLinkMetadataDisplay(sl sharing.SharedLinkMetadata) (name string, url 
 var shareLinkListCmd = &cobra.Command{
 	Use:   "list [path]",
 	Short: "List shared links",
-	RunE:  shareLinkList,
+	Long: `List shared links.
+When path is supplied, dbxcli lists direct shared links for that Dropbox path only.`,
+	Example: `  dbxcli share-link list
+  dbxcli share-link list /file.txt`,
+	RunE: shareLinkList,
 }
 
 var shareListLinksCmd = &cobra.Command{

--- a/cmd/share_link.go
+++ b/cmd/share_link.go
@@ -48,6 +48,7 @@ var newSharedLinkClient = func(cfg dropbox.Config) sharedLinkClient {
 var shareLinkCmd = &cobra.Command{
 	Use:   "share-link",
 	Short: "Shared link commands",
+	Long:  "Create, list, inspect, download, update, and revoke Dropbox shared links.",
 }
 
 func init() {

--- a/cmd/share_link_create.go
+++ b/cmd/share_link_create.go
@@ -416,7 +416,15 @@ func linkAudience(tag string) *sharing.LinkAudience {
 var shareLinkCreateCmd = &cobra.Command{
 	Use:   "create <path>",
 	Short: "Create a shared link",
-	RunE:  shareLinkCreate,
+	Long: `Create a shared link for a Dropbox file or folder.
+If a direct shared link already exists, dbxcli returns that existing URL.
+Settings flags request Dropbox shared-link settings; account, team, and folder policies may still restrict the result.`,
+	Example: `  dbxcli share-link create /file.txt
+  dbxcli share-link create /folder
+  dbxcli share-link create /file.txt --audience team
+  dbxcli share-link create /file.txt --expires 2026-07-01T00:00:00Z
+  dbxcli share-link create /file.txt --password-prompt`,
+	RunE: shareLinkCreate,
 }
 
 func init() {

--- a/cmd/share_link_download.go
+++ b/cmd/share_link_download.go
@@ -498,8 +498,8 @@ func sharedLinkDownloadSize(link sharing.IsSharedLinkMetadata) uint64 {
 
 var shareLinkDownloadCmd = &cobra.Command{
 	Use:   "download <url> [target]",
-	Short: "Download a shared link file",
-	Long: `Download a file from a Dropbox shared link.
+	Short: "Download shared link content",
+	Long: `Download content from a Dropbox shared link.
   - If target is omitted, the local filename comes from shared-link metadata.
   - Use --path to download a file inside a folder shared link.
   - Use - as target to write file bytes to stdout.

--- a/cmd/share_link_info.go
+++ b/cmd/share_link_info.go
@@ -155,7 +155,11 @@ func sharedLinkBaseMetadata(link sharing.IsSharedLinkMetadata) (*sharing.SharedL
 var shareLinkInfoCmd = &cobra.Command{
 	Use:   "info <url>",
 	Short: "Display shared link information",
-	RunE:  shareLinkInfo,
+	Long: `Display metadata and permissions for a shared link.
+Use --path to inspect a file or folder inside a folder shared link.`,
+	Example: `  dbxcli share-link info https://www.dropbox.com/s/example/file.txt
+  dbxcli share-link info https://www.dropbox.com/s/example/folder --path /nested/file.txt`,
+	RunE: shareLinkInfo,
 }
 
 func init() {

--- a/cmd/share_link_update.go
+++ b/cmd/share_link_update.go
@@ -187,7 +187,14 @@ func rawSharedLinkSettingsFromUpdateOptions(opts shareLinkUpdateOptions) *rawSha
 var shareLinkUpdateCmd = &cobra.Command{
 	Use:   "update <url>",
 	Short: "Update shared link settings",
-	RunE:  shareLinkUpdate,
+	Long: `Update settings for an existing shared link.
+At least one setting flag is required. Dropbox account, team, and folder policies may reject or constrain requested settings.`,
+	Example: `  dbxcli share-link update https://www.dropbox.com/s/example/file.txt --audience team
+  dbxcli share-link update https://www.dropbox.com/s/example/file.txt --expires 2026-07-01T00:00:00Z
+  dbxcli share-link update https://www.dropbox.com/s/example/file.txt --remove-expiration
+  dbxcli share-link update https://www.dropbox.com/s/example/file.txt --password-prompt
+  dbxcli share-link update https://www.dropbox.com/s/example/file.txt --remove-password`,
+	RunE: shareLinkUpdate,
 }
 
 func init() {


### PR DESCRIPTION
## Summary

- Add `Long` and `Example` fields to all share-link subcommands (create, list, info, download, update)
- Add `Long` description to the `share-link` parent command
- Update `share-link download` short description from "file" to "content"

Depends on #261.

## Test plan

- [x] `dbxcli share-link --help` shows long description
- [x] `dbxcli share-link create --help` shows examples
- [x] No logic changes — documentation only
- [x] golangci-lint clean, all tests pass