### PR TITLE
Add --output=json support to account and du commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Text output is the default. JSON output is available through the global `--outpu
 
 ```sh
 $ dbxcli <command> --output=json
+$ dbxcli account --output=json
+$ dbxcli du --output=json
 $ dbxcli ls --output=json /
 $ dbxcli search --output=json report /Reports
 $ dbxcli revs --output=json /Reports/old.pdf
@@ -146,7 +148,7 @@ $ dbxcli rm --output=json /old-file.txt
 $ dbxcli restore --output=json /Reports/old.pdf 015f...
 ```
 
-JSON support is rolling out command by command. Currently migrated commands are `ls`, `search`, `revs`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
+JSON support is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
 
 Command results are written to stdout. Status, progress, warnings, diagnostics, and verbose logs are written to stderr.
 
@@ -215,6 +217,31 @@ Commands that return entry lists, such as `ls`, `search`, and `revs`, return an 
       "size": 123
     }
   ]
+}
+```
+
+Account and usage commands return command-specific objects:
+
+```json
+{
+  "input": {},
+  "account": {
+    "type": "full",
+    "account_id": "dbid:...",
+    "email": "user@example.com",
+    "email_verified": true,
+    "disabled": false
+  }
+}
+```
+
+```json
+{
+  "used": 123,
+  "allocation": {
+    "type": "individual",
+    "allocated": 100000
+  }
 }
 ```
 

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -17,15 +17,58 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
 	"github.com/spf13/cobra"
 )
 
-// printFullAccount prints the account details returned by GetCurrentAccount
-func printFullAccount(w *tabwriter.Writer, fa *users.FullAccount) {
+type accountInput struct {
+	AccountID string `json:"account_id,omitempty"`
+}
+
+type accountOutput struct {
+	Input   accountInput `json:"input"`
+	Account jsonAccount  `json:"account"`
+}
+
+type jsonAccount struct {
+	Type            string           `json:"type"`
+	AccountID       string           `json:"account_id"`
+	Name            *jsonAccountName `json:"name,omitempty"`
+	Email           string           `json:"email"`
+	EmailVerified   bool             `json:"email_verified"`
+	Disabled        bool             `json:"disabled"`
+	ProfilePhotoURL string           `json:"profile_photo_url,omitempty"`
+	Locale          string           `json:"locale,omitempty"`
+	ReferralLink    string           `json:"referral_link,omitempty"`
+	IsPaired        *bool            `json:"is_paired,omitempty"`
+	AccountType     string           `json:"account_type,omitempty"`
+	IsTeammate      *bool            `json:"is_teammate,omitempty"`
+	TeamMemberID    string           `json:"team_member_id,omitempty"`
+	Team            *jsonAccountTeam `json:"team,omitempty"`
+}
+
+type jsonAccountName struct {
+	GivenName       string `json:"given_name,omitempty"`
+	Surname         string `json:"surname,omitempty"`
+	FamiliarName    string `json:"familiar_name,omitempty"`
+	DisplayName     string `json:"display_name,omitempty"`
+	AbbreviatedName string `json:"abbreviated_name,omitempty"`
+}
+
+type jsonAccountTeam struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	MemberID string `json:"member_id,omitempty"`
+}
+
+// renderFullAccount prints the account details returned by GetCurrentAccount.
+func renderFullAccount(out io.Writer, fa *users.FullAccount) error {
+	w := new(tabwriter.Writer)
+	w.Init(out, 4, 8, 1, ' ', 0)
+
 	fmt.Fprintf(w, "Logged in as %s <%s>\n\n", fa.Name.DisplayName, fa.Email)
 	fmt.Fprintf(w, "Account Id:\t%s\n", fa.AccountId)
 	fmt.Fprintf(w, "Account Type:\t%s\n", fa.AccountType.Tag)
@@ -36,20 +79,28 @@ func printFullAccount(w *tabwriter.Writer, fa *users.FullAccount) {
 	if fa.Team != nil {
 		fmt.Fprintf(w, "Team:\n  Name:\t%s\n  Id:\t%s\n  Member Id:\t%s\n", fa.Team.Name, fa.Team.Id, fa.TeamMemberId)
 	}
+
+	return w.Flush()
 }
 
-// printBasicAccount prints the account details returned by GetAccount
-func printBasicAccount(w *tabwriter.Writer, ba *users.BasicAccount) {
+// renderBasicAccount prints the account details returned by GetAccount.
+func renderBasicAccount(out io.Writer, ba *users.BasicAccount) error {
+	w := new(tabwriter.Writer)
+	w.Init(out, 4, 8, 1, ' ', 0)
+
 	fmt.Fprintf(w, "Name:\t%s\n", ba.Name.DisplayName)
+	email := ba.Email
 	if !ba.EmailVerified {
-		ba.Email += " (unverified)"
+		email += " (unverified)"
 	}
-	fmt.Fprintf(w, "Email:\t%s\n", ba.Email)
+	fmt.Fprintf(w, "Email:\t%s\n", email)
 	fmt.Fprintf(w, "Is Teammate:\t%t\n", ba.IsTeammate)
 	if ba.TeamMemberId != "" {
 		fmt.Fprintf(w, "Team Member Id:\t%s\n", ba.TeamMemberId)
 	}
 	fmt.Fprintf(w, "Profile Photo URL:\t%s\n", ba.ProfilePhotoUrl)
+
+	return w.Flush()
 }
 
 func account(cmd *cobra.Command, args []string) error {
@@ -57,9 +108,8 @@ func account(cmd *cobra.Command, args []string) error {
 		return errors.New("`account` accepts an optional `id` argument")
 	}
 
-	dbx := users.New(config)
-	w := new(tabwriter.Writer)
-	w.Init(os.Stdout, 4, 8, 1, ' ', 0)
+	dbx := usersNewFunc(config)
+	out := commandOutput(cmd)
 
 	if len(args) == 0 {
 		// If no arguments are provided get the current user's account
@@ -67,18 +117,83 @@ func account(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		printFullAccount(w, res)
-	} else {
-		// Otherwise look up an account with the provided ID
-		arg := users.NewGetAccountArg(args[0])
-		res, err := dbx.GetAccount(arg)
-		if err != nil {
-			return err
-		}
-		printBasicAccount(w, res)
+		return out.Render(func(w io.Writer) error {
+			return renderFullAccount(w, res)
+		}, accountOutput{
+			Input:   accountInput{},
+			Account: jsonFullAccount(res),
+		})
 	}
 
-	return w.Flush()
+	// Otherwise look up an account with the provided ID
+	arg := users.NewGetAccountArg(args[0])
+	res, err := dbx.GetAccount(arg)
+	if err != nil {
+		return err
+	}
+	return out.Render(func(w io.Writer) error {
+		return renderBasicAccount(w, res)
+	}, accountOutput{
+		Input: accountInput{
+			AccountID: args[0],
+		},
+		Account: jsonBasicAccount(res),
+	})
+}
+
+func jsonFullAccount(fa *users.FullAccount) jsonAccount {
+	account := jsonAccountFromBase("full", fa.Account)
+	account.Locale = fa.Locale
+	account.ReferralLink = fa.ReferralLink
+	account.IsPaired = boolPtr(fa.IsPaired)
+	if fa.AccountType != nil {
+		account.AccountType = fa.AccountType.Tag
+	}
+	account.TeamMemberID = fa.TeamMemberId
+	if fa.Team != nil {
+		account.Team = &jsonAccountTeam{
+			ID:       fa.Team.Id,
+			Name:     fa.Team.Name,
+			MemberID: fa.TeamMemberId,
+		}
+	}
+	return account
+}
+
+func jsonBasicAccount(ba *users.BasicAccount) jsonAccount {
+	account := jsonAccountFromBase("basic", ba.Account)
+	account.IsTeammate = boolPtr(ba.IsTeammate)
+	account.TeamMemberID = ba.TeamMemberId
+	return account
+}
+
+func jsonAccountFromBase(accountType string, account users.Account) jsonAccount {
+	return jsonAccount{
+		Type:            accountType,
+		AccountID:       account.AccountId,
+		Name:            jsonAccountNameFromDropbox(account.Name),
+		Email:           account.Email,
+		EmailVerified:   account.EmailVerified,
+		Disabled:        account.Disabled,
+		ProfilePhotoURL: account.ProfilePhotoUrl,
+	}
+}
+
+func jsonAccountNameFromDropbox(name *users.Name) *jsonAccountName {
+	if name == nil {
+		return nil
+	}
+	return &jsonAccountName{
+		GivenName:       name.GivenName,
+		Surname:         name.Surname,
+		FamiliarName:    name.FamiliarName,
+		DisplayName:     name.DisplayName,
+		AbbreviatedName: name.AbbreviatedName,
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 var accountCmd = &cobra.Command{
@@ -90,4 +205,5 @@ var accountCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(accountCmd)
+	enableStructuredOutput(accountCmd)
 }

--- a/cmd/account_test.go
+++ b/cmd/account_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users_common"
+	"github.com/spf13/cobra"
+)
+
+func TestAccountCurrentTextUsesCommandOutput(t *testing.T) {
+	cmd, stdout := testAccountCmd()
+	stubUsersClient(t, &mockUsersClient{
+		getCurrentAccountFn: func() (*users.FullAccount, error) {
+			return testFullAccount(), nil
+		},
+	})
+
+	if err := account(cmd, nil); err != nil {
+		t.Fatalf("account returned error: %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Logged in as Test User <test@example.com>") {
+		t.Fatalf("stdout = %q, want current account text output", output)
+	}
+	if !strings.Contains(output, "Account Type:") {
+		t.Fatalf("stdout = %q, want account type", output)
+	}
+}
+
+func TestAccountCurrentJSONOutputsAccount(t *testing.T) {
+	cmd, stdout := testAccountCmd()
+	setAccountOutputJSON(t, cmd)
+	stubUsersClient(t, &mockUsersClient{
+		getCurrentAccountFn: func() (*users.FullAccount, error) {
+			return testFullAccount(), nil
+		},
+	})
+
+	if err := account(cmd, nil); err != nil {
+		t.Fatalf("account returned error: %v", err)
+	}
+
+	got := decodeAccountOutput(t, stdout)
+	if got.Input.AccountID != "" {
+		t.Fatalf("input.account_id = %q, want empty for current account", got.Input.AccountID)
+	}
+	account := got.Account
+	if account.Type != "full" || account.AccountID != "dbid:current" || account.Email != "test@example.com" {
+		t.Fatalf("account = %#v, want current full account", account)
+	}
+	if account.Name == nil || account.Name.DisplayName != "Test User" {
+		t.Fatalf("name = %#v, want display name", account.Name)
+	}
+	if account.AccountType != "business" {
+		t.Fatalf("account_type = %q, want business", account.AccountType)
+	}
+	if account.IsPaired == nil || *account.IsPaired {
+		t.Fatalf("is_paired = %#v, want false pointer", account.IsPaired)
+	}
+	if account.Team == nil || account.Team.ID != "team-id" || account.Team.MemberID != "dbmid:member" {
+		t.Fatalf("team = %#v, want team metadata", account.Team)
+	}
+}
+
+func TestAccountLookupJSONUsesAccountID(t *testing.T) {
+	cmd, stdout := testAccountCmd()
+	setAccountOutputJSON(t, cmd)
+	var gotArg *users.GetAccountArg
+	stubUsersClient(t, &mockUsersClient{
+		getAccountFn: func(arg *users.GetAccountArg) (*users.BasicAccount, error) {
+			gotArg = arg
+			return testBasicAccount(), nil
+		},
+	})
+
+	if err := account(cmd, []string{"dbid:lookup"}); err != nil {
+		t.Fatalf("account returned error: %v", err)
+	}
+	if gotArg == nil || gotArg.AccountId != "dbid:lookup" {
+		t.Fatalf("GetAccount arg = %#v, want dbid:lookup", gotArg)
+	}
+
+	got := decodeAccountOutput(t, stdout)
+	if got.Input.AccountID != "dbid:lookup" {
+		t.Fatalf("input.account_id = %q, want dbid:lookup", got.Input.AccountID)
+	}
+	account := got.Account
+	if account.Type != "basic" || account.AccountID != "dbid:lookup" || account.Email != "lookup@example.com" {
+		t.Fatalf("account = %#v, want lookup basic account", account)
+	}
+	if account.IsTeammate == nil || *account.IsTeammate {
+		t.Fatalf("is_teammate = %#v, want false pointer", account.IsTeammate)
+	}
+}
+
+func TestAccountJSONErrorWritesNoOutput(t *testing.T) {
+	cmd, stdout := testAccountCmd()
+	setAccountOutputJSON(t, cmd)
+	stubUsersClient(t, &mockUsersClient{
+		getCurrentAccountFn: func() (*users.FullAccount, error) {
+			return nil, errors.New("account failed")
+		},
+	})
+
+	if err := account(cmd, nil); err == nil {
+		t.Fatal("expected account error")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty output on error", got)
+	}
+}
+
+func TestAccountCommandSupportsStructuredOutput(t *testing.T) {
+	if !commandSupportsStructuredOutput(accountCmd) {
+		t.Fatal("account command should support structured output")
+	}
+}
+
+func testAccountCmd() (*cobra.Command, *bytes.Buffer) {
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{Use: "account"}
+	cmd.SetOut(&stdout)
+	cmd.Flags().String(outputFlag, "text", "")
+	return cmd, &stdout
+}
+
+func setAccountOutputJSON(t *testing.T, cmd *cobra.Command) {
+	t.Helper()
+	if err := cmd.Flags().Set(outputFlag, "json"); err != nil {
+		t.Fatalf("set output: %v", err)
+	}
+}
+
+func decodeAccountOutput(t *testing.T, out *bytes.Buffer) accountOutput {
+	t.Helper()
+
+	var got accountOutput
+	if err := json.NewDecoder(out).Decode(&got); err != nil {
+		t.Fatalf("decode JSON output: %v\noutput: %s", err, out.String())
+	}
+	return got
+}
+
+func testFullAccount() *users.FullAccount {
+	account := users.NewFullAccount(
+		"dbid:current",
+		users.NewName("Test", "User", "Test", "Test User", "TU"),
+		"test@example.com",
+		true,
+		false,
+		"en",
+		"https://dropbox.example/ref",
+		false,
+		accountType(users_common.AccountTypeBusiness),
+		nil,
+	)
+	account.ProfilePhotoUrl = "https://dropbox.example/photo"
+	account.Team = users.NewFullTeam("team-id", "Team Name", nil, nil)
+	account.TeamMemberId = "dbmid:member"
+	return account
+}
+
+func testBasicAccount() *users.BasicAccount {
+	return users.NewBasicAccount(
+		"dbid:lookup",
+		users.NewName("Lookup", "User", "Lookup", "Lookup User", "LU"),
+		"lookup@example.com",
+		false,
+		false,
+		false,
+	)
+}
+
+func accountType(tag string) *users_common.AccountType {
+	return &users_common.AccountType{
+		Tagged: dropbox.Tagged{Tag: tag},
+	}
+}

--- a/cmd/du.go
+++ b/cmd/du.go
@@ -16,34 +16,87 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 )
 
+type duOutput struct {
+	Used       uint64       `json:"used"`
+	Allocation duAllocation `json:"allocation"`
+}
+
+type duAllocation struct {
+	Type                          string  `json:"type"`
+	Allocated                     *uint64 `json:"allocated,omitempty"`
+	Used                          *uint64 `json:"used,omitempty"`
+	UserWithinTeamSpaceAllocated  *uint64 `json:"user_within_team_space_allocated,omitempty"`
+	UserWithinTeamSpaceUsedCached *uint64 `json:"user_within_team_space_used_cached,omitempty"`
+	UserWithinTeamSpaceLimitType  string  `json:"user_within_team_space_limit_type,omitempty"`
+}
+
 func du(cmd *cobra.Command, args []string) (err error) {
-	dbx := users.New(config)
+	dbx := usersNewFunc(config)
 	usage, err := dbx.GetSpaceUsage()
 	if err != nil {
 		return
 	}
 
-	fmt.Printf("Used: %s\n", humanize.IBytes(usage.Used))
-	fmt.Printf("Type: %s\n", usage.Allocation.Tag)
+	return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderUsage(w, usage)
+	}, newDuOutput(usage))
+}
+
+func renderUsage(out io.Writer, usage *users.SpaceUsage) error {
+	fmt.Fprintf(out, "Used: %s\n", humanize.IBytes(usage.Used))
+	fmt.Fprintf(out, "Type: %s\n", usage.Allocation.Tag)
 
 	allocation := usage.Allocation
 
 	switch allocation.Tag {
 	case "individual":
-		fmt.Printf("Allocated: %s\n", humanize.IBytes(allocation.Individual.Allocated))
+		fmt.Fprintf(out, "Allocated: %s\n", humanize.IBytes(allocation.Individual.Allocated))
 	case "team":
-		fmt.Printf("Allocated: %s (Used: %s)\n",
+		fmt.Fprintf(out, "Allocated: %s (Used: %s)\n",
 			humanize.IBytes(allocation.Team.Allocated),
 			humanize.IBytes(allocation.Team.Used))
 	}
 
-	return
+	return nil
+}
+
+func newDuOutput(usage *users.SpaceUsage) duOutput {
+	return duOutput{
+		Used:       usage.Used,
+		Allocation: newDuAllocation(usage.Allocation),
+	}
+}
+
+func newDuAllocation(allocation *users.SpaceAllocation) duAllocation {
+	result := duAllocation{
+		Type: allocation.Tag,
+	}
+
+	switch allocation.Tag {
+	case "individual":
+		result.Allocated = uint64Ptr(allocation.Individual.Allocated)
+	case "team":
+		result.Allocated = uint64Ptr(allocation.Team.Allocated)
+		result.Used = uint64Ptr(allocation.Team.Used)
+		result.UserWithinTeamSpaceAllocated = uint64Ptr(allocation.Team.UserWithinTeamSpaceAllocated)
+		result.UserWithinTeamSpaceUsedCached = uint64Ptr(allocation.Team.UserWithinTeamSpaceUsedCached)
+		if allocation.Team.UserWithinTeamSpaceLimitType != nil {
+			result.UserWithinTeamSpaceLimitType = allocation.Team.UserWithinTeamSpaceLimitType.Tag
+		}
+	}
+
+	return result
+}
+
+func uint64Ptr(value uint64) *uint64 {
+	return &value
 }
 
 // duCmd represents the du command
@@ -55,4 +108,5 @@ var duCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(duCmd)
+	enableStructuredOutput(duCmd)
 }

--- a/cmd/du_test.go
+++ b/cmd/du_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team_common"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
+	"github.com/spf13/cobra"
+)
+
+func TestDuTextUsesCommandOutput(t *testing.T) {
+	cmd, stdout := testDuCmd()
+	stubUsersClient(t, &mockUsersClient{
+		getSpaceUsageFn: func() (*users.SpaceUsage, error) {
+			return individualSpaceUsage(), nil
+		},
+	})
+
+	if err := du(cmd, nil); err != nil {
+		t.Fatalf("du returned error: %v", err)
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"Used: 1.0 KiB",
+		"Type: individual",
+		"Allocated: 2.0 KiB",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("stdout = %q, want %q", output, want)
+		}
+	}
+}
+
+func TestDuJSONIndividualAllocation(t *testing.T) {
+	cmd, stdout := testDuCmd()
+	setDuOutputJSON(t, cmd)
+	stubUsersClient(t, &mockUsersClient{
+		getSpaceUsageFn: func() (*users.SpaceUsage, error) {
+			return individualSpaceUsage(), nil
+		},
+	})
+
+	if err := du(cmd, nil); err != nil {
+		t.Fatalf("du returned error: %v", err)
+	}
+
+	got := decodeDuOutput(t, stdout)
+	if got.Used != 1024 {
+		t.Fatalf("used = %d, want 1024", got.Used)
+	}
+	if got.Allocation.Type != "individual" || got.Allocation.Allocated == nil || *got.Allocation.Allocated != 2048 {
+		t.Fatalf("allocation = %#v, want individual allocation", got.Allocation)
+	}
+	if got.Allocation.Used != nil {
+		t.Fatalf("allocation.used = %#v, want omitted for individual allocation", got.Allocation.Used)
+	}
+}
+
+func TestDuJSONTeamAllocation(t *testing.T) {
+	cmd, stdout := testDuCmd()
+	setDuOutputJSON(t, cmd)
+	stubUsersClient(t, &mockUsersClient{
+		getSpaceUsageFn: func() (*users.SpaceUsage, error) {
+			return teamSpaceUsage(), nil
+		},
+	})
+
+	if err := du(cmd, nil); err != nil {
+		t.Fatalf("du returned error: %v", err)
+	}
+
+	got := decodeDuOutput(t, stdout)
+	if got.Used != 4096 {
+		t.Fatalf("used = %d, want 4096", got.Used)
+	}
+	if got.Allocation.Type != "team" {
+		t.Fatalf("allocation.type = %q, want team", got.Allocation.Type)
+	}
+	if got.Allocation.Allocated == nil || *got.Allocation.Allocated != 8192 {
+		t.Fatalf("allocation.allocated = %#v, want 8192", got.Allocation.Allocated)
+	}
+	if got.Allocation.Used == nil || *got.Allocation.Used != 2048 {
+		t.Fatalf("allocation.used = %#v, want 2048", got.Allocation.Used)
+	}
+	if got.Allocation.UserWithinTeamSpaceLimitType != "alert_only" {
+		t.Fatalf("user_within_team_space_limit_type = %q, want alert_only", got.Allocation.UserWithinTeamSpaceLimitType)
+	}
+}
+
+func TestDuJSONErrorWritesNoOutput(t *testing.T) {
+	cmd, stdout := testDuCmd()
+	setDuOutputJSON(t, cmd)
+	stubUsersClient(t, &mockUsersClient{
+		getSpaceUsageFn: func() (*users.SpaceUsage, error) {
+			return nil, errors.New("du failed")
+		},
+	})
+
+	if err := du(cmd, nil); err == nil {
+		t.Fatal("expected du error")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty output on error", got)
+	}
+}
+
+func TestDuCommandSupportsStructuredOutput(t *testing.T) {
+	if !commandSupportsStructuredOutput(duCmd) {
+		t.Fatal("du command should support structured output")
+	}
+}
+
+func testDuCmd() (*cobra.Command, *bytes.Buffer) {
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{Use: "du"}
+	cmd.SetOut(&stdout)
+	cmd.Flags().String(outputFlag, "text", "")
+	return cmd, &stdout
+}
+
+func setDuOutputJSON(t *testing.T, cmd *cobra.Command) {
+	t.Helper()
+	if err := cmd.Flags().Set(outputFlag, "json"); err != nil {
+		t.Fatalf("set output: %v", err)
+	}
+}
+
+func decodeDuOutput(t *testing.T, out *bytes.Buffer) duOutput {
+	t.Helper()
+
+	var got duOutput
+	if err := json.NewDecoder(out).Decode(&got); err != nil {
+		t.Fatalf("decode JSON output: %v\noutput: %s", err, out.String())
+	}
+	return got
+}
+
+func individualSpaceUsage() *users.SpaceUsage {
+	return users.NewSpaceUsage(1024, &users.SpaceAllocation{
+		Tagged: dropbox.Tagged{Tag: users.SpaceAllocationIndividual},
+		Individual: &users.IndividualSpaceAllocation{
+			Allocated: 2048,
+		},
+	})
+}
+
+func teamSpaceUsage() *users.SpaceUsage {
+	return users.NewSpaceUsage(4096, &users.SpaceAllocation{
+		Tagged: dropbox.Tagged{Tag: users.SpaceAllocationTeam},
+		Team: &users.TeamSpaceAllocation{
+			Used:                          2048,
+			Allocated:                     8192,
+			UserWithinTeamSpaceAllocated:  4096,
+			UserWithinTeamSpaceUsedCached: 1024,
+			UserWithinTeamSpaceLimitType: &team_common.MemberSpaceLimitType{
+				Tagged: dropbox.Tagged{Tag: "alert_only"},
+			},
+		},
+	})
+}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -198,6 +198,8 @@ func jsonErrorCode(err error) string {
 		return "path_conflict"
 	case strings.Contains(message, "requires a"):
 		return "invalid_arguments"
+	case strings.Contains(message, "accepts an optional"):
+		return "invalid_arguments"
 	default:
 		return "command_failed"
 	}

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -413,6 +413,13 @@ func TestJSONErrorCodePathConflict(t *testing.T) {
 	}
 }
 
+func TestJSONErrorCodeOptionalArgumentValidation(t *testing.T) {
+	err := errors.New("`account` accepts an optional `id` argument")
+	if got, want := jsonErrorCode(err), "invalid_arguments"; got != want {
+		t.Fatalf("jsonErrorCode = %q, want %q", got, want)
+	}
+}
+
 func decodeJSONErrorResponse(t *testing.T, value string) jsonErrorResponse {
 	t.Helper()
 

--- a/cmd/users_client.go
+++ b/cmd/users_client.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
+)
+
+type usersClient interface {
+	GetAccount(*users.GetAccountArg) (*users.BasicAccount, error)
+	GetCurrentAccount() (*users.FullAccount, error)
+	GetSpaceUsage() (*users.SpaceUsage, error)
+}
+
+var usersNewFunc = func(cfg dropbox.Config) usersClient {
+	return users.New(cfg)
+}

--- a/cmd/users_test.go
+++ b/cmd/users_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
+)
+
+type mockUsersClient struct {
+	getAccountFn        func(*users.GetAccountArg) (*users.BasicAccount, error)
+	getCurrentAccountFn func() (*users.FullAccount, error)
+	getSpaceUsageFn     func() (*users.SpaceUsage, error)
+}
+
+func (m *mockUsersClient) GetAccount(arg *users.GetAccountArg) (*users.BasicAccount, error) {
+	if m.getAccountFn != nil {
+		return m.getAccountFn(arg)
+	}
+	return nil, nil
+}
+
+func (m *mockUsersClient) GetCurrentAccount() (*users.FullAccount, error) {
+	if m.getCurrentAccountFn != nil {
+		return m.getCurrentAccountFn()
+	}
+	return nil, nil
+}
+
+func (m *mockUsersClient) GetSpaceUsage() (*users.SpaceUsage, error) {
+	if m.getSpaceUsageFn != nil {
+		return m.getSpaceUsageFn()
+	}
+	return nil, nil
+}
+
+func stubUsersClient(t *testing.T, client usersClient) {
+	t.Helper()
+
+	origNew := usersNewFunc
+	usersNewFunc = func(_ dropbox.Config) usersClient { return client }
+	t.Cleanup(func() { usersNewFunc = origNew })
+}


### PR DESCRIPTION
## Summary

- Migrate `account` and `du` to emit structured JSON when `--output=json` is used
- Add `usersClient` interface and `usersNewFunc` factory for testability (same pattern as `filesNewFunc`)
- `account` outputs full/basic account metadata with name, email, team info
- `du` outputs usage and allocation details (individual + team with space limit fields)
- Text rendering now writes to `io.Writer` instead of `os.Stdout`
- Fix: `renderBasicAccount` no longer mutates the input `BasicAccount.Email` field

## Test plan

- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] All tests pass (`go test ./... -count=1`)
- [x] Manual: `dbxcli account --output=json` emits JSON with full account metadata
- [x] Manual: `dbxcli account --output=json <account-id>` emits JSON with basic account lookup
- [x] Manual: `dbxcli du --output=json` emits JSON with usage and allocation
- [x] Manual: `dbxcli account` and `dbxcli du` text output unchanged