### PR TITLE
Add --output=json support to put command

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ $ dbxcli search --output=json report /Reports
 $ dbxcli revs --output=json /Reports/old.pdf
 $ dbxcli cp --output=json /Reports/old.pdf /Reports/copy.pdf
 $ dbxcli mv --output=json /Reports/copy.pdf /Reports/archive/copy.pdf
+$ dbxcli put --output=json README.md /README.md
 $ dbxcli share-link create --output=json /Reports/old.pdf
 $ dbxcli share-link list --output=json /Reports/old.pdf
 $ dbxcli mkdir --output=json /new-folder
@@ -152,7 +153,7 @@ $ dbxcli rm --output=json /old-file.txt
 $ dbxcli restore --output=json /Reports/old.pdf 015f...
 ```
 
-Structured success output is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `cp`, `mv`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
+Structured success output is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `cp`, `mv`, `put`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
 
 Command results are written to stdout. Status, progress, warnings, diagnostics, and verbose logs are written to stderr.
 
@@ -212,6 +213,38 @@ For commands such as `rm`, `input` uses command-specific path and flag fields:
         "type": "file",
         "path_display": "/old-file.txt",
         "path_lower": "/old-file.txt",
+        "id": "id:...",
+        "rev": "...",
+        "size": 123
+      }
+    }
+  ]
+}
+```
+
+`put` always returns a `results` array, including single-file and stdin uploads. The top-level `input` describes the command request; each result reports whether a file was `uploaded`, `skipped`, or a directory was `created` or already `existing`:
+
+```json
+{
+  "input": {
+    "source": "README.md",
+    "target": "/README.md",
+    "recursive": false,
+    "if_exists": "overwrite",
+    "stdin": false
+  },
+  "results": [
+    {
+      "status": "uploaded",
+      "kind": "file",
+      "input": {
+        "source": "README.md",
+        "target": "/README.md"
+      },
+      "result": {
+        "type": "file",
+        "path_display": "/README.md",
+        "path_lower": "/readme.md",
         "id": "id:...",
         "rev": "...",
         "size": 123

--- a/cmd/json_metadata.go
+++ b/cmd/json_metadata.go
@@ -21,6 +21,9 @@ type jsonMetadata struct {
 func jsonMetadataFromDropbox(metadata files.IsMetadata) jsonMetadata {
 	switch m := metadata.(type) {
 	case *files.FileMetadata:
+		if m == nil {
+			return jsonMetadata{Type: "unknown"}
+		}
 		size := m.Size
 		return jsonMetadata{
 			Type:           "file",
@@ -33,6 +36,9 @@ func jsonMetadataFromDropbox(metadata files.IsMetadata) jsonMetadata {
 			ClientModified: jsonTime(m.ClientModified),
 		}
 	case *files.FolderMetadata:
+		if m == nil {
+			return jsonMetadata{Type: "unknown"}
+		}
 		return jsonMetadata{
 			Type:        "folder",
 			PathDisplay: m.PathDisplay,
@@ -40,6 +46,9 @@ func jsonMetadataFromDropbox(metadata files.IsMetadata) jsonMetadata {
 			ID:          m.Id,
 		}
 	case *files.DeletedMetadata:
+		if m == nil {
+			return jsonMetadata{Type: "unknown"}
+		}
 		return jsonMetadata{
 			Type:        "deleted",
 			PathDisplay: m.PathDisplay,

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -74,10 +74,13 @@ func uploadChunkAlreadyAccepted(err error, expectedOffset uint64) bool {
 		endpointErr.IncorrectOffset.CorrectOffset == expectedOffset
 }
 
-func uploadProgressReader(r io.Reader, size int64) *ioprogress.Reader {
+func uploadProgressReader(r io.Reader, size int64, errOut io.Writer) *ioprogress.Reader {
+	if errOut == nil {
+		errOut = os.Stderr
+	}
 	return &ioprogress.Reader{
 		Reader: r,
-		DrawFunc: ioprogress.DrawTerminalf(os.Stderr, func(progress, total int64) string {
+		DrawFunc: ioprogress.DrawTerminalf(errOut, func(progress, total int64) string {
 			return fmt.Sprintf("Uploading %s/%s",
 				humanize.IBytes(uint64(progress)), humanize.IBytes(uint64(total)))
 		}),
@@ -85,17 +88,20 @@ func uploadProgressReader(r io.Reader, size int64) *ioprogress.Reader {
 	}
 }
 
-func uploadSingleShot(dbx files.Client, r io.ReadSeeker, uploadArg *files.UploadArg, size int64) error {
-	return retryWithBackoff(func() error {
+func uploadSingleShot(dbx files.Client, r io.ReadSeeker, uploadArg *files.UploadArg, size int64, errOut io.Writer) (*files.FileMetadata, error) {
+	var metadata *files.FileMetadata
+	err := retryWithBackoff(func() error {
 		if _, err := r.Seek(0, io.SeekStart); err != nil {
 			return err
 		}
-		_, err := dbx.Upload(uploadArg, uploadProgressReader(r, size))
+		var err error
+		metadata, err = dbx.Upload(uploadArg, uploadProgressReader(r, size, errOut))
 		return err
 	})
+	return metadata, err
 }
 
-func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, sizeTotal int64, workers int, chunkSize int64, debug bool) (err error) {
+func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, sizeTotal int64, workers int, chunkSize int64, debug bool) (metadata *files.FileMetadata, err error) {
 	t0 := time.Now()
 	startArgs := files.NewUploadSessionStartArg()
 	startArgs.SessionType = &files.UploadSessionType{}
@@ -141,14 +147,14 @@ func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, 
 	for written < sizeTotal {
 		data, err := io.ReadAll(&io.LimitedReader{R: r, N: chunkSize})
 		if err != nil {
-			return err
+			return nil, err
 		}
 		expectedLen := chunkSize
 		if written+chunkSize > sizeTotal {
 			expectedLen = sizeTotal - written
 		}
 		if len(data) != int(expectedLen) {
-			return fmt.Errorf("failed to read %d bytes from source", expectedLen)
+			return nil, fmt.Errorf("failed to read %d bytes from source", expectedLen)
 		}
 
 		chunk := uploadChunk{
@@ -160,7 +166,7 @@ func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, 
 		select {
 		case workCh <- chunk:
 		case err := <-errCh:
-			return err
+			return nil, err
 		}
 
 		written += int64(len(data))
@@ -170,7 +176,7 @@ func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, 
 	wg.Wait()
 	select {
 	case err := <-errCh:
-		return err
+		return nil, err
 	default:
 	}
 	if debug {
@@ -181,13 +187,14 @@ func uploadChunked(dbx files.Client, r io.Reader, commitInfo *files.CommitInfo, 
 	cursor := files.NewUploadSessionCursor(res.SessionId, uint64(written))
 	finishArgs := files.NewUploadSessionFinishArg(cursor, commitInfo)
 	err = retryWithBackoff(func() error {
-		_, e := dbx.UploadSessionFinish(finishArgs, nil)
+		var e error
+		metadata, e = dbx.UploadSessionFinish(finishArgs, nil)
 		return e
 	})
 	if debug {
 		log.Printf("Finish took: %v\n", time.Since(t2))
 	}
-	return
+	return metadata, err
 }
 
 type putOptions struct {
@@ -196,6 +203,42 @@ type putOptions struct {
 	debug     bool
 	ifExists  string
 	output    *output.Renderer
+	errOut    io.Writer
+}
+
+const (
+	putStatusUploaded = "uploaded"
+	putStatusSkipped  = "skipped"
+	putStatusCreated  = "created"
+	putStatusExisting = "existing"
+
+	putKindFile   = "file"
+	putKindFolder = "folder"
+)
+
+type putCommandInput struct {
+	Source    string `json:"source"`
+	Target    string `json:"target"`
+	Recursive bool   `json:"recursive"`
+	IfExists  string `json:"if_exists"`
+	Stdin     bool   `json:"stdin"`
+}
+
+type putResultInput struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+}
+
+type putResult struct {
+	Status string         `json:"status"`
+	Kind   string         `json:"kind"`
+	Input  putResultInput `json:"input"`
+	Result *jsonMetadata  `json:"result,omitempty"`
+}
+
+type putOutputData struct {
+	Input   putCommandInput `json:"input"`
+	Results []putResult     `json:"results"`
 }
 
 type putDestinationAction int
@@ -204,6 +247,29 @@ const (
 	putDestinationUpload putDestinationAction = iota
 	putDestinationSkip
 )
+
+func newPutResult(status, kind, source, target string, metadata files.IsMetadata) putResult {
+	result := putResult{
+		Status: status,
+		Kind:   kind,
+		Input: putResultInput{
+			Source: source,
+			Target: target,
+		},
+	}
+	if metadata != nil {
+		jsonResult := jsonMetadataFromDropbox(metadata)
+		result.Result = &jsonResult
+	}
+	return result
+}
+
+func renderPutResults(cmd *cobra.Command, input putCommandInput, results []putResult) error {
+	return commandOutput(cmd).Render(nil, putOutputData{
+		Input:   input,
+		Results: results,
+	})
+}
 
 func put(cmd *cobra.Command, args []string) (err error) {
 	if len(args) == 0 || len(args) > 2 {
@@ -248,10 +314,33 @@ func put(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	if srcInfo.IsDir() {
-		return putRecursive(src, dst, opts)
+		if commandOutputFormat(cmd) == output.FormatText {
+			return putRecursive(src, dst, opts)
+		}
+		results, err := putRecursiveWithResults(src, dst, opts)
+		if err != nil {
+			return err
+		}
+		return renderPutResults(cmd, putCommandInput{
+			Source:    src,
+			Target:    dst,
+			Recursive: true,
+			IfExists:  opts.ifExists,
+			Stdin:     false,
+		}, results)
 	}
 
-	return putFile(src, dst, opts)
+	result, err := putFileWithResult(src, dst, opts)
+	if err != nil {
+		return err
+	}
+	return renderPutResults(cmd, putCommandInput{
+		Source:    src,
+		Target:    dst,
+		Recursive: false,
+		IfExists:  opts.ifExists,
+		Stdin:     false,
+	}, []putResult{result})
 }
 
 func putStdin(cmd *cobra.Command, args []string, opts putOptions, recursive bool) error {
@@ -273,13 +362,20 @@ func putStdin(cmd *cobra.Command, args []string, opts putOptions, recursive bool
 	}
 
 	dbx := filesNewFunc(config)
-	action, err := checkPutStdinDestination(dbx, dstPath, opts.ifExists)
+	action, existingMetadata, err := checkPutStdinDestination(dbx, dstPath, opts.ifExists)
 	if err != nil {
 		return err
 	}
 	if action == putDestinationSkip {
 		reportPutSkipped(opts, dstPath)
-		return nil
+		result := newPutResult(putStatusSkipped, putKindFile, "-", dstPath, existingMetadata)
+		return renderPutResults(cmd, putCommandInput{
+			Source:    "-",
+			Target:    dstPath,
+			Recursive: false,
+			IfExists:  opts.ifExists,
+			Stdin:     true,
+		}, []putResult{result})
 	}
 
 	tmpPath, _, cleanup, err := spoolStdinToTemp(cmd.InOrStdin())
@@ -287,7 +383,7 @@ func putStdin(cmd *cobra.Command, args []string, opts putOptions, recursive bool
 		return err
 	}
 
-	uploadErr := putFile(tmpPath, dstPath, opts)
+	result, uploadErr := putFileWithResult(tmpPath, dstPath, opts)
 	cleanupErr := cleanup()
 
 	if uploadErr != nil {
@@ -302,7 +398,14 @@ func putStdin(cmd *cobra.Command, args []string, opts putOptions, recursive bool
 		return fmt.Errorf("failed to remove temp file %s after upload; sensitive stdin data may remain on disk: %w", tmpPath, cleanupErr)
 	}
 
-	return nil
+	result.Input.Source = "-"
+	return renderPutResults(cmd, putCommandInput{
+		Source:    "-",
+		Target:    dstPath,
+		Recursive: false,
+		IfExists:  opts.ifExists,
+		Stdin:     true,
+	}, []putResult{result})
 }
 
 func reportStdinCleanupFailure(opts putOptions, tmpPath string, err error) {
@@ -349,6 +452,7 @@ func parsePutOptions(cmd *cobra.Command) (putOptions, error) {
 		debug:     debug,
 		ifExists:  ifExists,
 		output:    commandOutput(cmd),
+		errOut:    cmd.ErrOrStderr(),
 	}, nil
 }
 
@@ -373,30 +477,35 @@ func normalizePutIfExists(ifExists string) (string, error) {
 }
 
 func putFile(src, dst string, opts putOptions) error {
+	_, err := putFileWithResult(src, dst, opts)
+	return err
+}
+
+func putFileWithResult(src, dst string, opts putOptions) (putResult, error) {
 	ifExists, err := normalizePutIfExists(opts.ifExists)
 	if err != nil {
-		return err
+		return putResult{}, err
 	}
 
 	dbx := filesNewFunc(config)
-	action, err := checkPutDestination(dbx, dst, ifExists)
+	action, existingMetadata, err := checkPutDestination(dbx, dst, ifExists)
 	if err != nil {
-		return err
+		return putResult{}, err
 	}
 	if action == putDestinationSkip {
 		reportPutSkipped(opts, dst)
-		return nil
+		return newPutResult(putStatusSkipped, putKindFile, src, dst, existingMetadata), nil
 	}
 
 	contents, err := os.Open(src)
 	if err != nil {
-		return err
+		return putResult{}, err
 	}
 	defer contents.Close()
 
 	contentsInfo, err := contents.Stat()
 	if err != nil {
-		return err
+		return putResult{}, err
 	}
 
 	commitInfo := files.NewCommitInfo(dst)
@@ -408,21 +517,27 @@ func putFile(src, dst string, opts putOptions) error {
 	commitInfo.ClientModified = &ts
 
 	if contentsInfo.Size() > singleShotUploadSizeCutoff {
-		err = uploadChunked(dbx, uploadProgressReader(contents, contentsInfo.Size()), commitInfo, contentsInfo.Size(), opts.workers, opts.chunkSize, opts.debug)
+		metadata, err := uploadChunked(dbx, uploadProgressReader(contents, contentsInfo.Size(), putErrorOutput(opts)), commitInfo, contentsInfo.Size(), opts.workers, opts.chunkSize, opts.debug)
 		if err != nil && ifExists == putIfExistsSkip && isUploadDestinationFileConflict(err) {
 			reportPutSkipped(opts, dst)
-			return nil
+			return newPutResult(putStatusSkipped, putKindFile, src, dst, nil), nil
 		}
-		return err
+		if err != nil {
+			return putResult{}, err
+		}
+		return newPutResult(putStatusUploaded, putKindFile, src, dst, metadata), nil
 	}
 
 	uploadArg := &files.UploadArg{CommitInfo: *commitInfo}
-	err = uploadSingleShot(dbx, contents, uploadArg, contentsInfo.Size())
+	metadata, err := uploadSingleShot(dbx, contents, uploadArg, contentsInfo.Size(), putErrorOutput(opts))
 	if err != nil && ifExists == putIfExistsSkip && isUploadDestinationFileConflict(err) {
 		reportPutSkipped(opts, dst)
-		return nil
+		return newPutResult(putStatusSkipped, putKindFile, src, dst, nil), nil
 	}
-	return err
+	if err != nil {
+		return putResult{}, err
+	}
+	return newPutResult(putStatusUploaded, putKindFile, src, dst, metadata), nil
 }
 
 func writeModeForIfExists(ifExists string) string {
@@ -432,58 +547,58 @@ func writeModeForIfExists(ifExists string) string {
 	return files.WriteModeAdd
 }
 
-func checkPutStdinDestination(dbx files.Client, dst string, ifExists string) (putDestinationAction, error) {
+func checkPutStdinDestination(dbx files.Client, dst string, ifExists string) (putDestinationAction, files.IsMetadata, error) {
 	ifExists, err := normalizePutIfExists(ifExists)
 	if err != nil {
-		return putDestinationUpload, err
+		return putDestinationUpload, nil, err
 	}
 
 	meta, exists, err := getDestinationMetadata(dbx, dst)
 	if err != nil {
 		if ifExists == putIfExistsOverwrite {
-			return putDestinationUpload, nil
+			return putDestinationUpload, nil, nil
 		}
-		return putDestinationUpload, err
+		return putDestinationUpload, nil, err
 	}
 	if !exists {
-		return putDestinationUpload, nil
+		return putDestinationUpload, nil, nil
 	}
 	if _, ok := meta.(*files.FolderMetadata); ok {
-		return putDestinationUpload, fmt.Errorf("cannot upload stdin to folder %q; provide a full Dropbox file path", dst)
+		return putDestinationUpload, nil, fmt.Errorf("cannot upload stdin to folder %q; provide a full Dropbox file path", dst)
 	}
-	return actionForExistingDestination(dst, ifExists)
+	return actionForExistingDestination(dst, ifExists, meta)
 }
 
-func checkPutDestination(dbx files.Client, dst string, ifExists string) (putDestinationAction, error) {
+func checkPutDestination(dbx files.Client, dst string, ifExists string) (putDestinationAction, files.IsMetadata, error) {
 	ifExists, err := normalizePutIfExists(ifExists)
 	if err != nil {
-		return putDestinationUpload, err
+		return putDestinationUpload, nil, err
 	}
 	if ifExists == putIfExistsOverwrite {
-		return putDestinationUpload, nil
+		return putDestinationUpload, nil, nil
 	}
 
 	meta, exists, err := getDestinationMetadata(dbx, dst)
 	if err != nil {
-		return putDestinationUpload, err
+		return putDestinationUpload, nil, err
 	}
 	if !exists {
-		return putDestinationUpload, nil
+		return putDestinationUpload, nil, nil
 	}
 	if _, ok := meta.(*files.FolderMetadata); ok {
-		return putDestinationUpload, fmt.Errorf("destination %q is a folder", dst)
+		return putDestinationUpload, nil, fmt.Errorf("destination %q is a folder", dst)
 	}
-	return actionForExistingDestination(dst, ifExists)
+	return actionForExistingDestination(dst, ifExists, meta)
 }
 
-func actionForExistingDestination(dst string, ifExists string) (putDestinationAction, error) {
+func actionForExistingDestination(dst string, ifExists string, metadata files.IsMetadata) (putDestinationAction, files.IsMetadata, error) {
 	switch ifExists {
 	case putIfExistsSkip:
-		return putDestinationSkip, nil
+		return putDestinationSkip, metadata, nil
 	case putIfExistsFail:
-		return putDestinationUpload, fmt.Errorf("destination %q already exists", dst)
+		return putDestinationUpload, nil, fmt.Errorf("destination %q already exists", dst)
 	default:
-		return putDestinationUpload, nil
+		return putDestinationUpload, nil, nil
 	}
 }
 
@@ -575,8 +690,25 @@ func putOutput(opts putOptions) *output.Renderer {
 	return output.New(nil, nil, output.FormatText)
 }
 
+func putErrorOutput(opts putOptions) io.Writer {
+	if opts.errOut != nil {
+		return opts.errOut
+	}
+	return os.Stderr
+}
+
 func putRecursive(src, dst string, opts putOptions) error {
+	_, err := putRecursiveInternal(src, dst, opts, false)
+	return err
+}
+
+func putRecursiveWithResults(src, dst string, opts putOptions) ([]putResult, error) {
+	return putRecursiveInternal(src, dst, opts, true)
+}
+
+func putRecursiveInternal(src, dst string, opts putOptions, collectResults bool) ([]putResult, error) {
 	src = filepath.Clean(src)
+	var results []putResult
 	var uploadErrors []error
 	dirsWithFiles := make(map[string]bool)
 
@@ -601,21 +733,37 @@ func putRecursive(src, dst string, opts putOptions) error {
 		remotePath := path.Join(dst, filepath.ToSlash(relPath))
 		putOutput(opts).Status("Processing %s -> %s", filePath, remotePath)
 
+		if collectResults {
+			result, err := putFileWithResult(filePath, remotePath, opts)
+			if err != nil {
+				uploadErrors = append(uploadErrors, fmt.Errorf("%s: %w", filePath, err))
+				return nil
+			}
+			results = append(results, result)
+			return nil
+		}
 		if err := putFile(filePath, remotePath, opts); err != nil {
 			uploadErrors = append(uploadErrors, fmt.Errorf("%s: %w", filePath, err))
+			return nil
 		}
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	dbx := filesNewFunc(config)
 
 	putOutput(opts).Status("Creating directory %s", dst)
-	arg := files.NewCreateFolderArg(dst)
-	if _, mkdirErr := dbx.CreateFolderV2(arg); mkdirErr != nil {
-		if !isConflictError(mkdirErr) {
+	if collectResults {
+		result, mkdirErr := putDirectoryWithResult(dbx, src, dst)
+		if mkdirErr != nil {
+			uploadErrors = append(uploadErrors, fmt.Errorf("mkdir %s: %w", dst, mkdirErr))
+		} else {
+			results = append(results, result)
+		}
+	} else {
+		if mkdirErr := putDirectory(dbx, dst); mkdirErr != nil {
 			uploadErrors = append(uploadErrors, fmt.Errorf("mkdir %s: %w", dst, mkdirErr))
 		}
 	}
@@ -641,22 +789,72 @@ func putRecursive(src, dst string, opts putOptions) error {
 
 		remotePath := path.Join(dst, filepath.ToSlash(relPath))
 		putOutput(opts).Status("Creating directory %s", remotePath)
-		arg := files.NewCreateFolderArg(remotePath)
-		if _, mkdirErr := dbx.CreateFolderV2(arg); mkdirErr != nil {
-			if !isConflictError(mkdirErr) {
+		if collectResults {
+			result, mkdirErr := putDirectoryWithResult(dbx, dirPath, remotePath)
+			if mkdirErr != nil {
 				uploadErrors = append(uploadErrors, fmt.Errorf("mkdir %s: %w", remotePath, mkdirErr))
+				return nil
+			}
+			results = append(results, result)
+		} else {
+			if mkdirErr := putDirectory(dbx, remotePath); mkdirErr != nil {
+				uploadErrors = append(uploadErrors, fmt.Errorf("mkdir %s: %w", remotePath, mkdirErr))
+				return nil
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if len(uploadErrors) > 0 {
-		return fmt.Errorf("failed to upload %d file(s): %v", len(uploadErrors), uploadErrors[0])
+		return nil, fmt.Errorf("failed to upload %d file(s): %v", len(uploadErrors), uploadErrors[0])
 	}
-	return nil
+	return results, nil
+}
+
+func putDirectory(dbx files.Client, dst string) error {
+	_, err := dbx.CreateFolderV2(files.NewCreateFolderArg(dst))
+	if err == nil {
+		return nil
+	}
+	return putDirectoryConflictError(dst, err)
+}
+
+func putDirectoryWithResult(dbx files.Client, src, dst string) (putResult, error) {
+	arg := files.NewCreateFolderArg(dst)
+	created, err := dbx.CreateFolderV2(arg)
+	if err != nil {
+		if conflictErr := putDirectoryConflictError(dst, err); conflictErr != nil {
+			return putResult{}, conflictErr
+		}
+		metadata, metaErr := existingFolderMetadata(dbx, dst)
+		if metaErr != nil {
+			return putResult{}, metaErr
+		}
+		return newPutResult(putStatusExisting, putKindFolder, src, dst, metadata), nil
+	}
+	if created == nil {
+		return newPutResult(putStatusCreated, putKindFolder, src, dst, nil), nil
+	}
+	return newPutResult(putStatusCreated, putKindFolder, src, dst, created.Metadata), nil
+}
+
+func putDirectoryConflictError(dst string, err error) error {
+	conflictTag, ok := createFolderConflictTag(err)
+	switch {
+	case ok && conflictTag == files.WriteConflictErrorFolder:
+		return nil
+	case ok && (conflictTag == files.WriteConflictErrorFile || conflictTag == files.WriteConflictErrorFileAncestor):
+		return fmt.Errorf("path exists and is not a folder: %s", dst)
+	case ok:
+		return err
+	case isConflictError(err):
+		return nil
+	default:
+		return err
+	}
 }
 
 // putCmd represents the put command
@@ -679,6 +877,7 @@ var putCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(putCmd)
+	enableStructuredOutput(putCmd)
 	putCmd.Flags().BoolP("recursive", "r", false, "Recursively upload directories")
 	putCmd.Flags().IntP("workers", "w", 4, "Number of concurrent upload workers to use")
 	putCmd.Flags().Int64P("chunksize", "c", 1<<24, "Chunk size to use (should be multiple of 4MiB)")

--- a/cmd/put_test.go
+++ b/cmd/put_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -188,7 +189,7 @@ func TestUploadSingleShot_RetryOnServerErrorResetsReader(t *testing.T) {
 		},
 	}
 
-	err := uploadSingleShot(mock, reader, uploadArg, int64(len(data)))
+	_, err := uploadSingleShot(mock, reader, uploadArg, int64(len(data)), nil)
 	if err != nil {
 		t.Errorf("expected nil error after retry, got %v", err)
 	}
@@ -225,7 +226,7 @@ func TestUploadSingleShot_RetriesTooManyWriteOperations(t *testing.T) {
 		},
 	}
 
-	err := uploadSingleShot(mock, reader, uploadArg, int64(len(data)))
+	_, err := uploadSingleShot(mock, reader, uploadArg, int64(len(data)), nil)
 	if err != nil {
 		t.Errorf("expected nil error after write-throttle retry, got %v", err)
 	}
@@ -246,6 +247,55 @@ func testPutCmd() *cobra.Command {
 	cmd.Flags().BoolP("debug", "d", false, "Print debug timing")
 	cmd.Flags().String("if-exists", putIfExistsOverwrite, "What to do when the destination file exists: overwrite, skip, or fail")
 	return cmd
+}
+
+func testPutJSONCmd(stdout, stderr *bytes.Buffer) *cobra.Command {
+	cmd := testPutCmd()
+	cmd.Flags().String(outputFlag, "text", "")
+	if err := cmd.Flags().Set(outputFlag, "json"); err != nil {
+		panic(err)
+	}
+	if stdout != nil {
+		cmd.SetOut(stdout)
+	}
+	if stderr != nil {
+		cmd.SetErr(stderr)
+	}
+	return cmd
+}
+
+func decodePutOutput(t *testing.T, stdout *bytes.Buffer) putOutputData {
+	t.Helper()
+
+	var got putOutputData
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode put JSON output: %v\noutput: %s", err, stdout.String())
+	}
+	return got
+}
+
+func putFileMetadata(path string, size uint64) *files.FileMetadata {
+	return &files.FileMetadata{
+		Metadata: files.Metadata{
+			Name:        strings.TrimPrefix(path, "/"),
+			PathDisplay: path,
+			PathLower:   strings.ToLower(path),
+		},
+		Id:   "id:" + strings.TrimPrefix(path, "/"),
+		Rev:  "rev:" + strings.TrimPrefix(path, "/"),
+		Size: size,
+	}
+}
+
+func putFolderMetadata(path string) *files.FolderMetadata {
+	return &files.FolderMetadata{
+		Metadata: files.Metadata{
+			Name:        strings.TrimPrefix(path, "/"),
+			PathDisplay: path,
+			PathLower:   strings.ToLower(path),
+		},
+		Id: "id:" + strings.TrimPrefix(path, "/"),
+	}
 }
 
 func getMetadataNotFoundError() files.GetMetadataAPIError {
@@ -624,6 +674,349 @@ func TestPutIfExistsValidation(t *testing.T) {
 	}
 }
 
+func TestPutJSONSingleFileOutputsUploadedResult(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			if arg.Path != "/uploaded.txt" {
+				t.Fatalf("upload path = %q, want /uploaded.txt", arg.Path)
+			}
+			if _, err := io.ReadAll(content); err != nil {
+				t.Fatal(err)
+			}
+			return putFileMetadata(arg.Path, 4), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout, stderr bytes.Buffer
+	cmd := testPutJSONCmd(&stdout, &stderr)
+	if err := put(cmd, []string{tmpFile, "/uploaded.txt"}); err != nil {
+		t.Fatalf("put error: %v", err)
+	}
+
+	got := decodePutOutput(t, &stdout)
+	if got.Input.Source != tmpFile || got.Input.Target != "/uploaded.txt" || got.Input.Recursive || got.Input.Stdin {
+		t.Fatalf("input = %+v", got.Input)
+	}
+	if got.Input.IfExists != putIfExistsOverwrite {
+		t.Fatalf("if_exists = %q", got.Input.IfExists)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if result.Status != putStatusUploaded || result.Kind != putKindFile {
+		t.Fatalf("result status/kind = %s/%s", result.Status, result.Kind)
+	}
+	if result.Input.Source != tmpFile || result.Input.Target != "/uploaded.txt" {
+		t.Fatalf("result input = %+v", result.Input)
+	}
+	if result.Result == nil {
+		t.Fatal("result metadata is nil")
+	}
+	if result.Result.Type != "file" || result.Result.PathDisplay != "/uploaded.txt" || result.Result.PathLower != "/uploaded.txt" {
+		t.Fatalf("metadata = %+v", result.Result)
+	}
+	if result.Result.Size == nil || *result.Result.Size != 4 {
+		t.Fatalf("size = %v, want 4", result.Result.Size)
+	}
+}
+
+func TestPutJSONDefaultTargetUsesComputedPath(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "local.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			if arg.Path != "/local.txt" {
+				t.Fatalf("upload path = %q, want /local.txt", arg.Path)
+			}
+			if _, err := io.ReadAll(content); err != nil {
+				t.Fatal(err)
+			}
+			return putFileMetadata(arg.Path, 4), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := testPutJSONCmd(&stdout, nil)
+	if err := put(cmd, []string{tmpFile}); err != nil {
+		t.Fatalf("put error: %v", err)
+	}
+
+	got := decodePutOutput(t, &stdout)
+	if got.Input.Target != "/local.txt" {
+		t.Fatalf("target = %q, want /local.txt", got.Input.Target)
+	}
+	if got.Results[0].Input.Target != "/local.txt" {
+		t.Fatalf("result target = %q, want /local.txt", got.Results[0].Input.Target)
+	}
+}
+
+func TestPutJSONIfExistsSkipOutputsSkippedResult(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return putFileMetadata(arg.Path, 12), nil
+		},
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			t.Fatal("upload should not be called for skipped destination")
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout, stderr bytes.Buffer
+	cmd := testPutJSONCmd(&stdout, &stderr)
+	if err := cmd.Flags().Set("if-exists", putIfExistsSkip); err != nil {
+		t.Fatal(err)
+	}
+	if err := put(cmd, []string{tmpFile, "/existing.txt"}); err != nil {
+		t.Fatalf("put error: %v", err)
+	}
+
+	got := decodePutOutput(t, &stdout)
+	if len(got.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if result.Status != putStatusSkipped || result.Kind != putKindFile {
+		t.Fatalf("result status/kind = %s/%s", result.Status, result.Kind)
+	}
+	if result.Result == nil || result.Result.PathDisplay != "/existing.txt" {
+		t.Fatalf("metadata = %+v", result.Result)
+	}
+	if !strings.Contains(stderr.String(), "Skipping /existing.txt") {
+		t.Fatalf("stderr = %q, want skip status", stderr.String())
+	}
+}
+
+func TestPutJSONIfExistsFailReturnsErrorWithoutStdout(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return putFileMetadata(arg.Path, 12), nil
+		},
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			t.Fatal("upload should not be called for failed destination")
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := testPutJSONCmd(&stdout, nil)
+	if err := cmd.Flags().Set("if-exists", putIfExistsFail); err != nil {
+		t.Fatal(err)
+	}
+	err := put(cmd, []string{tmpFile, "/existing.txt"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on error", stdout.String())
+	}
+}
+
+func TestPutJSONStdinDoesNotExposeTempPath(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return nil, getMetadataNotFoundError()
+		},
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			body, err := io.ReadAll(content)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(body) != "hello" {
+				t.Fatalf("uploaded body = %q, want hello", string(body))
+			}
+			return putFileMetadata(arg.Path, uint64(len(body))), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := testPutJSONCmd(&stdout, nil)
+	cmd.SetIn(strings.NewReader("hello"))
+	if err := put(cmd, []string{"-", "/stdin.txt"}); err != nil {
+		t.Fatalf("put error: %v", err)
+	}
+
+	output := stdout.String()
+	if strings.Contains(output, "dbxcli-stdin") {
+		t.Fatalf("stdout exposes temp path: %s", output)
+	}
+	got := decodePutOutput(t, &stdout)
+	if got.Input.Source != "-" || !got.Input.Stdin || got.Input.Target != "/stdin.txt" {
+		t.Fatalf("input = %+v", got.Input)
+	}
+	if got.Results[0].Input.Source != "-" || got.Results[0].Input.Target != "/stdin.txt" {
+		t.Fatalf("result input = %+v", got.Results[0].Input)
+	}
+}
+
+func TestPutJSONRecursiveOutputsDirectoryAndFileResults(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "empty"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("file"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			if _, err := io.ReadAll(content); err != nil {
+				t.Fatal(err)
+			}
+			return putFileMetadata(arg.Path, 4), nil
+		},
+		createFolderV2Fn: func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error) {
+			return files.NewCreateFolderResult(putFolderMetadata(arg.Path)), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout, stderr bytes.Buffer
+	cmd := testPutJSONCmd(&stdout, &stderr)
+	if err := cmd.Flags().Set("recursive", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := put(cmd, []string{dir, "/remote"}); err != nil {
+		t.Fatalf("put error: %v", err)
+	}
+
+	got := decodePutOutput(t, &stdout)
+	if !got.Input.Recursive || got.Input.Source != dir || got.Input.Target != "/remote" {
+		t.Fatalf("input = %+v", got.Input)
+	}
+	want := map[string]string{
+		"/remote/file.txt": putStatusUploaded,
+		"/remote":          putStatusCreated,
+		"/remote/empty":    putStatusCreated,
+	}
+	if len(got.Results) != len(want) {
+		t.Fatalf("results len = %d, want %d: %+v", len(got.Results), len(want), got.Results)
+	}
+	for _, result := range got.Results {
+		wantStatus, ok := want[result.Input.Target]
+		if !ok {
+			t.Fatalf("unexpected result target %q", result.Input.Target)
+		}
+		if result.Status != wantStatus {
+			t.Fatalf("status for %s = %s, want %s", result.Input.Target, result.Status, wantStatus)
+		}
+		if result.Result == nil {
+			t.Fatalf("result metadata for %s is nil", result.Input.Target)
+		}
+	}
+	if !strings.Contains(stderr.String(), "Processing ") || !strings.Contains(stderr.String(), "Creating directory ") {
+		t.Fatalf("stderr = %q, want recursive status", stderr.String())
+	}
+	if !json.Valid(stdout.Bytes()) {
+		t.Fatalf("stdout is not valid JSON: %s", stdout.String())
+	}
+}
+
+func TestPutJSONRecursiveFailsWhenDirectoryTargetIsExistingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	mock := &mockFilesClient{
+		createFolderV2Fn: func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error) {
+			return nil, createFolderConflictError(files.WriteConflictErrorFile)
+		},
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			t.Fatal("GetMetadata should not be called for typed file conflicts")
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := testPutJSONCmd(&stdout, nil)
+	if err := cmd.Flags().Set("recursive", "true"); err != nil {
+		t.Fatal(err)
+	}
+	err := put(cmd, []string{dir, "/remote-file"})
+	if err == nil {
+		t.Fatal("expected existing file conflict")
+	}
+	if !strings.Contains(err.Error(), "path exists and is not a folder: /remote-file") {
+		t.Fatalf("error = %q, want not-a-folder error", err.Error())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on error", stdout.String())
+	}
+}
+
+func TestPutRecursiveTextModeDoesNotFetchExistingFolderMetadata(t *testing.T) {
+	dir := t.TempDir()
+
+	mock := &mockFilesClient{
+		createFolderV2Fn: func(arg *files.CreateFolderArg) (*files.CreateFolderResult, error) {
+			return nil, createFolderConflictError(files.WriteConflictErrorFolder)
+		},
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			t.Fatal("GetMetadata should not be called in text mode for existing folders")
+			return nil, nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	cmd := testPutCmd()
+	if err := cmd.Flags().Set("recursive", "true"); err != nil {
+		t.Fatal(err)
+	}
+	err := put(cmd, []string{dir, "/existing-folder"})
+	if err != nil {
+		t.Fatalf("put error: %v", err)
+	}
+}
+
+func TestPutTextModeWritesNoStdoutOnSuccess(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockFilesClient{
+		uploadFn: func(arg *files.UploadArg, content io.Reader) (*files.FileMetadata, error) {
+			if _, err := io.ReadAll(content); err != nil {
+				t.Fatal(err)
+			}
+			return putFileMetadata(arg.Path, 4), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := testPutCmd()
+	cmd.SetOut(&stdout)
+	if err := put(cmd, []string{tmpFile, "/text.txt"}); err != nil {
+		t.Fatalf("put error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
 func TestPutFileIfExistsSkipSkipsExistingFile(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "test.txt")
 	if err := os.WriteFile(tmpFile, []byte("test"), 0644); err != nil {
@@ -957,7 +1350,7 @@ func TestUploadChunked_RetriesSessionStart(t *testing.T) {
 	reader := bytes.NewReader(data)
 	commitInfo := files.NewCommitInfo("/test.txt")
 
-	err := uploadChunked(mock, reader, commitInfo, int64(len(data)), 1, 512, false)
+	_, err := uploadChunked(mock, reader, commitInfo, int64(len(data)), 1, 512, false)
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
@@ -997,7 +1390,7 @@ func TestUploadChunked_RetriesFinishTooManyWriteOperations(t *testing.T) {
 	reader := bytes.NewReader(data)
 	commitInfo := files.NewCommitInfo("/test.txt")
 
-	err := uploadChunked(mock, reader, commitInfo, int64(len(data)), 1, 512, false)
+	_, err := uploadChunked(mock, reader, commitInfo, int64(len(data)), 1, 512, false)
 	if err != nil {
 		t.Errorf("expected nil error after finish retry, got %v", err)
 	}
@@ -1030,7 +1423,7 @@ func TestUploadChunked_Success(t *testing.T) {
 	reader := bytes.NewReader(data)
 	commitInfo := files.NewCommitInfo("/test.txt")
 
-	err := uploadChunked(mock, reader, commitInfo, int64(len(data)), 1, 512, false)
+	_, err := uploadChunked(mock, reader, commitInfo, int64(len(data)), 1, 512, false)
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- Refactors `put` command to support structured JSON output via `--output=json`
- Upload functions (`uploadSingleShot`, `uploadChunked`) now return `*files.FileMetadata` for result reporting
- Adds `putResult` with status tracking (`uploaded`, `skipped`, `created`, `existing`) and kind (`file`, `folder`)
- Recursive directory handling reports per-file/folder results in a single JSON array
- Stdin uploads hide internal temp spool paths from JSON output
- Adds nil checks in `jsonMetadataFromDropbox` for typed nil interfaces
- Updates README with put JSON example and migrated command list

## Test plan
- [x] All existing tests pass
- [x] New JSON tests: single file upload, default target, if-exists skip/fail, stdin (verifies temp path not leaked), recursive with directories and files, text mode silent
- [x] `gofmt`, `go vet`, `golangci-lint` clean
