### PR TITLE
Add --output=json support to all share-link commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,14 @@ $ dbxcli du --output=json
 $ dbxcli ls --output=json /
 $ dbxcli search --output=json report /Reports
 $ dbxcli revs --output=json /Reports/old.pdf
+$ dbxcli share-link create --output=json /Reports/old.pdf
+$ dbxcli share-link list --output=json /Reports/old.pdf
 $ dbxcli mkdir --output=json /new-folder
 $ dbxcli rm --output=json /old-file.txt
 $ dbxcli restore --output=json /Reports/old.pdf 015f...
 ```
 
-JSON support is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
+JSON support is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
 
 Command results are written to stdout. Status, progress, warnings, diagnostics, and verbose logs are written to stderr.
 
@@ -244,6 +246,27 @@ Account and usage commands return command-specific objects:
   }
 }
 ```
+
+Shared-link commands return command-specific objects built around shared-link metadata:
+
+```json
+{
+  "input": {
+    "path": "/Reports/old.pdf"
+  },
+  "result": {
+    "type": "file",
+    "url": "https://www.dropbox.com/s/...",
+    "name": "old.pdf",
+    "path_lower": "/reports/old.pdf",
+    "rev": "...",
+    "size": 123
+  },
+  "existing": false
+}
+```
+
+`share-link download --output=json <url> -` is not supported because stdout is reserved for downloaded file bytes when the target is `-`.
 
 In JSON mode, command errors are also written to stdout. The process still exits with a non-zero status:
 

--- a/cmd/share-list-links.go
+++ b/cmd/share-list-links.go
@@ -23,6 +23,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type shareLinkListInput struct {
+	Path       string `json:"path,omitempty"`
+	DirectOnly bool   `json:"direct_only"`
+}
+
+type shareLinkListOutput struct {
+	Input   shareLinkListInput      `json:"input"`
+	Entries []shareLinkJSONMetadata `json:"entries"`
+}
+
 func shareListLinks(cmd *cobra.Command, args []string) (err error) {
 	return shareLinkList(cmd, args)
 }
@@ -54,8 +64,19 @@ func shareLinkList(cmd *cobra.Command, args []string) error {
 		commandVerboseStatus(cmd, "Listed %d shared links", len(links))
 	}
 
-	return commandOutput(cmd).RenderText(func(w io.Writer) error {
+	entries, ok := shareLinkJSONMetadataListFromDropbox(links)
+	if !ok {
+		return errors.New("found unknown shared link type")
+	}
+
+	return commandOutput(cmd).Render(func(w io.Writer) error {
 		return renderSharedLinks(w, links)
+	}, shareLinkListOutput{
+		Input: shareLinkListInput{
+			Path:       arg.Path,
+			DirectOnly: arg.DirectOnly,
+		},
+		Entries: entries,
 	})
 }
 
@@ -136,4 +157,6 @@ var shareListLinksCmd = &cobra.Command{
 func init() {
 	shareLinkCmd.AddCommand(shareLinkListCmd)
 	shareListCmd.AddCommand(shareListLinksCmd)
+	enableStructuredOutput(shareLinkListCmd)
+	enableStructuredOutput(shareListLinksCmd)
 }

--- a/cmd/share_link_create.go
+++ b/cmd/share_link_create.go
@@ -36,6 +36,23 @@ type shareLinkCreateOptions struct {
 	password         sharedLinkPasswordOptions
 }
 
+type shareLinkCreateInput struct {
+	Path             string `json:"path"`
+	Access           string `json:"access,omitempty"`
+	Audience         string `json:"audience,omitempty"`
+	Expires          string `json:"expires,omitempty"`
+	RemoveExpiration bool   `json:"remove_expiration,omitempty"`
+	AllowDownload    bool   `json:"allow_download,omitempty"`
+	DisallowDownload bool   `json:"disallow_download,omitempty"`
+	Password         bool   `json:"password,omitempty"`
+}
+
+type shareLinkCreateOutput struct {
+	Input    shareLinkCreateInput  `json:"input"`
+	Result   shareLinkJSONMetadata `json:"result"`
+	Existing bool                  `json:"existing"`
+}
+
 func shareLinkCreate(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("`share-link create` requires a `path` argument")
@@ -81,10 +98,39 @@ func shareLinkCreate(cmd *cobra.Command, args []string) error {
 		commandVerboseStatus(cmd, "Created shared link for %s", path)
 	}
 
-	return out.RenderText(func(w io.Writer) error {
+	result, ok := shareLinkJSONMetadataFromDropbox(link)
+	if !ok {
+		return errors.New("found unknown shared link type")
+	}
+
+	return out.Render(func(w io.Writer) error {
 		_, err := fmt.Fprintln(w, url)
 		return err
+	}, shareLinkCreateOutput{
+		Input:    newShareLinkCreateInput(path, opts),
+		Result:   result,
+		Existing: usedExisting,
 	})
+}
+
+func newShareLinkCreateInput(path string, opts shareLinkCreateOptions) shareLinkCreateInput {
+	input := shareLinkCreateInput{
+		Path:             path,
+		RemoveExpiration: opts.removeExpiration,
+		AllowDownload:    opts.allowDownload,
+		DisallowDownload: opts.disallowDownload,
+		Password:         opts.password.set,
+	}
+	if opts.access != nil {
+		input.Access = opts.access.Tag
+	}
+	if opts.audience != nil {
+		input.Audience = opts.audience.Tag
+	}
+	if opts.expires != nil {
+		input.Expires = opts.expires.UTC().Format(time.RFC3339)
+	}
+	return input
 }
 
 func createSharedLink(dbx sharedLinkClient, path string, opts shareLinkCreateOptions) (sharing.IsSharedLinkMetadata, error) {
@@ -436,4 +482,5 @@ func init() {
 	shareLinkCreateCmd.Flags().Bool("remove-expiration", false, "Remove expiration when returning an existing shared link")
 	addSharedLinkPasswordFlags(shareLinkCreateCmd)
 	shareLinkCmd.AddCommand(shareLinkCreateCmd)
+	enableStructuredOutput(shareLinkCreateCmd)
 }

--- a/cmd/share_link_download.go
+++ b/cmd/share_link_download.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dropbox/dbxcli/internal/output"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
 	"github.com/dustin/go-humanize"
@@ -34,6 +35,24 @@ type shareLinkDownloadOptions struct {
 	path      string
 	password  sharedLinkPasswordOptions
 	recursive bool
+}
+
+type shareLinkDownloadInput struct {
+	URL       string `json:"url"`
+	Target    string `json:"target,omitempty"`
+	Path      string `json:"path,omitempty"`
+	Recursive bool   `json:"recursive,omitempty"`
+	Password  bool   `json:"password,omitempty"`
+}
+
+type shareLinkDownloadResult struct {
+	Target string                `json:"target"`
+	Link   shareLinkJSONMetadata `json:"link"`
+}
+
+type shareLinkDownloadOutput struct {
+	Input  shareLinkDownloadInput  `json:"input"`
+	Result shareLinkDownloadResult `json:"result"`
 }
 
 func shareLinkDownload(cmd *cobra.Command, args []string) error {
@@ -62,11 +81,14 @@ func shareLinkDownload(cmd *cobra.Command, args []string) error {
 	if opts.password.set {
 		arg.LinkPassword = opts.password.password
 	}
+	if target == "-" && commandOutputFormat(cmd) == output.FormatJSON {
+		return errors.New("`share-link download -` cannot be used with --output=json")
+	}
 
 	dbx := newSharedLinkClient(config)
 	if opts.path != "" {
 		arg.Path = opts.path
-		return downloadSharedLinkPath(cmd, dbx, arg, target)
+		return downloadSharedLinkPath(cmd, dbx, arg, target, opts)
 	}
 
 	link, err := dbx.GetSharedLinkMetadata(arg)
@@ -90,7 +112,7 @@ func shareLinkDownload(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		commandVerboseStatus(cmd, "Downloaded shared link folder to %s", dst)
-		return nil
+		return renderShareLinkDownloadOutput(cmd, newShareLinkDownloadInput(url, target, opts), dst, folder)
 	}
 
 	if target == "-" {
@@ -104,12 +126,12 @@ func shareLinkDownload(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	dst, err := downloadSharedLinkToFile(dbx, arg, target, cmd.ErrOrStderr())
+	dst, downloaded, err := downloadSharedLinkToFile(dbx, arg, target, cmd.ErrOrStderr())
 	if err != nil {
 		return err
 	}
 	commandVerboseStatus(cmd, "Downloaded shared link to %s", dst)
-	return nil
+	return renderShareLinkDownloadOutput(cmd, newShareLinkDownloadInput(url, target, opts), dst, downloaded)
 }
 
 func parseShareLinkDownloadOptions(cmd *cobra.Command) (shareLinkDownloadOptions, error) {
@@ -152,7 +174,7 @@ func parseShareLinkDownloadOptions(cmd *cobra.Command) (shareLinkDownloadOptions
 	return opts, nil
 }
 
-func downloadSharedLinkPath(cmd *cobra.Command, dbx sharedLinkClient, arg *sharing.GetSharedLinkMetadataArg, target string) error {
+func downloadSharedLinkPath(cmd *cobra.Command, dbx sharedLinkClient, arg *sharing.GetSharedLinkMetadataArg, target string, opts shareLinkDownloadOptions) error {
 	if target == "-" {
 		if err := downloadSharedLinkToStdout(dbx, arg, cmd.OutOrStdout()); err != nil {
 			return err
@@ -161,12 +183,12 @@ func downloadSharedLinkPath(cmd *cobra.Command, dbx sharedLinkClient, arg *shari
 		return nil
 	}
 
-	dst, err := downloadSharedLinkToFile(dbx, arg, target, cmd.ErrOrStderr())
+	dst, downloaded, err := downloadSharedLinkToFile(dbx, arg, target, cmd.ErrOrStderr())
 	if err != nil {
 		return err
 	}
 	commandVerboseStatus(cmd, "Downloaded shared link path %s to %s", arg.Path, dst)
-	return nil
+	return renderShareLinkDownloadOutput(cmd, newShareLinkDownloadInput(arg.Url, target, opts), dst, downloaded)
 }
 
 func sharedLinkFolderDownloadTarget(target string, link *sharing.FolderLinkMetadata) (string, error) {
@@ -354,8 +376,9 @@ func sharedLinkLocalPath(root, rel string) (string, error) {
 	return filepath.Join(root, localRel), nil
 }
 
-func downloadSharedLinkToFile(dbx sharedLinkClient, arg *sharing.GetSharedLinkMetadataArg, target string, errOut io.Writer) (string, error) {
+func downloadSharedLinkToFile(dbx sharedLinkClient, arg *sharing.GetSharedLinkMetadataArg, target string, errOut io.Writer) (string, sharing.IsSharedLinkMetadata, error) {
 	var dst string
+	var downloaded sharing.IsSharedLinkMetadata
 	err := retryWithBackoff(func() error {
 		link, contents, err := dbx.GetSharedLinkFile(arg)
 		if err != nil {
@@ -370,10 +393,11 @@ func downloadSharedLinkToFile(dbx sharedLinkClient, arg *sharing.GetSharedLinkMe
 		if err != nil {
 			return err
 		}
+		downloaded = link
 
 		return copySharedLinkContentToFile(contents, sharedLinkDownloadSize(link), dst, errOut)
 	})
-	return dst, err
+	return dst, downloaded, err
 }
 
 func downloadSharedLinkToStdout(dbx sharedLinkClient, arg *sharing.GetSharedLinkMetadataArg, w io.Writer) error {
@@ -496,6 +520,31 @@ func sharedLinkDownloadSize(link sharing.IsSharedLinkMetadata) uint64 {
 	return file.Size
 }
 
+func newShareLinkDownloadInput(url, target string, opts shareLinkDownloadOptions) shareLinkDownloadInput {
+	return shareLinkDownloadInput{
+		URL:       url,
+		Target:    target,
+		Path:      opts.path,
+		Recursive: opts.recursive,
+		Password:  opts.password.set,
+	}
+}
+
+func renderShareLinkDownloadOutput(cmd *cobra.Command, input shareLinkDownloadInput, target string, link sharing.IsSharedLinkMetadata) error {
+	result, ok := shareLinkJSONMetadataFromDropbox(link)
+	if !ok {
+		return errors.New("found unknown shared link type")
+	}
+
+	return commandOutput(cmd).Render(nil, shareLinkDownloadOutput{
+		Input: input,
+		Result: shareLinkDownloadResult{
+			Target: target,
+			Link:   result,
+		},
+	})
+}
+
 var shareLinkDownloadCmd = &cobra.Command{
 	Use:   "download <url> [target]",
 	Short: "Download shared link content",
@@ -518,4 +567,5 @@ func init() {
 	shareLinkDownloadCmd.Flags().String("path", "", "Download a file path inside a folder shared link")
 	shareLinkDownloadCmd.Flags().BoolP("recursive", "r", false, "Recursively download a folder shared link")
 	shareLinkCmd.AddCommand(shareLinkDownloadCmd)
+	enableStructuredOutput(shareLinkDownloadCmd)
 }

--- a/cmd/share_link_info.go
+++ b/cmd/share_link_info.go
@@ -31,6 +31,17 @@ type shareLinkInfoOptions struct {
 	password sharedLinkPasswordOptions
 }
 
+type shareLinkInfoInput struct {
+	URL      string `json:"url"`
+	Path     string `json:"path,omitempty"`
+	Password bool   `json:"password,omitempty"`
+}
+
+type shareLinkInfoOutput struct {
+	Input  shareLinkInfoInput    `json:"input"`
+	Result shareLinkJSONMetadata `json:"result"`
+}
+
 func shareLinkInfo(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("`share-link info` requires a `url` argument")
@@ -60,8 +71,20 @@ func shareLinkInfo(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return commandOutput(cmd).RenderText(func(w io.Writer) error {
+	result, ok := shareLinkJSONMetadataFromDropbox(link)
+	if !ok {
+		return errors.New("found unknown shared link type")
+	}
+
+	return commandOutput(cmd).Render(func(w io.Writer) error {
 		return renderSharedLinkInfo(w, link)
+	}, shareLinkInfoOutput{
+		Input: shareLinkInfoInput{
+			URL:      url,
+			Path:     opts.path,
+			Password: opts.password.set,
+		},
+		Result: result,
 	})
 }
 
@@ -166,4 +189,5 @@ func init() {
 	shareLinkInfoCmd.Flags().String("path", "", "Display metadata for a path inside the shared link")
 	addSharedLinkPasswordFlags(shareLinkInfoCmd)
 	shareLinkCmd.AddCommand(shareLinkInfoCmd)
+	enableStructuredOutput(shareLinkInfoCmd)
 }

--- a/cmd/share_link_json.go
+++ b/cmd/share_link_json.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
+)
+
+type shareLinkJSONMetadata struct {
+	Type           string                    `json:"type"`
+	URL            string                    `json:"url"`
+	Name           string                    `json:"name,omitempty"`
+	PathLower      string                    `json:"path_lower,omitempty"`
+	ID             string                    `json:"id,omitempty"`
+	Expires        *string                   `json:"expires,omitempty"`
+	Rev            string                    `json:"rev,omitempty"`
+	Size           *uint64                   `json:"size,omitempty"`
+	ServerModified *string                   `json:"server_modified,omitempty"`
+	ClientModified *string                   `json:"client_modified,omitempty"`
+	Permissions    *shareLinkJSONPermissions `json:"permissions,omitempty"`
+}
+
+type shareLinkJSONPermissions struct {
+	ResolvedVisibility            string `json:"resolved_visibility,omitempty"`
+	RequestedVisibility           string `json:"requested_visibility,omitempty"`
+	EffectiveAudience             string `json:"effective_audience,omitempty"`
+	AccessLevel                   string `json:"access_level,omitempty"`
+	CanRevoke                     bool   `json:"can_revoke"`
+	AllowDownload                 bool   `json:"allow_download"`
+	CanSetExpiry                  bool   `json:"can_set_expiry"`
+	CanRemoveExpiry               bool   `json:"can_remove_expiry"`
+	CanAllowDownload              bool   `json:"can_allow_download"`
+	CanDisallowDownload           bool   `json:"can_disallow_download"`
+	AllowComments                 bool   `json:"allow_comments"`
+	CanSetPassword                bool   `json:"can_set_password,omitempty"`
+	CanRemovePassword             bool   `json:"can_remove_password,omitempty"`
+	RequirePassword               bool   `json:"require_password,omitempty"`
+	CanUseExtendedSharingControls bool   `json:"can_use_extended_sharing_controls,omitempty"`
+}
+
+func shareLinkJSONMetadataFromDropbox(link sharing.IsSharedLinkMetadata) (shareLinkJSONMetadata, bool) {
+	base, linkType, ok := sharedLinkBaseMetadata(link)
+	if !ok {
+		return shareLinkJSONMetadata{}, false
+	}
+
+	result := shareLinkJSONMetadata{
+		Type:        linkType,
+		URL:         base.Url,
+		Name:        base.Name,
+		PathLower:   base.PathLower,
+		ID:          base.Id,
+		Expires:     jsonTimePtr(base.Expires),
+		Permissions: shareLinkJSONPermissionsFromDropbox(base.LinkPermissions),
+	}
+
+	if file, ok := link.(*sharing.FileLinkMetadata); ok {
+		size := file.Size
+		result.Rev = file.Rev
+		result.Size = &size
+		result.ServerModified = jsonTime(file.ServerModified)
+		result.ClientModified = jsonTime(file.ClientModified)
+	}
+
+	return result, true
+}
+
+func shareLinkJSONMetadataListFromDropbox(links []sharing.IsSharedLinkMetadata) ([]shareLinkJSONMetadata, bool) {
+	result := make([]shareLinkJSONMetadata, 0, len(links))
+	for _, link := range links {
+		metadata, ok := shareLinkJSONMetadataFromDropbox(link)
+		if !ok {
+			return nil, false
+		}
+		result = append(result, metadata)
+	}
+	return result, true
+}
+
+func shareLinkJSONPermissionsFromDropbox(permissions *sharing.LinkPermissions) *shareLinkJSONPermissions {
+	if permissions == nil {
+		return nil
+	}
+
+	result := &shareLinkJSONPermissions{
+		CanRevoke:                     permissions.CanRevoke,
+		AllowDownload:                 permissions.AllowDownload,
+		CanSetExpiry:                  permissions.CanSetExpiry,
+		CanRemoveExpiry:               permissions.CanRemoveExpiry,
+		CanAllowDownload:              permissions.CanAllowDownload,
+		CanDisallowDownload:           permissions.CanDisallowDownload,
+		AllowComments:                 permissions.AllowComments,
+		CanSetPassword:                permissions.CanSetPassword,
+		CanRemovePassword:             permissions.CanRemovePassword,
+		RequirePassword:               permissions.RequirePassword,
+		CanUseExtendedSharingControls: permissions.CanUseExtendedSharingControls,
+	}
+	if permissions.ResolvedVisibility != nil {
+		result.ResolvedVisibility = permissions.ResolvedVisibility.Tag
+	}
+	if permissions.RequestedVisibility != nil {
+		result.RequestedVisibility = permissions.RequestedVisibility.Tag
+	}
+	if permissions.EffectiveAudience != nil {
+		result.EffectiveAudience = permissions.EffectiveAudience.Tag
+	}
+	if permissions.LinkAccessLevel != nil {
+		result.AccessLevel = permissions.LinkAccessLevel.Tag
+	}
+	return result
+}
+
+func jsonTimePtr(value *time.Time) *string {
+	if value == nil {
+		return nil
+	}
+	return jsonTime(*value)
+}

--- a/cmd/share_link_json_test.go
+++ b/cmd/share_link_json_test.go
@@ -1,0 +1,269 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
+	"github.com/spf13/cobra"
+)
+
+func TestShareLinkCreateJSONOutputsLinkMetadata(t *testing.T) {
+	expires := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			link := sharedLinkFile("/docs/report.txt", "https://example.com/report")
+			link.Id = "id:file"
+			link.Expires = &expires
+			link.Size = 42
+			return link, nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	setShareLinkOutputJSON(t, cmd)
+
+	if err := shareLinkCreate(cmd, []string{"/docs/report.txt"}); err != nil {
+		t.Fatalf("shareLinkCreate error: %v", err)
+	}
+
+	var got shareLinkCreateOutput
+	decodeJSONOutput(t, stdout.Bytes(), &got)
+	if got.Input.Path != "/docs/report.txt" {
+		t.Fatalf("input.path = %q, want /docs/report.txt", got.Input.Path)
+	}
+	if got.Existing {
+		t.Fatal("existing = true, want false")
+	}
+	if got.Result.Type != "file" || got.Result.URL != "https://example.com/report" || got.Result.PathLower != "/docs/report.txt" {
+		t.Fatalf("result = %#v, want file shared link metadata", got.Result)
+	}
+	if got.Result.Size == nil || *got.Result.Size != 42 {
+		t.Fatalf("result.size = %#v, want 42", got.Result.Size)
+	}
+	if got.Result.Expires == nil || *got.Result.Expires != "2026-07-01T00:00:00Z" {
+		t.Fatalf("result.expires = %#v, want RFC3339 expiration", got.Result.Expires)
+	}
+}
+
+func TestShareLinkListJSONOutputsEntriesAndInput(t *testing.T) {
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		listSharedLinksFn: func(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error) {
+			if arg.Path != "/docs/report.txt" || !arg.DirectOnly {
+				t.Fatalf("ListSharedLinks arg = %#v, want direct path filter", arg)
+			}
+			return sharing.NewListSharedLinksResult([]sharing.IsSharedLinkMetadata{
+				sharedLinkFile("/docs/report.txt", "https://example.com/report"),
+			}, false), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	setShareLinkOutputJSON(t, cmd)
+
+	if err := shareLinkList(cmd, []string{"/docs/report.txt"}); err != nil {
+		t.Fatalf("shareLinkList error: %v", err)
+	}
+
+	var got shareLinkListOutput
+	decodeJSONOutput(t, stdout.Bytes(), &got)
+	if got.Input.Path != "/docs/report.txt" || !got.Input.DirectOnly {
+		t.Fatalf("input = %#v, want direct path input", got.Input)
+	}
+	if len(got.Entries) != 1 || got.Entries[0].URL != "https://example.com/report" {
+		t.Fatalf("entries = %#v, want report shared link", got.Entries)
+	}
+}
+
+func TestShareLinkInfoJSONOutputsPermissions(t *testing.T) {
+	permissions := sharing.NewLinkPermissions(true, nil, true, true, true, true, true, false, false)
+	permissions.ResolvedVisibility = &sharing.ResolvedVisibility{Tagged: dropbox.Tagged{Tag: sharing.ResolvedVisibilityPublic}}
+	permissions.LinkAccessLevel = &sharing.LinkAccessLevel{Tagged: dropbox.Tagged{Tag: sharing.LinkAccessLevelViewer}}
+	permissions.RequirePassword = true
+
+	link := sharedLinkFile("/docs/report.txt", "https://example.com/report")
+	link.LinkPermissions = permissions
+
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		getSharedLinkMetadataFn: func(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, error) {
+			return link, nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := newShareLinkInfoTestCommand(&stdout)
+	setShareLinkOutputJSON(t, cmd)
+
+	if err := shareLinkInfo(cmd, []string{"https://example.com/report"}); err != nil {
+		t.Fatalf("shareLinkInfo error: %v", err)
+	}
+
+	var got shareLinkInfoOutput
+	decodeJSONOutput(t, stdout.Bytes(), &got)
+	if got.Input.URL != "https://example.com/report" {
+		t.Fatalf("input.url = %q, want https://example.com/report", got.Input.URL)
+	}
+	if got.Result.Permissions == nil {
+		t.Fatal("result.permissions = nil, want permissions")
+	}
+	if got.Result.Permissions.ResolvedVisibility != "public" || got.Result.Permissions.AccessLevel != "viewer" {
+		t.Fatalf("permissions = %#v, want visibility and access level", got.Result.Permissions)
+	}
+	if !got.Result.Permissions.AllowDownload || !got.Result.Permissions.RequirePassword {
+		t.Fatalf("permissions = %#v, want allow_download and require_password", got.Result.Permissions)
+	}
+}
+
+func TestShareLinkUpdateJSONOutputsUpdatedMetadata(t *testing.T) {
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		modifySharedLinkSettingsFn: func(arg *sharing.ModifySharedLinkSettingsArgs) (sharing.IsSharedLinkMetadata, error) {
+			return sharedLinkFile("/docs/report.txt", arg.Url), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := newShareLinkUpdateTestCommand(&stdout, nil)
+	setShareLinkOutputJSON(t, cmd)
+	if err := cmd.Flags().Set("allow-download", "true"); err != nil {
+		t.Fatalf("set allow-download: %v", err)
+	}
+
+	if err := shareLinkUpdate(cmd, []string{"https://example.com/report"}); err != nil {
+		t.Fatalf("shareLinkUpdate error: %v", err)
+	}
+
+	var got shareLinkUpdateOutput
+	decodeJSONOutput(t, stdout.Bytes(), &got)
+	if got.Input.URL != "https://example.com/report" || !got.Input.AllowDownload {
+		t.Fatalf("input = %#v, want update input", got.Input)
+	}
+	if got.Result.URL != "https://example.com/report" {
+		t.Fatalf("result.url = %q, want updated URL", got.Result.URL)
+	}
+}
+
+func TestShareLinkRevokeJSONOutputsRevokedURL(t *testing.T) {
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		revokeSharedLinkFn: func(arg *sharing.RevokeSharedLinkArg) error {
+			return nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := newShareLinkRevokeTestCommand(&stdout, nil)
+	setShareLinkOutputJSON(t, cmd)
+
+	if err := shareLinkRevoke(cmd, []string{"https://example.com/report"}); err != nil {
+		t.Fatalf("shareLinkRevoke error: %v", err)
+	}
+
+	var got shareLinkRevokeOutput
+	decodeJSONOutput(t, stdout.Bytes(), &got)
+	if got.Input.URL != "https://example.com/report" {
+		t.Fatalf("input.url = %q, want revoked URL", got.Input.URL)
+	}
+	if len(got.Revoked) != 1 || got.Revoked[0].URL != "https://example.com/report" {
+		t.Fatalf("revoked = %#v, want revoked URL", got.Revoked)
+	}
+}
+
+func TestShareLinkDownloadJSONOutputsTargetAndMetadata(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "report.txt")
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		getSharedLinkMetadataFn: func(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, error) {
+			return sharedLinkFile("/docs/report.txt", arg.Url), nil
+		},
+		getSharedLinkFileFn: func(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, io.ReadCloser, error) {
+			return downloadableSharedLinkFile("report.txt", "/docs/report.txt", arg.Url, 7),
+				io.NopCloser(strings.NewReader("content")), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := newShareLinkDownloadTestCommand(&stdout, &stderr)
+	setShareLinkOutputJSON(t, cmd)
+
+	if err := shareLinkDownload(cmd, []string{"https://example.com/report", target}); err != nil {
+		t.Fatalf("shareLinkDownload error: %v", err)
+	}
+	assertFileContent(t, target, "content")
+
+	var got shareLinkDownloadOutput
+	decodeJSONOutput(t, stdout.Bytes(), &got)
+	if got.Input.URL != "https://example.com/report" || got.Input.Target != target {
+		t.Fatalf("input = %#v, want download input", got.Input)
+	}
+	if got.Result.Target != target || got.Result.Link.URL != "https://example.com/report" {
+		t.Fatalf("result = %#v, want target and link metadata", got.Result)
+	}
+}
+
+func TestShareLinkDownloadJSONRejectsStdoutTarget(t *testing.T) {
+	called := false
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		getSharedLinkFileFn: func(arg *sharing.GetSharedLinkMetadataArg) (sharing.IsSharedLinkMetadata, io.ReadCloser, error) {
+			called = true
+			return nil, nil, nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := newShareLinkDownloadTestCommand(&stdout, nil)
+	setShareLinkOutputJSON(t, cmd)
+
+	err := shareLinkDownload(cmd, []string{"https://example.com/report", "-"})
+	if err == nil || !strings.Contains(err.Error(), "cannot be used with --output=json") {
+		t.Fatalf("error = %v, want JSON stdout rejection", err)
+	}
+	if called {
+		t.Fatal("GetSharedLinkFile should not be called")
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestShareLinkCommandsSupportStructuredOutput(t *testing.T) {
+	for _, cmd := range []*cobra.Command{
+		shareLinkCreateCmd,
+		shareLinkListCmd,
+		shareListLinksCmd,
+		shareLinkInfoCmd,
+		shareLinkUpdateCmd,
+		shareLinkRevokeCmd,
+		shareLinkDownloadCmd,
+	} {
+		if !commandSupportsStructuredOutput(cmd) {
+			t.Fatalf("%s should support structured output", cmd.CommandPath())
+		}
+	}
+}
+
+func setShareLinkOutputJSON(t *testing.T, cmd *cobra.Command) {
+	t.Helper()
+	if cmd.Flags().Lookup(outputFlag) == nil {
+		cmd.Flags().String(outputFlag, "text", "")
+	}
+	if err := cmd.Flags().Set(outputFlag, "json"); err != nil {
+		t.Fatalf("set output: %v", err)
+	}
+}
+
+func decodeJSONOutput(t *testing.T, data []byte, out any) {
+	t.Helper()
+	if err := json.Unmarshal(data, out); err != nil {
+		t.Fatalf("decode JSON output: %v\noutput: %s", err, string(data))
+	}
+}

--- a/cmd/share_link_revoke.go
+++ b/cmd/share_link_revoke.go
@@ -26,6 +26,21 @@ type shareLinkRevokeOptions struct {
 	path string
 }
 
+type shareLinkRevokeInput struct {
+	URL  string `json:"url,omitempty"`
+	Path string `json:"path,omitempty"`
+}
+
+type shareLinkRevokeResult struct {
+	URL  string                 `json:"url"`
+	Link *shareLinkJSONMetadata `json:"link,omitempty"`
+}
+
+type shareLinkRevokeOutput struct {
+	Input   shareLinkRevokeInput    `json:"input"`
+	Revoked []shareLinkRevokeResult `json:"revoked"`
+}
+
 func shareLinkRevoke(cmd *cobra.Command, args []string) error {
 	opts, err := parseShareLinkRevokeOptions(cmd, args)
 	if err != nil {
@@ -33,7 +48,16 @@ func shareLinkRevoke(cmd *cobra.Command, args []string) error {
 	}
 
 	if opts.path != "" {
-		return revokeSharedLinksForPath(cmd, opts.path)
+		revoked, err := revokeSharedLinksForPath(cmd, opts.path)
+		if err != nil {
+			return err
+		}
+		return commandOutput(cmd).Render(nil, shareLinkRevokeOutput{
+			Input: shareLinkRevokeInput{
+				Path: opts.path,
+			},
+			Revoked: revoked,
+		})
 	}
 
 	if len(args) != 1 {
@@ -52,7 +76,12 @@ func shareLinkRevoke(cmd *cobra.Command, args []string) error {
 	}
 
 	commandVerboseStatus(cmd, "Revoked shared link %s", url)
-	return nil
+	return commandOutput(cmd).Render(nil, shareLinkRevokeOutput{
+		Input: shareLinkRevokeInput{
+			URL: url,
+		},
+		Revoked: []shareLinkRevokeResult{{URL: url}},
+	})
 }
 
 func parseShareLinkRevokeOptions(cmd *cobra.Command, args []string) (shareLinkRevokeOptions, error) {
@@ -85,7 +114,7 @@ func parseShareLinkRevokeOptions(cmd *cobra.Command, args []string) (shareLinkRe
 	return opts, nil
 }
 
-func revokeSharedLinksForPath(cmd *cobra.Command, path string) error {
+func revokeSharedLinksForPath(cmd *cobra.Command, path string) ([]shareLinkRevokeResult, error) {
 	arg := sharing.NewListSharedLinksArg()
 	arg.Path = path
 	arg.DirectOnly = true
@@ -93,24 +122,33 @@ func revokeSharedLinksForPath(cmd *cobra.Command, path string) error {
 	dbx := newSharedLinkClient(config)
 	links, err := listSharedLinks(dbx, arg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(links) == 0 {
-		return fmt.Errorf("no direct shared links found for %q", path)
+		return nil, fmt.Errorf("no direct shared links found for %q", path)
 	}
 
+	revoked := make([]shareLinkRevokeResult, 0, len(links))
 	for _, link := range links {
 		url, ok := sharedLinkURL(link)
 		if !ok {
-			return errors.New("shared link response did not include a URL")
+			return nil, errors.New("shared link response did not include a URL")
+		}
+		metadata, ok := shareLinkJSONMetadataFromDropbox(link)
+		if !ok {
+			return nil, errors.New("found unknown shared link type")
 		}
 		if err := dbx.RevokeSharedLink(sharing.NewRevokeSharedLinkArg(url)); err != nil {
-			return fmt.Errorf("revoke shared link %s: %w", url, err)
+			return nil, fmt.Errorf("revoke shared link %s: %w", url, err)
 		}
+		revoked = append(revoked, shareLinkRevokeResult{
+			URL:  url,
+			Link: &metadata,
+		})
 	}
 
 	commandVerboseStatus(cmd, "Revoked %d shared links for %s", len(links), path)
-	return nil
+	return revoked, nil
 }
 
 var shareLinkRevokeCmd = &cobra.Command{
@@ -125,4 +163,5 @@ var shareLinkRevokeCmd = &cobra.Command{
 func init() {
 	shareLinkRevokeCmd.Flags().String("path", "", "Revoke direct shared links for a Dropbox path")
 	shareLinkCmd.AddCommand(shareLinkRevokeCmd)
+	enableStructuredOutput(shareLinkRevokeCmd)
 }

--- a/cmd/share_link_update.go
+++ b/cmd/share_link_update.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dropbox/dbxcli/internal/output"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,22 @@ type shareLinkUpdateOptions struct {
 	audience         *sharing.LinkAudience
 	password         sharedLinkPasswordOptions
 	removePassword   bool
+}
+
+type shareLinkUpdateInput struct {
+	URL              string `json:"url"`
+	Audience         string `json:"audience,omitempty"`
+	Expires          string `json:"expires,omitempty"`
+	RemoveExpiration bool   `json:"remove_expiration,omitempty"`
+	AllowDownload    bool   `json:"allow_download,omitempty"`
+	DisallowDownload bool   `json:"disallow_download,omitempty"`
+	Password         bool   `json:"password,omitempty"`
+	RemovePassword   bool   `json:"remove_password,omitempty"`
+}
+
+type shareLinkUpdateOutput struct {
+	Input  shareLinkUpdateInput  `json:"input"`
+	Result shareLinkJSONMetadata `json:"result"`
 }
 
 func shareLinkUpdate(cmd *cobra.Command, args []string) error {
@@ -53,8 +70,7 @@ func shareLinkUpdate(cmd *cobra.Command, args []string) error {
 		if err := dbx.ModifySharedLinkSettingsRaw(url, rawSharedLinkSettingsFromUpdateOptions(opts), opts.removeExpiration); err != nil {
 			return err
 		}
-		commandVerboseStatus(cmd, "Updated shared link %s", url)
-		return nil
+		return renderShareLinkUpdateOutput(cmd, dbx, url, opts, nil)
 	}
 
 	settings := sharing.NewSharedLinkSettings()
@@ -76,13 +92,62 @@ func shareLinkUpdate(cmd *cobra.Command, args []string) error {
 	arg.RemoveExpiration = opts.removeExpiration
 
 	if opts.hasSDKSettings() {
-		if _, err := dbx.ModifySharedLinkSettings(arg); err != nil {
+		link, err := dbx.ModifySharedLinkSettings(arg)
+		if err != nil {
+			return err
+		}
+		return renderShareLinkUpdateOutput(cmd, dbx, url, opts, link)
+	}
+
+	return renderShareLinkUpdateOutput(cmd, dbx, url, opts, nil)
+}
+
+func renderShareLinkUpdateOutput(cmd *cobra.Command, dbx sharedLinkClient, url string, opts shareLinkUpdateOptions, link sharing.IsSharedLinkMetadata) error {
+	commandVerboseStatus(cmd, "Updated shared link %s", url)
+
+	if commandOutputFormat(cmd) != output.FormatJSON {
+		return nil
+	}
+
+	if link == nil {
+		arg := sharing.NewGetSharedLinkMetadataArg(url)
+		if opts.password.set {
+			arg.LinkPassword = opts.password.password
+		}
+		var err error
+		link, err = dbx.GetSharedLinkMetadata(arg)
+		if err != nil {
 			return err
 		}
 	}
-	commandVerboseStatus(cmd, "Updated shared link %s", url)
 
-	return nil
+	result, ok := shareLinkJSONMetadataFromDropbox(link)
+	if !ok {
+		return errors.New("found unknown shared link type")
+	}
+
+	return commandOutput(cmd).Render(nil, shareLinkUpdateOutput{
+		Input:  newShareLinkUpdateInput(url, opts),
+		Result: result,
+	})
+}
+
+func newShareLinkUpdateInput(url string, opts shareLinkUpdateOptions) shareLinkUpdateInput {
+	input := shareLinkUpdateInput{
+		URL:              url,
+		RemoveExpiration: opts.removeExpiration,
+		AllowDownload:    opts.allowDownload,
+		DisallowDownload: opts.disallowDownload,
+		Password:         opts.password.set,
+		RemovePassword:   opts.removePassword,
+	}
+	if opts.audience != nil {
+		input.Audience = opts.audience.Tag
+	}
+	if opts.expires != nil {
+		input.Expires = opts.expires.UTC().Format(time.RFC3339)
+	}
+	return input
 }
 
 func parseShareLinkUpdateOptions(cmd *cobra.Command) (shareLinkUpdateOptions, error) {
@@ -206,4 +271,5 @@ func init() {
 	addSharedLinkPasswordFlags(shareLinkUpdateCmd)
 	shareLinkUpdateCmd.Flags().Bool("remove-password", false, "Remove the shared link password")
 	shareLinkCmd.AddCommand(shareLinkUpdateCmd)
+	enableStructuredOutput(shareLinkUpdateCmd)
 }


### PR DESCRIPTION
## Summary

- Migrate all `share-link` subcommands (create, list, info, update, revoke, download) to emit structured JSON
- Add `shareLinkJSONMetadata` and `shareLinkJSONPermissions` types in `cmd/share_link_json.go` for shared-link-specific serialization (URL, permissions, visibility, expiration)
- `share-link create` includes `"existing": true/false` to indicate if a link was reused
- `share-link revoke` returns array of revoked URLs with optional link metadata
- `share-link download` rejects stdout target (`-`) with `--output=json` since stdout is reserved for file bytes
- `share-link update` fetches metadata after raw API calls so JSON consumers always get current state

## Test plan

- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] All tests pass (`go test ./... -count=1`)
- [x] Manual: `dbxcli share-link create --output=json /file.txt` emits JSON with link metadata
- [x] Manual: `dbxcli share-link list --output=json` emits entries array
- [x] Manual: `dbxcli share-link info --output=json <url>` shows permissions
- [x] Manual: `dbxcli share-link download --output=json <url> -` returns clear error
- [x] Manual: text mode unchanged for all share-link commands