### PR TITLE
Add --output=json support to cp and mv commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ $ dbxcli du --output=json
 $ dbxcli ls --output=json /
 $ dbxcli search --output=json report /Reports
 $ dbxcli revs --output=json /Reports/old.pdf
+$ dbxcli cp --output=json /Reports/old.pdf /Reports/copy.pdf
+$ dbxcli mv --output=json /Reports/copy.pdf /Reports/archive/copy.pdf
 $ dbxcli share-link create --output=json /Reports/old.pdf
 $ dbxcli share-link list --output=json /Reports/old.pdf
 $ dbxcli mkdir --output=json /new-folder
@@ -150,7 +152,7 @@ $ dbxcli rm --output=json /old-file.txt
 $ dbxcli restore --output=json /Reports/old.pdf 015f...
 ```
 
-JSON support is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
+Structured success output is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `cp`, `mv`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
 
 Command results are written to stdout. Status, progress, warnings, diagnostics, and verbose logs are written to stderr.
 
@@ -171,7 +173,30 @@ Successful JSON responses are command-specific. Commands that operate on one pat
 }
 ```
 
-Commands that operate on multiple paths return a `results` array:
+Commands that operate on multiple paths return a `results` array. For `cp` and `mv`, each `input` object uses `from_path` and `to_path`:
+
+```json
+{
+  "results": [
+    {
+      "input": {
+        "from_path": "/Reports/old.pdf",
+        "to_path": "/Reports/copy.pdf"
+      },
+      "result": {
+        "type": "file",
+        "path_display": "/Reports/copy.pdf",
+        "path_lower": "/reports/copy.pdf",
+        "id": "id:...",
+        "rev": "...",
+        "size": 123
+      }
+    }
+  ]
+}
+```
+
+For commands such as `rm`, `input` uses command-specific path and flag fields:
 
 ```json
 {
@@ -268,7 +293,7 @@ Shared-link commands return command-specific objects built around shared-link me
 
 `share-link download --output=json <url> -` is not supported because stdout is reserved for downloaded file bytes when the target is `-`.
 
-In JSON mode, command errors are also written to stdout. The process still exits with a non-zero status:
+In JSON mode, command errors are written to stdout as JSON, including errors from commands that do not yet support structured success output. The process still exits with a non-zero status. Detailed diagnostics may also be written to stderr:
 
 ```json
 {

--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
@@ -40,6 +39,7 @@ func cp(cmd *cobra.Command, args []string) error {
 
 	var cpErrors []error
 	var relocationArgs []*files.RelocationArg
+	var results []relocationResult
 
 	dbx := filesNewFunc(config)
 	destIsFolder := len(argsToCopy) > 1 || strings.HasSuffix(destination, "/") || isRemoteFolder(dbx, destination)
@@ -56,20 +56,23 @@ func cp(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, arg := range relocationArgs {
-		if _, err := dbx.CopyV2(arg); err != nil {
+		res, err := dbx.CopyV2(arg)
+		if err != nil {
 			copyError := fmt.Errorf("copy %q to %q: %v", arg.FromPath, arg.ToPath, err)
 			cpErrors = append(cpErrors, copyError)
+			continue
 		}
+		results = append(results, newRelocationResult(arg, res))
 	}
 
 	if len(cpErrors) > 0 {
 		for _, cpError := range cpErrors {
-			_, _ = fmt.Fprintf(os.Stderr, "%v\n", cpError)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%v\n", cpError)
 		}
 		return fmt.Errorf("cp: %d error(s)", len(cpErrors))
 	}
 
-	return nil
+	return commandOutput(cmd).Render(nil, relocationOutput{Results: results})
 }
 
 // cpCmd represents the cp command
@@ -82,4 +85,5 @@ var cpCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(cpCmd)
+	enableStructuredOutput(cpCmd)
 }

--- a/cmd/cp_test.go
+++ b/cmd/cp_test.go
@@ -1,14 +1,20 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/dropbox/dbxcli/internal/output"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/spf13/cobra"
 )
 
 func stubFilesClient(t *testing.T, client files.Client) {
@@ -193,4 +199,123 @@ func TestCpCopyErrorIncludesAPIError(t *testing.T) {
 	if strings.Contains(stderr, "&{{") {
 		t.Errorf("stderr still contains formatted relocation arg: %q", stderr)
 	}
+}
+
+func TestCpJSONOutputsRelocationResults(t *testing.T) {
+	stubFilesClient(t, &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, fmt.Errorf("path/not_found/")
+		},
+		copyV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			metadata := files.NewFileMetadata("file-copy.txt", "id:file-copy", time.Time{}, time.Time{}, "rev-copy", 42)
+			metadata.PathDisplay = arg.ToPath
+			metadata.PathLower = strings.ToLower(arg.ToPath)
+			return files.NewRelocationResult(metadata), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := newRelocationTestCommand(&stdout, nil)
+
+	if err := cp(cmd, []string{"/src/file.txt", "/dest/file-copy.txt"}); err != nil {
+		t.Fatalf("cp error: %v", err)
+	}
+
+	got := decodeRelocationOutput(t, stdout.Bytes())
+	if len(got.Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if result.Input.FromPath != "/src/file.txt" || result.Input.ToPath != "/dest/file-copy.txt" {
+		t.Fatalf("input = %#v, want source and destination", result.Input)
+	}
+	if result.Result.Type != "file" || result.Result.PathDisplay != "/dest/file-copy.txt" {
+		t.Fatalf("result = %#v, want copied file metadata", result.Result)
+	}
+	if result.Result.Size == nil || *result.Result.Size != 42 {
+		t.Fatalf("size = %#v, want 42", result.Result.Size)
+	}
+}
+
+func TestCpJSONMultipleSourcesOutputsMultipleResults(t *testing.T) {
+	stubFilesClient(t, &mockFilesClient{
+		copyV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			name := path.Base(arg.ToPath)
+			metadata := files.NewFileMetadata(name, "id:"+name, time.Time{}, time.Time{}, "rev", 1)
+			metadata.PathDisplay = arg.ToPath
+			metadata.PathLower = strings.ToLower(arg.ToPath)
+			return files.NewRelocationResult(metadata), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := newRelocationTestCommand(&stdout, nil)
+
+	if err := cp(cmd, []string{"/src/a.txt", "/src/b.txt", "/dest"}); err != nil {
+		t.Fatalf("cp error: %v", err)
+	}
+
+	got := decodeRelocationOutput(t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("results = %d, want 2", len(got.Results))
+	}
+	if got.Results[0].Input.ToPath != "/dest/a.txt" || got.Results[1].Input.ToPath != "/dest/b.txt" {
+		t.Fatalf("results = %#v, want folder destinations", got.Results)
+	}
+}
+
+func TestCpJSONErrorUsesCommandStderr(t *testing.T) {
+	stubFilesClient(t, &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, fmt.Errorf("path/not_found/")
+		},
+		copyV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			return nil, fmt.Errorf("path/malformed_path/")
+		},
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := newRelocationTestCommand(&stdout, &stderr)
+
+	err := cp(cmd, []string{"/src/file.txt", "/dest/file.txt"})
+	if err == nil {
+		t.Fatal("expected cp error")
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `copy "/src/file.txt" to "/dest/file.txt": path/malformed_path/`) {
+		t.Fatalf("stderr = %q, want copy API error", stderr.String())
+	}
+}
+
+func TestCpCommandSupportsStructuredOutput(t *testing.T) {
+	if !commandSupportsStructuredOutput(cpCmd) {
+		t.Fatal("cp should support structured output")
+	}
+}
+
+func newRelocationTestCommand(stdout, stderr *bytes.Buffer) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String(outputFlag, string(output.FormatText), "")
+	if err := cmd.Flags().Set(outputFlag, string(output.FormatJSON)); err != nil {
+		panic(err)
+	}
+	if stdout != nil {
+		cmd.SetOut(stdout)
+	}
+	if stderr != nil {
+		cmd.SetErr(stderr)
+	}
+	return cmd
+}
+
+func decodeRelocationOutput(t *testing.T, data []byte) relocationOutput {
+	t.Helper()
+	var got relocationOutput
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("decode JSON output: %v\noutput: %s", err, string(data))
+	}
+	return got
 }

--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
@@ -39,6 +38,7 @@ func mv(cmd *cobra.Command, args []string) error {
 
 	var mvErrors []error
 	var relocationArgs []*files.RelocationArg
+	var results []relocationResult
 
 	dbx := filesNewFunc(config)
 	destIsFolder := len(argsToMove) > 1 || strings.HasSuffix(destination, "/") || isRemoteFolder(dbx, destination)
@@ -54,20 +54,23 @@ func mv(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, arg := range relocationArgs {
-		if _, err := dbx.MoveV2(arg); err != nil {
+		res, err := dbx.MoveV2(arg)
+		if err != nil {
 			moveError := fmt.Errorf("move %q to %q: %v", arg.FromPath, arg.ToPath, err)
 			mvErrors = append(mvErrors, moveError)
+			continue
 		}
+		results = append(results, newRelocationResult(arg, res))
 	}
 
 	if len(mvErrors) > 0 {
 		for _, mvError := range mvErrors {
-			_, _ = fmt.Fprintf(os.Stderr, "%v\n", mvError)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%v\n", mvError)
 		}
 		return fmt.Errorf("mv: %d error(s)", len(mvErrors))
 	}
 
-	return nil
+	return commandOutput(cmd).Render(nil, relocationOutput{Results: results})
 }
 
 // mvCmd represents the mv command
@@ -79,4 +82,5 @@ var mvCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(mvCmd)
+	enableStructuredOutput(mvCmd)
 }

--- a/cmd/mv_test.go
+++ b/cmd/mv_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
+	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 )
@@ -72,5 +75,100 @@ func TestMvMoveErrorIncludesAPIError(t *testing.T) {
 	}
 	if strings.Contains(stderr, "&{{") {
 		t.Errorf("stderr still contains formatted relocation arg: %q", stderr)
+	}
+}
+
+func TestMvJSONOutputsRelocationResults(t *testing.T) {
+	stubFilesClient(t, &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, fmt.Errorf("path/not_found/")
+		},
+		moveV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			metadata := files.NewFileMetadata("file-moved.txt", "id:file-moved", time.Time{}, time.Time{}, "rev-moved", 64)
+			metadata.PathDisplay = arg.ToPath
+			metadata.PathLower = strings.ToLower(arg.ToPath)
+			return files.NewRelocationResult(metadata), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := newRelocationTestCommand(&stdout, nil)
+
+	if err := mv(cmd, []string{"/src/file.txt", "/dest/file-moved.txt"}); err != nil {
+		t.Fatalf("mv error: %v", err)
+	}
+
+	got := decodeRelocationOutput(t, stdout.Bytes())
+	if len(got.Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if result.Input.FromPath != "/src/file.txt" || result.Input.ToPath != "/dest/file-moved.txt" {
+		t.Fatalf("input = %#v, want source and destination", result.Input)
+	}
+	if result.Result.Type != "file" || result.Result.PathDisplay != "/dest/file-moved.txt" {
+		t.Fatalf("result = %#v, want moved file metadata", result.Result)
+	}
+	if result.Result.Size == nil || *result.Result.Size != 64 {
+		t.Fatalf("size = %#v, want 64", result.Result.Size)
+	}
+}
+
+func TestMvJSONMultipleSourcesOutputsMultipleResults(t *testing.T) {
+	stubFilesClient(t, &mockFilesClient{
+		moveV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			name := path.Base(arg.ToPath)
+			metadata := files.NewFileMetadata(name, "id:"+name, time.Time{}, time.Time{}, "rev", 1)
+			metadata.PathDisplay = arg.ToPath
+			metadata.PathLower = strings.ToLower(arg.ToPath)
+			return files.NewRelocationResult(metadata), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := newRelocationTestCommand(&stdout, nil)
+
+	if err := mv(cmd, []string{"/src/a.txt", "/src/b.txt", "/dest"}); err != nil {
+		t.Fatalf("mv error: %v", err)
+	}
+
+	got := decodeRelocationOutput(t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("results = %d, want 2", len(got.Results))
+	}
+	if got.Results[0].Input.ToPath != "/dest/a.txt" || got.Results[1].Input.ToPath != "/dest/b.txt" {
+		t.Fatalf("results = %#v, want folder destinations", got.Results)
+	}
+}
+
+func TestMvJSONErrorUsesCommandStderr(t *testing.T) {
+	stubFilesClient(t, &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, fmt.Errorf("path/not_found/")
+		},
+		moveV2Fn: func(arg *files.RelocationArg) (*files.RelocationResult, error) {
+			return nil, fmt.Errorf("path/malformed_path/")
+		},
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := newRelocationTestCommand(&stdout, &stderr)
+
+	err := mv(cmd, []string{"/src/file.txt", "/dest/file.txt"})
+	if err == nil {
+		t.Fatal("expected mv error")
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `move "/src/file.txt" to "/dest/file.txt": path/malformed_path/`) {
+		t.Fatalf("stderr = %q, want move API error", stderr.String())
+	}
+}
+
+func TestMvCommandSupportsStructuredOutput(t *testing.T) {
+	if !commandSupportsStructuredOutput(mvCmd) {
+		t.Fatal("mv should support structured output")
 	}
 }

--- a/cmd/relocation_output.go
+++ b/cmd/relocation_output.go
@@ -1,0 +1,32 @@
+package cmd
+
+import "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+
+type relocationInput struct {
+	FromPath string `json:"from_path"`
+	ToPath   string `json:"to_path"`
+}
+
+type relocationResult struct {
+	Input  relocationInput `json:"input"`
+	Result jsonMetadata    `json:"result"`
+}
+
+type relocationOutput struct {
+	Results []relocationResult `json:"results"`
+}
+
+func newRelocationResult(arg *files.RelocationArg, res *files.RelocationResult) relocationResult {
+	var metadata files.IsMetadata
+	if res != nil {
+		metadata = res.Metadata
+	}
+
+	return relocationResult{
+		Input: relocationInput{
+			FromPath: arg.FromPath,
+			ToPath:   arg.ToPath,
+		},
+		Result: jsonMetadataFromDropbox(metadata),
+	}
+}


### PR DESCRIPTION
## Summary

- Migrate `cp` and `mv` to emit structured JSON with `{"results": [...]}` containing `from_path`, `to_path`, and result metadata per operation
- Add shared `cmd/relocation_output.go` with `relocationInput`/`relocationResult`/`relocationOutput` types used by both commands
- Errors now write to `cmd.ErrOrStderr()` instead of `os.Stderr` for testability
- Text mode behavior unchanged (silent on success)

## Test plan

- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] All tests pass (`go test ./... -count=1`)
- [x] Manual: `dbxcli cp --output=json /src.txt /dest.txt` emits JSON with relocation result
- [x] Manual: `dbxcli mv --output=json /src.txt /dest.txt` emits JSON with relocation result
- [x] Manual: `dbxcli cp /src.txt /dest.txt` text mode unchanged (silent)
