### PR TITLE
Add JSON output support to rm and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Text output is the default. JSON output is available through the global `--outpu
 
 ```sh
 $ dbxcli <command> --output=json
+$ dbxcli rm --output=json /old-file.txt
+$ dbxcli restore --output=json /Reports/old.pdf 015f...
 ```
 
 JSON support is rolling out command by command. Commands that have not been migrated return `structured output is not supported for this command yet` when used with `--output=json`.

--- a/cmd/metadata.go
+++ b/cmd/metadata.go
@@ -1,0 +1,22 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+func metadataDisplayPath(inputPath, metadataPath string) string {
+	if metadataPath != "" {
+		return metadataPath
+	}
+	return inputPath
+}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -16,6 +16,8 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
@@ -27,19 +29,9 @@ type restoreInput struct {
 	Revision string `json:"revision"`
 }
 
-type restoreMetadata struct {
-	Type           string    `json:"type"`
-	PathDisplay    string    `json:"path_display,omitempty"`
-	ID             string    `json:"id,omitempty"`
-	Rev            string    `json:"rev,omitempty"`
-	Size           uint64    `json:"size,omitempty"`
-	ClientModified time.Time `json:"client_modified"`
-	ServerModified time.Time `json:"server_modified"`
-}
-
 type restoreResult struct {
-	Input  restoreInput    `json:"input"`
-	Result restoreMetadata `json:"result"`
+	Input  restoreInput `json:"input"`
+	Result jsonMetadata `json:"result"`
 }
 
 func restore(cmd *cobra.Command, args []string) (err error) {
@@ -63,11 +55,14 @@ func restore(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	verbose, _ := cmd.Flags().GetBool("verbose")
-	if verbose {
-		printRestoreResult(cmd, newRestoreResult(path, rev, metadata))
-	}
+	result := newRestoreResult(path, rev, metadata)
 
-	return
+	return commandOutput(cmd).Render(func(w io.Writer) error {
+		if !verbose {
+			return nil
+		}
+		return renderRestoreResult(w, result)
+	}, result)
 }
 
 func newRestoreResult(path, revision string, metadata *files.FileMetadata) restoreResult {
@@ -80,38 +75,41 @@ func newRestoreResult(path, revision string, metadata *files.FileMetadata) resto
 	}
 }
 
-func restoreMetadataFromDropbox(path string, metadata *files.FileMetadata) restoreMetadata {
+func restoreMetadataFromDropbox(path string, metadata *files.FileMetadata) jsonMetadata {
 	if metadata == nil {
-		return restoreMetadata{
+		return jsonMetadata{
 			Type:        "file",
 			PathDisplay: path,
 		}
 	}
-	return restoreMetadata{
-		Type:           "file",
-		PathDisplay:    metadataDisplayPath(path, metadata.PathDisplay),
-		ID:             metadata.Id,
-		Rev:            metadata.Rev,
-		Size:           metadata.Size,
-		ClientModified: metadata.ClientModified,
-		ServerModified: metadata.ServerModified,
-	}
+
+	result := jsonMetadataFromDropbox(metadata)
+	result.PathDisplay = metadataDisplayPath(path, result.PathDisplay)
+	return result
 }
 
-func printRestoreResult(cmd *cobra.Command, result restoreResult) {
+func renderRestoreResult(w io.Writer, result restoreResult) error {
 	path := result.Result.PathDisplay
 	if path == "" {
 		path = result.Input.Path
 	}
 
 	if result.Result.Rev != "" && result.Result.Rev != result.Input.Revision {
-		commandOutput(cmd).Info("Restored %s to revision %s (current revision %s, server modified %s)",
-			path, result.Input.Revision, result.Result.Rev, result.Result.ServerModified.Format(time.RFC3339))
-		return
+		_, err := fmt.Fprintf(w, "Restored %s to revision %s (current revision %s, server modified %s)\n",
+			path, result.Input.Revision, result.Result.Rev, restoreResultServerModified(result))
+		return err
 	}
 
-	commandOutput(cmd).Info("Restored %s to revision %s (server modified %s)",
-		path, result.Input.Revision, result.Result.ServerModified.Format(time.RFC3339))
+	_, err := fmt.Fprintf(w, "Restored %s to revision %s (server modified %s)\n",
+		path, result.Input.Revision, restoreResultServerModified(result))
+	return err
+}
+
+func restoreResultServerModified(result restoreResult) string {
+	if result.Result.ServerModified != nil {
+		return *result.Result.ServerModified
+	}
+	return time.Time{}.Format(time.RFC3339)
 }
 
 // restoreCmd represents the restore command
@@ -129,4 +127,5 @@ Use "dbxcli revs <target-path>" to list available revisions.`,
 
 func init() {
 	RootCmd.AddCommand(restoreCmd)
+	enableStructuredOutput(restoreCmd)
 }

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -45,7 +47,7 @@ func TestRestoreQuietByDefault(t *testing.T) {
 		restoreFn: func(arg *files.RestoreArg) (*files.FileMetadata, error) {
 			restoreArg = arg
 			return &files.FileMetadata{
-				Metadata:       files.Metadata{PathDisplay: "/Reports/old.pdf"},
+				Metadata:       files.Metadata{PathDisplay: "/Reports/old.pdf", PathLower: "/reports/old.pdf"},
 				Rev:            "current-rev",
 				ServerModified: serverModified,
 			}, nil
@@ -77,7 +79,7 @@ func TestRestoreVerbosePrintsRevisionAndServerModifiedTime(t *testing.T) {
 	mock := &mockFilesClient{
 		restoreFn: func(arg *files.RestoreArg) (*files.FileMetadata, error) {
 			return &files.FileMetadata{
-				Metadata:       files.Metadata{PathDisplay: "/Reports/old.pdf"},
+				Metadata:       files.Metadata{PathDisplay: "/Reports/old.pdf", PathLower: "/reports/old.pdf"},
 				Rev:            "current-rev",
 				ServerModified: serverModified,
 			}, nil
@@ -101,6 +103,7 @@ func TestNewRestoreResultKeepsInputAndMetadata(t *testing.T) {
 	result := newRestoreResult("/Reports/old.pdf", "target-rev", &files.FileMetadata{
 		Metadata: files.Metadata{
 			PathDisplay: "/Reports/old.pdf",
+			PathLower:   "/reports/old.pdf",
 		},
 		Id:             "id:abc",
 		Rev:            "current-rev",
@@ -115,11 +118,141 @@ func TestNewRestoreResultKeepsInputAndMetadata(t *testing.T) {
 	if result.Result.Type != "file" || result.Result.PathDisplay != "/Reports/old.pdf" {
 		t.Fatalf("metadata = %#v, want file path metadata", result.Result)
 	}
-	if result.Result.ID != "id:abc" || result.Result.Rev != "current-rev" || result.Result.Size != 123 {
+	if result.Result.ID != "id:abc" || result.Result.Rev != "current-rev" ||
+		result.Result.Size == nil || *result.Result.Size != 123 {
 		t.Fatalf("metadata = %#v, want id, current rev, and size", result.Result)
 	}
-	if !result.Result.ClientModified.Equal(clientModified) || !result.Result.ServerModified.Equal(serverModified) {
-		t.Fatalf("metadata times = %#v, want client and server modified times", result.Result)
+	if result.Result.ServerModified == nil || *result.Result.ServerModified != "2026-06-17T12:30:00Z" {
+		t.Fatalf("server modified = %v, want 2026-06-17T12:30:00Z", result.Result.ServerModified)
+	}
+	if result.Result.ClientModified == nil || *result.Result.ClientModified != "2026-06-16T10:00:00Z" {
+		t.Fatalf("client modified = %v, want 2026-06-16T10:00:00Z", result.Result.ClientModified)
+	}
+}
+
+func TestRestoreJSONOutputsInputAndMetadata(t *testing.T) {
+	cmd, stdout := testRestoreCmd()
+	setRestoreOutputJSON(t, cmd)
+	var restoreArg *files.RestoreArg
+	clientModified := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	serverModified := time.Date(2026, 6, 17, 12, 30, 0, 0, time.UTC)
+	mock := &mockFilesClient{
+		restoreFn: func(arg *files.RestoreArg) (*files.FileMetadata, error) {
+			restoreArg = arg
+			return &files.FileMetadata{
+				Metadata: files.Metadata{
+					PathDisplay: "/Reports/old.pdf",
+					PathLower:   "/reports/old.pdf",
+				},
+				Id:             "id:abc",
+				Rev:            "current-rev",
+				Size:           123,
+				ClientModified: clientModified,
+				ServerModified: serverModified,
+			}, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := restore(cmd, []string{"/Reports/old.pdf", "target-rev"}); err != nil {
+		t.Fatalf("restore error: %v", err)
+	}
+	if restoreArg == nil || restoreArg.Path != "/Reports/old.pdf" || restoreArg.Rev != "target-rev" {
+		t.Fatalf("restore arg = %#v, want path /Reports/old.pdf and rev target-rev", restoreArg)
+	}
+
+	got := decodeRestoreOutput(t, stdout)
+	if got.Input.Path != "/Reports/old.pdf" || got.Input.Revision != "target-rev" {
+		t.Fatalf("input = %#v, want path and target revision", got.Input)
+	}
+	if got.Result.Type != "file" || got.Result.PathDisplay != "/Reports/old.pdf" || got.Result.PathLower != "/reports/old.pdf" {
+		t.Fatalf("metadata = %#v, want file path metadata", got.Result)
+	}
+	if got.Result.ID != "id:abc" || got.Result.Rev != "current-rev" {
+		t.Fatalf("metadata = %#v, want returned id and current revision", got.Result)
+	}
+	if got.Result.Size == nil || *got.Result.Size != 123 {
+		t.Fatalf("size = %v, want 123", got.Result.Size)
+	}
+	if got.Result.ServerModified == nil || *got.Result.ServerModified != "2026-06-17T12:30:00Z" {
+		t.Fatalf("server modified = %v, want 2026-06-17T12:30:00Z", got.Result.ServerModified)
+	}
+	if got.Result.ClientModified == nil || *got.Result.ClientModified != "2026-06-16T10:00:00Z" {
+		t.Fatalf("client modified = %v, want 2026-06-16T10:00:00Z", got.Result.ClientModified)
+	}
+}
+
+func TestRestoreJSONUsesInputPathWhenMetadataPathDisplayMissing(t *testing.T) {
+	cmd, stdout := testRestoreCmd()
+	setRestoreOutputJSON(t, cmd)
+	mock := &mockFilesClient{
+		restoreFn: func(arg *files.RestoreArg) (*files.FileMetadata, error) {
+			return &files.FileMetadata{Rev: "current-rev"}, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := restore(cmd, []string{"/Reports/old.pdf", "target-rev"}); err != nil {
+		t.Fatalf("restore error: %v", err)
+	}
+
+	got := decodeRestoreOutput(t, stdout)
+	if got.Result.PathDisplay != "/Reports/old.pdf" {
+		t.Fatalf("path_display = %q, want fallback input path", got.Result.PathDisplay)
+	}
+}
+
+func TestRestoreJSONVerboseDoesNotPrintText(t *testing.T) {
+	cmd, stdout := testRestoreCmd()
+	setRestoreOutputJSON(t, cmd)
+	if err := cmd.Flags().Set("verbose", "true"); err != nil {
+		t.Fatalf("set verbose: %v", err)
+	}
+
+	mock := &mockFilesClient{
+		restoreFn: func(arg *files.RestoreArg) (*files.FileMetadata, error) {
+			return &files.FileMetadata{
+				Metadata:       files.Metadata{PathDisplay: "/Reports/old.pdf"},
+				Rev:            "current-rev",
+				ServerModified: time.Date(2026, 6, 17, 12, 30, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := restore(cmd, []string{"/Reports/old.pdf", "target-rev"}); err != nil {
+		t.Fatalf("restore error: %v", err)
+	}
+	if strings.Contains(stdout.String(), "Restored ") {
+		t.Fatalf("stdout = %q, want JSON only", stdout.String())
+	}
+	got := decodeRestoreOutput(t, stdout)
+	if got.Result.Rev != "current-rev" {
+		t.Fatalf("rev = %q, want current-rev", got.Result.Rev)
+	}
+}
+
+func TestRestoreJSONErrorWritesNoOutput(t *testing.T) {
+	cmd, stdout := testRestoreCmd()
+	setRestoreOutputJSON(t, cmd)
+	mock := &mockFilesClient{
+		restoreFn: func(arg *files.RestoreArg) (*files.FileMetadata, error) {
+			return nil, errors.New("restore failed")
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := restore(cmd, []string{"/Reports/old.pdf", "target-rev"}); err == nil {
+		t.Fatal("expected restore error")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty output on error", got)
+	}
+}
+
+func TestRestoreCommandSupportsStructuredOutput(t *testing.T) {
+	if !commandSupportsStructuredOutput(restoreCmd) {
+		t.Fatal("restore command should support structured output")
 	}
 }
 
@@ -128,5 +261,24 @@ func testRestoreCmd() (*cobra.Command, *bytes.Buffer) {
 	cmd := &cobra.Command{Use: "restore"}
 	cmd.SetOut(&stdout)
 	cmd.Flags().BoolP("verbose", "v", false, "")
+	cmd.Flags().String(outputFlag, "text", "")
 	return cmd, &stdout
+}
+
+func setRestoreOutputJSON(t *testing.T, cmd *cobra.Command) {
+	t.Helper()
+
+	if err := cmd.Flags().Set(outputFlag, "json"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func decodeRestoreOutput(t *testing.T, stdout *bytes.Buffer) restoreResult {
+	t.Helper()
+
+	var got restoreResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode JSON output: %v\noutput: %s", err, stdout.String())
+	}
+	return got
 }

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 
@@ -42,17 +43,13 @@ type removeInput struct {
 	Force     bool   `json:"force"`
 }
 
-type removeMetadata struct {
-	Type        string `json:"type"`
-	PathDisplay string `json:"path_display,omitempty"`
-	ID          string `json:"id,omitempty"`
-	Rev         string `json:"rev,omitempty"`
-	Size        uint64 `json:"size,omitempty"`
+type removeResult struct {
+	Input  removeInput  `json:"input"`
+	Result jsonMetadata `json:"result"`
 }
 
-type removeResult struct {
-	Input  removeInput    `json:"input"`
-	Result removeMetadata `json:"result"`
+type removeOutput struct {
+	Results []removeResult `json:"results"`
 }
 
 func rm(cmd *cobra.Command, args []string) error {
@@ -77,11 +74,12 @@ func rm(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if opts.verbose {
-		printRemoveResults(cmd, results)
-	}
-
-	return nil
+	return commandOutput(cmd).Render(func(w io.Writer) error {
+		if !opts.verbose {
+			return nil
+		}
+		return renderRemoveResults(w, results)
+	}, removeOutput{Results: results})
 }
 
 func parseRemoveOptions(cmd *cobra.Command) (removeOptions, error) {
@@ -180,46 +178,25 @@ func newRemoveResult(path string, metadata files.IsMetadata, opts removeOptions)
 	}
 }
 
-func removeMetadataFromDropbox(path string, metadata files.IsMetadata) removeMetadata {
-	switch m := metadata.(type) {
-	case *files.FileMetadata:
-		return removeMetadata{
-			Type:        "file",
-			PathDisplay: metadataDisplayPath(path, m.PathDisplay),
-			ID:          m.Id,
-			Rev:         m.Rev,
-			Size:        m.Size,
-		}
-	case *files.FolderMetadata:
-		return removeMetadata{
-			Type:        "folder",
-			PathDisplay: metadataDisplayPath(path, m.PathDisplay),
-			ID:          m.Id,
-		}
-	default:
-		return removeMetadata{
-			Type:        "unknown",
-			PathDisplay: path,
-		}
-	}
+func removeMetadataFromDropbox(path string, metadata files.IsMetadata) jsonMetadata {
+	result := jsonMetadataFromDropbox(metadata)
+	result.PathDisplay = metadataDisplayPath(path, result.PathDisplay)
+	return result
 }
 
-func metadataDisplayPath(inputPath, metadataPath string) string {
-	if metadataPath != "" {
-		return metadataPath
-	}
-	return inputPath
-}
-
-func printRemoveResults(cmd *cobra.Command, results []removeResult) {
-	out := commandOutput(cmd)
+func renderRemoveResults(w io.Writer, results []removeResult) error {
 	for _, result := range results {
 		if result.Input.Permanent {
-			out.Info("Permanently deleted %s", result.displayPath())
+			if _, err := fmt.Fprintf(w, "Permanently deleted %s\n", result.displayPath()); err != nil {
+				return err
+			}
 			continue
 		}
-		out.Info("Deleted %s", result.displayPath())
+		if _, err := fmt.Fprintf(w, "Deleted %s\n", result.displayPath()); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (r removeResult) displayPath() string {
@@ -242,6 +219,7 @@ var rmCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(rmCmd)
+	enableStructuredOutput(rmCmd)
 	rmCmd.Flags().BoolP("force", "f", false, "Allow removing non-empty folders; same as --recursive")
 	rmCmd.Flags().BoolP("recursive", "r", false, "Recursively remove folders")
 	rmCmd.Flags().Bool("permanent", false, "Permanently delete instead of moving to Dropbox trash")

--- a/cmd/rm_test.go
+++ b/cmd/rm_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -20,6 +22,7 @@ func testRmCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
 	cmd.Flags().BoolP("recursive", "r", false, "")
 	cmd.Flags().Bool("permanent", false, "")
 	cmd.Flags().BoolP("verbose", "v", false, "")
+	cmd.Flags().String(outputFlag, "text", "")
 	return cmd, &stdout
 }
 
@@ -36,6 +39,7 @@ func rmFileMetadata(path string) *files.FileMetadata {
 		Metadata: files.Metadata{
 			Name:        strings.TrimPrefix(path, "/"),
 			PathDisplay: path,
+			PathLower:   strings.ToLower(path),
 		},
 		Id:   "id:file",
 		Rev:  "rev",
@@ -48,9 +52,34 @@ func rmFolderMetadata(path string) *files.FolderMetadata {
 		Metadata: files.Metadata{
 			Name:        strings.TrimPrefix(path, "/"),
 			PathDisplay: path,
+			PathLower:   strings.ToLower(path),
 		},
 		Id: "id:folder",
 	}
+}
+
+func setRmOutputJSON(t *testing.T, cmd *cobra.Command) {
+	t.Helper()
+
+	if err := cmd.Flags().Set(outputFlag, "json"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func decodeRemoveOutput(t *testing.T, stdout *bytes.Buffer) removeOutput {
+	t.Helper()
+
+	return decodeRemoveOutputString(t, stdout.String())
+}
+
+func decodeRemoveOutputString(t *testing.T, output string) removeOutput {
+	t.Helper()
+
+	var got removeOutput
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode JSON output: %v\noutput: %s", err, output)
+	}
+	return got
 }
 
 func rmNonEmptyFolderResult() *files.ListFolderResult {
@@ -378,5 +407,217 @@ func TestRmVerbosePrintsPermanentDeleteResults(t *testing.T) {
 	}
 	if got, want := stdout.String(), "Permanently deleted /File.txt\n"; got != want {
 		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRmJSONDeletesFile(t *testing.T) {
+	cmd, stdout := testRmCmd(t)
+	setRmOutputJSON(t, cmd)
+	file := rmFileMetadata("/File.txt")
+	deletedFile := rmFileMetadata("/File.txt")
+	deletedFile.Rev = "deleted-rev"
+	deletedFile.Size = 456
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return file, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			return files.NewDeleteResult(deletedFile), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/File.txt"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+
+	got := decodeRemoveOutput(t, stdout)
+	if len(got.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if result.Input.Path != "/File.txt" {
+		t.Fatalf("input path = %q, want /File.txt", result.Input.Path)
+	}
+	if result.Input.Permanent || result.Input.Recursive || result.Input.Force {
+		t.Fatalf("input flags = %+v, want all false", result.Input)
+	}
+	if result.Result.Type != "file" {
+		t.Fatalf("result type = %q, want file", result.Result.Type)
+	}
+	if result.Result.PathDisplay != "/File.txt" {
+		t.Fatalf("path_display = %q, want /File.txt", result.Result.PathDisplay)
+	}
+	if result.Result.PathLower != "/file.txt" {
+		t.Fatalf("path_lower = %q, want /file.txt", result.Result.PathLower)
+	}
+	if result.Result.ID != "id:file" {
+		t.Fatalf("id = %q, want id:file", result.Result.ID)
+	}
+	if result.Result.Rev != "deleted-rev" {
+		t.Fatalf("rev = %q, want deleted-rev", result.Result.Rev)
+	}
+	if result.Result.Size == nil || *result.Result.Size != 456 {
+		t.Fatalf("size = %v, want 456", result.Result.Size)
+	}
+}
+
+func TestRmJSONFolderOmitsFileFields(t *testing.T) {
+	cmd, stdout := testRmCmd(t)
+	setRmOutputJSON(t, cmd)
+	setRmFlag(t, cmd, "recursive")
+	folder := rmFolderMetadata("/Folder")
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return folder, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			return files.NewDeleteResult(folder), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/Folder"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+
+	output := stdout.String()
+	if strings.Contains(output, `"rev"`) || strings.Contains(output, `"size"`) {
+		t.Fatalf("folder JSON output = %s, want no file-only fields", output)
+	}
+	got := decodeRemoveOutputString(t, output)
+	if len(got.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if result.Result.Type != "folder" {
+		t.Fatalf("result type = %q, want folder", result.Result.Type)
+	}
+	if !result.Input.Recursive {
+		t.Fatalf("recursive = false, want true")
+	}
+}
+
+func TestRmJSONPermanentUsesValidatedMetadata(t *testing.T) {
+	cmd, stdout := testRmCmd(t)
+	setRmOutputJSON(t, cmd)
+	setRmFlag(t, cmd, "permanent")
+	file := rmFileMetadata("/File.txt")
+	file.Rev = "validated-rev"
+	var permanentlyDeleted []string
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return file, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			t.Fatalf("DeleteV2 called for permanent delete: %v", arg)
+			return nil, nil
+		},
+		permanentlyDeleteFn: func(arg *files.DeleteArg) error {
+			permanentlyDeleted = append(permanentlyDeleted, arg.Path)
+			return nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/File.txt"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	if len(permanentlyDeleted) != 1 || permanentlyDeleted[0] != "/File.txt" {
+		t.Fatalf("permanentlyDeleted = %v, want [/File.txt]", permanentlyDeleted)
+	}
+	got := decodeRemoveOutput(t, stdout)
+	if len(got.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if !result.Input.Permanent {
+		t.Fatalf("permanent = false, want true")
+	}
+	if result.Result.Rev != "validated-rev" {
+		t.Fatalf("rev = %q, want validated-rev", result.Result.Rev)
+	}
+}
+
+func TestRmJSONMultipleTargets(t *testing.T) {
+	cmd, stdout := testRmCmd(t)
+	setRmOutputJSON(t, cmd)
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return rmFileMetadata(arg.Path), nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			return files.NewDeleteResult(rmFileMetadata(arg.Path)), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/one.txt", "/two.txt"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+
+	got := decodeRemoveOutput(t, stdout)
+	if len(got.Results) != 2 {
+		t.Fatalf("results len = %d, want 2", len(got.Results))
+	}
+	if got.Results[0].Input.Path != "/one.txt" || got.Results[1].Input.Path != "/two.txt" {
+		t.Fatalf("result paths = %q, %q; want /one.txt, /two.txt", got.Results[0].Input.Path, got.Results[1].Input.Path)
+	}
+}
+
+func TestRmJSONVerboseDoesNotPrintText(t *testing.T) {
+	cmd, stdout := testRmCmd(t)
+	setRmOutputJSON(t, cmd)
+	setRmFlag(t, cmd, "verbose")
+	file := rmFileMetadata("/File.txt")
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return file, nil
+		},
+		deleteV2Fn: func(arg *files.DeleteArg) (*files.DeleteResult, error) {
+			return files.NewDeleteResult(file), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/File.txt"}); err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	if strings.Contains(stdout.String(), "Deleted ") {
+		t.Fatalf("stdout = %q, want JSON only", stdout.String())
+	}
+	got := decodeRemoveOutput(t, stdout)
+	if len(got.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(got.Results))
+	}
+}
+
+func TestRmJSONErrorWritesNoOutput(t *testing.T) {
+	cmd, stdout := testRmCmd(t)
+	setRmOutputJSON(t, cmd)
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, errors.New("metadata failed")
+		},
+	}
+	stubFilesClient(t, mock)
+
+	if err := rm(cmd, []string{"/File.txt"}); err == nil {
+		t.Fatal("expected rm error")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty output on error", got)
+	}
+}
+
+func TestRmCommandSupportsStructuredOutput(t *testing.T) {
+	if !commandSupportsStructuredOutput(rmCmd) {
+		t.Fatal("rm command should support structured output")
 	}
 }


### PR DESCRIPTION
## Summary
- add structured JSON output for rm
- add structured JSON output for restore
- share Dropbox metadata path fallback between commands
- document migrated command examples in README

## Validation
- go test ./cmd
- go test ./...
- go vet ./...
- git diff --check origin/master...HEAD