### PR TITLE
Add --output=json support to get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ $ dbxcli revs --output=json /Reports/old.pdf
 $ dbxcli cp --output=json /Reports/old.pdf /Reports/copy.pdf
 $ dbxcli mv --output=json /Reports/copy.pdf /Reports/archive/copy.pdf
 $ dbxcli put --output=json README.md /README.md
+$ dbxcli get --output=json /Reports/old.pdf ./old.pdf
 $ dbxcli share-link create --output=json /Reports/old.pdf
 $ dbxcli share-link list --output=json /Reports/old.pdf
 $ dbxcli mkdir --output=json /new-folder
@@ -153,7 +154,7 @@ $ dbxcli rm --output=json /old-file.txt
 $ dbxcli restore --output=json /Reports/old.pdf 015f...
 ```
 
-Structured success output is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `cp`, `mv`, `put`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
+Structured success output is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `cp`, `mv`, `put`, `get`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
 
 Command results are written to stdout. Status, progress, warnings, diagnostics, and verbose logs are written to stderr.
 
@@ -254,6 +255,8 @@ For commands such as `rm`, `input` uses command-specific path and flag fields:
 }
 ```
 
+`get` also returns a `results` array. File downloads use `downloaded`; recursive folder downloads may also include local directory results with `created` or `existing`.
+
 Commands that return entry lists, such as `ls`, `search`, and `revs`, return an `input` object and an `entries` array. `ls` input includes the listed path; `search` input includes the query and optional path scope; `revs` input includes the file path:
 
 ```json
@@ -324,7 +327,7 @@ Shared-link commands return command-specific objects built around shared-link me
 }
 ```
 
-`share-link download --output=json <url> -` is not supported because stdout is reserved for downloaded file bytes when the target is `-`.
+`get --output=json <source> -` and `share-link download --output=json <url> -` are not supported because stdout is reserved for downloaded file bytes when the target is `-`.
 
 In JSON mode, command errors are written to stdout as JSON, including errors from commands that do not yet support structured success output. The process still exits with a non-zero status. Detailed diagnostics may also be written to stderr:
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -24,11 +24,49 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dropbox/dbxcli/internal/output"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
 	"github.com/dustin/go-humanize"
 	"github.com/mitchellh/ioprogress"
 	"github.com/spf13/cobra"
 )
+
+const (
+	getStatusDownloaded = "downloaded"
+	getStatusCreated    = "created"
+	getStatusExisting   = "existing"
+
+	getKindFile   = "file"
+	getKindFolder = "folder"
+)
+
+type getOptions struct {
+	errOut io.Writer
+}
+
+type getCommandInput struct {
+	Source    string `json:"source"`
+	Target    string `json:"target"`
+	Recursive bool   `json:"recursive"`
+	Stdout    bool   `json:"stdout"`
+}
+
+type getResultInput struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+}
+
+type getResult struct {
+	Status string         `json:"status"`
+	Kind   string         `json:"kind"`
+	Input  getResultInput `json:"input"`
+	Result *jsonMetadata  `json:"result,omitempty"`
+}
+
+type getOutputData struct {
+	Input   getCommandInput `json:"input"`
+	Results []getResult     `json:"results"`
+}
 
 func get(cmd *cobra.Command, args []string) (err error) {
 	if len(args) == 0 || len(args) > 2 {
@@ -46,8 +84,12 @@ func get(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	recursive, _ := cmd.Flags().GetBool("recursive")
+	opts := parseGetOptions(cmd)
 
 	if dst == "-" {
+		if commandOutputFormat(cmd) == output.FormatJSON {
+			return errors.New("`get --output=json` cannot be used with stdout target `-`")
+		}
 		return getStdout(cmd, src, recursive)
 	}
 
@@ -62,7 +104,16 @@ func get(cmd *cobra.Command, args []string) (err error) {
 		if f, statErr := os.Stat(dst); statErr == nil && f.IsDir() {
 			dst = filepath.Join(dst, path.Base(src))
 		}
-		return downloadFile(dbx, src, dst)
+		result, err := downloadFileWithResult(dbx, src, dst, opts)
+		if err != nil {
+			return err
+		}
+		return renderGetResults(cmd, getCommandInput{
+			Source:    src,
+			Target:    dst,
+			Recursive: false,
+			Stdout:    false,
+		}, []getResult{result})
 	}
 
 	if _, ok := meta.(*files.FolderMetadata); ok {
@@ -72,14 +123,71 @@ func get(cmd *cobra.Command, args []string) (err error) {
 		if f, statErr := os.Stat(dst); statErr == nil && f.IsDir() {
 			dst = filepath.Join(dst, path.Base(src))
 		}
-		return getRecursive(dbx, src, dst)
+		if commandOutputFormat(cmd) == output.FormatText {
+			return getRecursive(dbx, src, dst)
+		}
+		results, err := getRecursiveWithResults(dbx, src, dst, meta, opts)
+		if err != nil {
+			return err
+		}
+		return renderGetResults(cmd, getCommandInput{
+			Source:    src,
+			Target:    dst,
+			Recursive: true,
+			Stdout:    false,
+		}, results)
 	}
 
 	if f, statErr := os.Stat(dst); statErr == nil && f.IsDir() {
 		dst = filepath.Join(dst, path.Base(src))
 	}
 
-	return downloadFile(dbx, src, dst)
+	result, err := downloadFileWithResult(dbx, src, dst, opts)
+	if err != nil {
+		return err
+	}
+	return renderGetResults(cmd, getCommandInput{
+		Source:    src,
+		Target:    dst,
+		Recursive: false,
+		Stdout:    false,
+	}, []getResult{result})
+}
+
+func parseGetOptions(cmd *cobra.Command) getOptions {
+	return getOptions{
+		errOut: cmd.ErrOrStderr(),
+	}
+}
+
+func getErrorOutput(opts getOptions) io.Writer {
+	if opts.errOut != nil {
+		return opts.errOut
+	}
+	return os.Stderr
+}
+
+func newGetResult(status, kind, source, target string, metadata files.IsMetadata) getResult {
+	result := getResult{
+		Status: status,
+		Kind:   kind,
+		Input: getResultInput{
+			Source: source,
+			Target: target,
+		},
+	}
+	if metadata != nil {
+		jsonResult := jsonMetadataFromDropbox(metadata)
+		result.Result = &jsonResult
+	}
+	return result
+}
+
+func renderGetResults(cmd *cobra.Command, input getCommandInput, results []getResult) error {
+	return commandOutput(cmd).Render(nil, getOutputData{
+		Input:   input,
+		Results: results,
+	})
 }
 
 func getStdout(cmd *cobra.Command, src string, recursive bool) error {
@@ -121,12 +229,21 @@ func getWithClient(dbx files.Client, args []string) (err error) {
 }
 
 func getRecursive(dbx files.Client, src, dst string) error {
+	_, err := getRecursiveInternal(dbx, src, dst, nil, getOptions{}, false)
+	return err
+}
+
+func getRecursiveWithResults(dbx files.Client, src, dst string, rootMeta files.IsMetadata, opts getOptions) ([]getResult, error) {
+	return getRecursiveInternal(dbx, src, dst, rootMeta, opts, true)
+}
+
+func getRecursiveInternal(dbx files.Client, src, dst string, rootMeta files.IsMetadata, opts getOptions, collectResults bool) ([]getResult, error) {
 	arg := files.NewListFolderArg(src)
 	arg.Recursive = true
 
 	res, err := dbx.ListFolder(arg)
 	if err != nil {
-		return fmt.Errorf("list folder %s: %v", src, err)
+		return nil, fmt.Errorf("list folder %s: %v", src, err)
 	}
 
 	var entries []files.IsMetadata
@@ -135,13 +252,23 @@ func getRecursive(dbx files.Client, src, dst string) error {
 		cont := files.NewListFolderContinueArg(res.Cursor)
 		res, err = dbx.ListFolderContinue(cont)
 		if err != nil {
-			return fmt.Errorf("list folder continue: %v", err)
+			return nil, fmt.Errorf("list folder continue: %v", err)
 		}
 		entries = append(entries, res.Entries...)
 	}
 
-	if err := os.MkdirAll(dst, 0755); err != nil {
-		return err
+	var results []getResult
+
+	if collectResults {
+		result, err := ensureLocalDirectoryResult(src, dst, rootMeta)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+	} else {
+		if err := os.MkdirAll(dst, 0755); err != nil {
+			return nil, err
+		}
 	}
 
 	var downloadErrors []error
@@ -154,9 +281,21 @@ func getRecursive(dbx files.Client, src, dst string) error {
 				downloadErrors = append(downloadErrors, err)
 				continue
 			}
+			if relPath == "" {
+				continue
+			}
 			localDir := filepath.Join(dst, filepath.FromSlash(relPath))
-			if err := os.MkdirAll(localDir, 0755); err != nil {
-				downloadErrors = append(downloadErrors, fmt.Errorf("mkdir %s: %w", localDir, err))
+			if collectResults {
+				result, err := ensureLocalDirectoryResult(f.PathDisplay, localDir, f)
+				if err != nil {
+					downloadErrors = append(downloadErrors, fmt.Errorf("mkdir %s: %w", localDir, err))
+					continue
+				}
+				results = append(results, result)
+			} else {
+				if err := os.MkdirAll(localDir, 0755); err != nil {
+					downloadErrors = append(downloadErrors, fmt.Errorf("mkdir %s: %w", localDir, err))
+				}
 			}
 		case *files.FileMetadata:
 			relPath, err := relativeTo(src, f.PathDisplay)
@@ -169,7 +308,16 @@ func getRecursive(dbx files.Client, src, dst string) error {
 				downloadErrors = append(downloadErrors, fmt.Errorf("mkdir %s: %w", filepath.Dir(localPath), err))
 				continue
 			}
-			fmt.Fprintf(os.Stderr, "Downloading %s -> %s\n", f.PathDisplay, localPath)
+			fmt.Fprintf(getErrorOutput(opts), "Downloading %s -> %s\n", f.PathDisplay, localPath)
+			if collectResults {
+				result, err := downloadFileWithResult(dbx, f.PathDisplay, localPath, opts)
+				if err != nil {
+					downloadErrors = append(downloadErrors, fmt.Errorf("%s: %w", f.PathDisplay, err))
+					continue
+				}
+				results = append(results, result)
+				continue
+			}
 			if err := downloadFile(dbx, f.PathDisplay, localPath); err != nil {
 				downloadErrors = append(downloadErrors, fmt.Errorf("%s: %w", f.PathDisplay, err))
 			}
@@ -178,12 +326,29 @@ func getRecursive(dbx files.Client, src, dst string) error {
 
 	if len(downloadErrors) > 0 {
 		for _, e := range downloadErrors {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", e)
+			fmt.Fprintf(getErrorOutput(opts), "Error: %v\n", e)
 		}
-		return fmt.Errorf("get: %d error(s)", len(downloadErrors))
+		return nil, fmt.Errorf("get: %d error(s)", len(downloadErrors))
 	}
 
-	return nil
+	return results, nil
+}
+
+func ensureLocalDirectoryResult(source, target string, metadata files.IsMetadata) (getResult, error) {
+	status := getStatusCreated
+	if info, err := os.Stat(target); err == nil {
+		if !info.IsDir() {
+			return getResult{}, fmt.Errorf("path exists and is not a folder: %s", target)
+		}
+		status = getStatusExisting
+	} else if !os.IsNotExist(err) {
+		return getResult{}, err
+	}
+
+	if err := os.MkdirAll(target, 0755); err != nil {
+		return getResult{}, err
+	}
+	return newGetResult(status, getKindFolder, source, target, metadata), nil
 }
 
 func relativeTo(base, full string) (string, error) {
@@ -198,11 +363,28 @@ func relativeTo(base, full string) (string, error) {
 }
 
 func downloadFile(dbx files.Client, src string, dst string) error {
-	arg := files.NewDownloadArg(src)
+	_, err := downloadFileWithMetadata(dbx, src, dst, os.Stderr)
+	return err
+}
 
-	return retryWithBackoff(func() error {
-		return downloadFileOnce(dbx, arg, dst)
+func downloadFileWithResult(dbx files.Client, src string, dst string, opts getOptions) (getResult, error) {
+	metadata, err := downloadFileWithMetadata(dbx, src, dst, getErrorOutput(opts))
+	if err != nil {
+		return getResult{}, err
+	}
+	return newGetResult(getStatusDownloaded, getKindFile, src, dst, metadata), nil
+}
+
+func downloadFileWithMetadata(dbx files.Client, src string, dst string, errOut io.Writer) (*files.FileMetadata, error) {
+	arg := files.NewDownloadArg(src)
+	var metadata *files.FileMetadata
+
+	err := retryWithBackoff(func() error {
+		var err error
+		metadata, err = downloadFileOnce(dbx, arg, dst, errOut)
+		return err
 	})
+	return metadata, err
 }
 
 func createDownloadTemp(dst string) (*os.File, string, error) {
@@ -245,21 +427,21 @@ func downloadDestinationPath(dst string) (string, error) {
 	return "", fmt.Errorf("too many symlinks resolving %s", dst)
 }
 
-func downloadFileOnce(dbx files.Client, arg *files.DownloadArg, dst string) error {
+func downloadFileOnce(dbx files.Client, arg *files.DownloadArg, dst string, errOut io.Writer) (*files.FileMetadata, error) {
 	res, contents, err := dbx.Download(arg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() { _ = contents.Close() }()
 
 	finalDst, err := downloadDestinationPath(dst)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	f, tmp, err := createDownloadTemp(finalDst)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	removeTemp := true
 	defer func() {
@@ -270,26 +452,33 @@ func downloadFileOnce(dbx files.Client, arg *files.DownloadArg, dst string) erro
 
 	progressbar := &ioprogress.Reader{
 		Reader: contents,
-		DrawFunc: ioprogress.DrawTerminalf(os.Stderr, func(progress, total int64) string {
+		DrawFunc: ioprogress.DrawTerminalf(errOut, func(progress, total int64) string {
 			return fmt.Sprintf("Downloading %s/%s",
 				humanize.IBytes(uint64(progress)), humanize.IBytes(uint64(total)))
 		}),
-		Size: int64(res.Size),
+		Size: downloadMetadataSize(res),
 	}
 
 	_, copyErr := io.Copy(f, progressbar)
 	closeErr := f.Close()
 	if copyErr != nil {
-		return copyErr
+		return nil, copyErr
 	}
 	if closeErr != nil {
-		return closeErr
+		return nil, closeErr
 	}
 	if err := os.Rename(tmp, finalDst); err != nil {
-		return err
+		return nil, err
 	}
 	removeTemp = false
-	return nil
+	return res, nil
+}
+
+func downloadMetadataSize(metadata *files.FileMetadata) int64 {
+	if metadata == nil {
+		return 0
+	}
+	return int64(metadata.Size)
 }
 
 // getCmd represents the get command
@@ -311,4 +500,5 @@ var getCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(getCmd)
 	getCmd.Flags().BoolP("recursive", "r", false, "Recursively download a folder")
+	enableStructuredOutput(getCmd)
 }

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -29,6 +31,55 @@ func (r *failingReadCloser) Read(p []byte) (int, error) {
 }
 
 func (r *failingReadCloser) Close() error { return nil }
+
+func testGetJSONCmd(stdout, stderr *bytes.Buffer) *cobra.Command {
+	cmd := testGetCmd()
+	cmd.Flags().String(outputFlag, "text", "")
+	if err := cmd.Flags().Set(outputFlag, "json"); err != nil {
+		panic(err)
+	}
+	if stdout != nil {
+		cmd.SetOut(stdout)
+	}
+	if stderr != nil {
+		cmd.SetErr(stderr)
+	}
+	return cmd
+}
+
+func decodeGetOutput(t *testing.T, stdout *bytes.Buffer) getOutputData {
+	t.Helper()
+
+	var got getOutputData
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode get JSON output: %v\noutput: %s", err, stdout.String())
+	}
+	return got
+}
+
+func getTestFileMetadata(path string, size uint64) *files.FileMetadata {
+	return &files.FileMetadata{
+		Metadata: files.Metadata{
+			Name:        strings.TrimPrefix(path, "/"),
+			PathDisplay: path,
+			PathLower:   strings.ToLower(path),
+		},
+		Id:   "id:" + strings.TrimPrefix(path, "/"),
+		Rev:  "rev:" + strings.TrimPrefix(path, "/"),
+		Size: size,
+	}
+}
+
+func getTestFolderMetadata(path string) *files.FolderMetadata {
+	return &files.FolderMetadata{
+		Metadata: files.Metadata{
+			Name:        strings.TrimPrefix(path, "/"),
+			PathDisplay: path,
+			PathLower:   strings.ToLower(path),
+		},
+		Id: "id:" + strings.TrimPrefix(path, "/"),
+	}
+}
 
 func TestGetArgValidation(t *testing.T) {
 	err := get(getCmd, []string{})
@@ -522,6 +573,268 @@ func TestGetFileCommandDownloadsAfterMetadata(t *testing.T) {
 	}
 	if string(got) != "data" {
 		t.Errorf("downloaded file = %q, want data", got)
+	}
+}
+
+func TestGetJSONFileOutputsDownloadedResult(t *testing.T) {
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "file.txt")
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return getTestFileMetadata(arg.Path, 4), nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			if arg.Path != "/remote/file.txt" {
+				t.Fatalf("download path = %q, want /remote/file.txt", arg.Path)
+			}
+			return getTestFileMetadata(arg.Path, 4), io.NopCloser(strings.NewReader("data")), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout, stderr bytes.Buffer
+	cmd := testGetJSONCmd(&stdout, &stderr)
+	if err := get(cmd, []string{"/remote/file.txt", dst}); err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+
+	got := decodeGetOutput(t, &stdout)
+	if got.Input.Source != "/remote/file.txt" || got.Input.Target != dst || got.Input.Recursive || got.Input.Stdout {
+		t.Fatalf("input = %+v", got.Input)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if result.Status != getStatusDownloaded || result.Kind != getKindFile {
+		t.Fatalf("result status/kind = %s/%s", result.Status, result.Kind)
+	}
+	if result.Input.Source != "/remote/file.txt" || result.Input.Target != dst {
+		t.Fatalf("result input = %+v", result.Input)
+	}
+	if result.Result == nil || result.Result.Type != "file" || result.Result.PathDisplay != "/remote/file.txt" {
+		t.Fatalf("metadata = %+v", result.Result)
+	}
+	if result.Result.Size == nil || *result.Result.Size != 4 {
+		t.Fatalf("size = %v, want 4", result.Result.Size)
+	}
+	if strings.Contains(stdout.String(), "Downloading ") {
+		t.Fatalf("stdout contains progress: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Downloading ") {
+		t.Fatalf("stderr = %q, want download progress", stderr.String())
+	}
+	if content, err := os.ReadFile(dst); err != nil || string(content) != "data" {
+		t.Fatalf("downloaded file = %q, %v; want data", string(content), err)
+	}
+}
+
+func TestGetJSONDefaultTargetUsesBasename(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return getTestFileMetadata(arg.Path, 4), nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			return getTestFileMetadata(arg.Path, 4), io.NopCloser(strings.NewReader("data")), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := testGetJSONCmd(&stdout, nil)
+	if err := get(cmd, []string{"/remote/file.txt"}); err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+
+	got := decodeGetOutput(t, &stdout)
+	if got.Input.Target != "file.txt" {
+		t.Fatalf("target = %q, want file.txt", got.Input.Target)
+	}
+	if got.Results[0].Input.Target != "file.txt" {
+		t.Fatalf("result target = %q, want file.txt", got.Results[0].Input.Target)
+	}
+}
+
+func TestGetJSONExistingDirectoryTargetAppendsBasename(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return getTestFileMetadata(arg.Path, 4), nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			return getTestFileMetadata(arg.Path, 4), io.NopCloser(strings.NewReader("data")), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := testGetJSONCmd(&stdout, nil)
+	if err := get(cmd, []string{"/remote/file.txt", tmpDir}); err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+
+	wantTarget := filepath.Join(tmpDir, "file.txt")
+	got := decodeGetOutput(t, &stdout)
+	if got.Input.Target != wantTarget {
+		t.Fatalf("target = %q, want %q", got.Input.Target, wantTarget)
+	}
+	if got.Results[0].Input.Target != wantTarget {
+		t.Fatalf("result target = %q, want %q", got.Results[0].Input.Target, wantTarget)
+	}
+}
+
+func TestGetJSONRejectsStdoutTarget(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := testGetJSONCmd(&stdout, nil)
+
+	err := get(cmd, []string{"/remote/file.txt", "-"})
+	if err == nil {
+		t.Fatal("expected JSON stdout target error")
+	}
+	if !strings.Contains(err.Error(), "stdout target") {
+		t.Fatalf("error = %q, want stdout target", err.Error())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestGetTextStdoutTargetWritesOnlyFileBytes(t *testing.T) {
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return getTestFileMetadata(arg.Path, 4), nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			return getTestFileMetadata(arg.Path, 4), io.NopCloser(strings.NewReader("data")), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := testGetCmd()
+	cmd.SetOut(&stdout)
+	if err := get(cmd, []string{"/remote/file.txt", "-"}); err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+	if stdout.String() != "data" {
+		t.Fatalf("stdout = %q, want data", stdout.String())
+	}
+}
+
+func TestGetJSONRecursiveOutputsDirectoryAndFileResults(t *testing.T) {
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "out")
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return getTestFolderMetadata(arg.Path), nil
+		},
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			return &files.ListFolderResult{
+				Entries: []files.IsMetadata{
+					getTestFolderMetadata("/remote"),
+					getTestFolderMetadata("/remote/empty"),
+					getTestFileMetadata("/remote/file.txt", 4),
+				},
+				HasMore: false,
+			}, nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			return getTestFileMetadata(arg.Path, 4), io.NopCloser(strings.NewReader("data")), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout, stderr bytes.Buffer
+	cmd := testGetJSONCmd(&stdout, &stderr)
+	if err := cmd.Flags().Set("recursive", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := get(cmd, []string{"/remote", dst}); err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+
+	got := decodeGetOutput(t, &stdout)
+	if got.Input.Source != "/remote" || got.Input.Target != dst || !got.Input.Recursive || got.Input.Stdout {
+		t.Fatalf("input = %+v", got.Input)
+	}
+	want := map[string]string{
+		dst:                            getStatusCreated,
+		filepath.Join(dst, "empty"):    getStatusCreated,
+		filepath.Join(dst, "file.txt"): getStatusDownloaded,
+	}
+	if len(got.Results) != len(want) {
+		t.Fatalf("results len = %d, want %d: %+v", len(got.Results), len(want), got.Results)
+	}
+	for _, result := range got.Results {
+		wantStatus, ok := want[result.Input.Target]
+		if !ok {
+			t.Fatalf("unexpected target %q", result.Input.Target)
+		}
+		if result.Status != wantStatus {
+			t.Fatalf("status for %s = %s, want %s", result.Input.Target, result.Status, wantStatus)
+		}
+		if result.Result == nil {
+			t.Fatalf("result metadata for %s is nil", result.Input.Target)
+		}
+	}
+	if !strings.Contains(stderr.String(), "Downloading /remote/file.txt") {
+		t.Fatalf("stderr = %q, want recursive download status", stderr.String())
+	}
+}
+
+func TestGetJSONRecursiveErrorEmitsNoSuccessJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "out")
+
+	mock := &mockFilesClient{
+		getMetadataFn: func(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+			return getTestFolderMetadata(arg.Path), nil
+		},
+		listFolderFn: func(arg *files.ListFolderArg) (*files.ListFolderResult, error) {
+			return &files.ListFolderResult{
+				Entries: []files.IsMetadata{
+					getTestFileMetadata("/remote/good.txt", 4),
+					getTestFileMetadata("/remote/bad.txt", 4),
+				},
+				HasMore: false,
+			}, nil
+		},
+		downloadFn: func(arg *files.DownloadArg) (*files.FileMetadata, io.ReadCloser, error) {
+			if strings.Contains(arg.Path, "bad.txt") {
+				return nil, nil, &files.DownloadAPIError{}
+			}
+			return getTestFileMetadata(arg.Path, 4), io.NopCloser(strings.NewReader("data")), nil
+		},
+	}
+	stubFilesClient(t, mock)
+
+	var stdout bytes.Buffer
+	cmd := testGetJSONCmd(&stdout, nil)
+	if err := cmd.Flags().Set("recursive", "true"); err != nil {
+		t.Fatal(err)
+	}
+	err := get(cmd, []string{"/remote", dst})
+	if err == nil {
+		t.Fatal("expected recursive error")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on recursive error", stdout.String())
+	}
+	if _, statErr := os.Stat(filepath.Join(dst, "good.txt")); statErr != nil {
+		t.Fatalf("good file was not downloaded before failure: %v", statErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Refactors `get` command to support structured JSON output via `--output=json`
- Downloads report per-file results with status (`downloaded`, `created`, `existing`) and kind (`file`, `folder`)
- Recursive folder downloads include directory results in the `results` array
- Stdout target (`-`) correctly rejected with `--output=json` since stdout is reserved for JSON
- Updates README with get JSON example and migrated command list

## Test plan
- [x] All existing tests pass
- [x] New JSON tests cover: single file download, recursive folder download, stdout target rejection, text mode silent
- [x] `gofmt`, `go vet`, `golangci-lint` clean