### PR TITLE
Normalize multi-result commands to shared JSON output types

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Commands that operate on multiple paths return a `results` array. For `cp` and `
 
 ```json
 {
+  "input": {},
   "results": [
     {
       "input": {
@@ -194,7 +195,8 @@ Commands that operate on multiple paths return a `results` array. For `cp` and `
         "size": 123
       }
     }
-  ]
+  ],
+  "warnings": []
 }
 ```
 
@@ -202,6 +204,7 @@ For commands such as `rm`, `input` uses command-specific path and flag fields:
 
 ```json
 {
+  "input": {},
   "results": [
     {
       "input": {
@@ -219,7 +222,8 @@ For commands such as `rm`, `input` uses command-specific path and flag fields:
         "size": 123
       }
     }
-  ]
+  ],
+  "warnings": []
 }
 ```
 
@@ -251,11 +255,12 @@ For commands such as `rm`, `input` uses command-specific path and flag fields:
         "size": 123
       }
     }
-  ]
+  ],
+  "warnings": []
 }
 ```
 
-`get` also returns a `results` array. File downloads use `downloaded`; recursive folder downloads may also include local directory results with `created` or `existing`.
+`get` also returns a top-level `input`, a `results` array, and `warnings: []`. File downloads use `downloaded`; recursive folder downloads may also include local directory results with `created` or `existing`.
 
 Commands that return entry lists, such as `ls`, `search`, and `revs`, return an `input` object and an `entries` array. `ls` input includes the listed path; `search` input includes the query and optional path scope; `revs` input includes the file path:
 

--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -72,7 +72,7 @@ func cp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cp: %d error(s)", len(cpErrors))
 	}
 
-	return commandOutput(cmd).Render(nil, relocationOutput{Results: results})
+	return renderJSONOperationOutput(cmd, nil, relocationOperationResults(results))
 }
 
 // cpCmd represents the cp command

--- a/cmd/cp_test.go
+++ b/cmd/cp_test.go
@@ -311,11 +311,29 @@ func newRelocationTestCommand(stdout, stderr *bytes.Buffer) *cobra.Command {
 	return cmd
 }
 
+type relocationOutput struct {
+	Input    map[string]any     `json:"input"`
+	Results  []relocationResult `json:"results"`
+	Warnings []jsonWarning      `json:"warnings"`
+}
+
 func decodeRelocationOutput(t *testing.T, data []byte) relocationOutput {
 	t.Helper()
 	var got relocationOutput
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("decode JSON output: %v\noutput: %s", err, string(data))
+	}
+	if got.Input == nil {
+		t.Fatalf("input = nil, want empty object")
+	}
+	if len(got.Input) != 0 {
+		t.Fatalf("input = %+v, want empty object", got.Input)
+	}
+	if got.Warnings == nil {
+		t.Fatalf("warnings = nil, want empty array")
+	}
+	if len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %+v, want empty", got.Warnings)
 	}
 	return got
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -63,11 +63,6 @@ type getResult struct {
 	Result *jsonMetadata  `json:"result,omitempty"`
 }
 
-type getOutputData struct {
-	Input   getCommandInput `json:"input"`
-	Results []getResult     `json:"results"`
-}
-
 func get(cmd *cobra.Command, args []string) (err error) {
 	if len(args) == 0 || len(args) > 2 {
 		return errors.New("`get` requires `src` and/or `dst` arguments")
@@ -184,10 +179,19 @@ func newGetResult(status, kind, source, target string, metadata files.IsMetadata
 }
 
 func renderGetResults(cmd *cobra.Command, input getCommandInput, results []getResult) error {
-	return commandOutput(cmd).Render(nil, getOutputData{
-		Input:   input,
-		Results: results,
-	})
+	return renderJSONOperationOutput(cmd, input, getOperationResults(results))
+}
+
+func getOperationResults(results []getResult) []jsonOperationResult {
+	operationResults := make([]jsonOperationResult, 0, len(results))
+	for _, result := range results {
+		var metadata any
+		if result.Result != nil {
+			metadata = result.Result
+		}
+		operationResults = append(operationResults, newJSONOperationResult(result.Status, result.Kind, result.Input, metadata))
+	}
+	return operationResults
 }
 
 func getStdout(cmd *cobra.Command, src string, recursive bool) error {

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -47,12 +47,24 @@ func testGetJSONCmd(stdout, stderr *bytes.Buffer) *cobra.Command {
 	return cmd
 }
 
+type getOutputData struct {
+	Input    getCommandInput `json:"input"`
+	Results  []getResult     `json:"results"`
+	Warnings []jsonWarning   `json:"warnings"`
+}
+
 func decodeGetOutput(t *testing.T, stdout *bytes.Buffer) getOutputData {
 	t.Helper()
 
 	var got getOutputData
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("decode get JSON output: %v\noutput: %s", err, stdout.String())
+	}
+	if got.Warnings == nil {
+		t.Fatalf("warnings = nil, want empty array")
+	}
+	if len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %+v, want empty", got.Warnings)
 	}
 	return got
 }

--- a/cmd/json_output.go
+++ b/cmd/json_output.go
@@ -1,5 +1,7 @@
 package cmd
 
+import "github.com/spf13/cobra"
+
 type jsonErrorResponse struct {
 	OK       bool          `json:"ok"`
 	Error    jsonError     `json:"error"`
@@ -46,6 +48,19 @@ func newJSONOperationOutput(input any, results []jsonOperationResult, warnings [
 		Input:    normalizeJSONInput(input),
 		Results:  normalizeJSONOperationResults(results),
 		Warnings: normalizeJSONWarnings(warnings),
+	}
+}
+
+func renderJSONOperationOutput(cmd *cobra.Command, input any, results []jsonOperationResult) error {
+	return commandOutput(cmd).Render(nil, newJSONOperationOutput(input, results, nil))
+}
+
+func newJSONOperationResult(status, kind string, input any, result any) jsonOperationResult {
+	return jsonOperationResult{
+		Status: status,
+		Kind:   kind,
+		Input:  input,
+		Result: result,
 	}
 }
 

--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -70,7 +70,7 @@ func mv(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("mv: %d error(s)", len(mvErrors))
 	}
 
-	return commandOutput(cmd).Render(nil, relocationOutput{Results: results})
+	return renderJSONOperationOutput(cmd, nil, relocationOperationResults(results))
 }
 
 // mvCmd represents the mv command

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -257,8 +257,8 @@ func TestRenderCommandErrorWritesJSONErrorToStdout(t *testing.T) {
 	if got := stderr.String(); got != "" {
 		t.Fatalf("stderr = %q, want empty", got)
 	}
-	output := stdout.String()
-	got := decodeJSONErrorResponse(t, output)
+	rendered := stdout.String()
+	got := decodeJSONErrorResponse(t, rendered)
 	if got.OK {
 		t.Fatalf("ok = true, want false")
 	}
@@ -271,8 +271,8 @@ func TestRenderCommandErrorWritesJSONErrorToStdout(t *testing.T) {
 	if len(got.Warnings) != 0 {
 		t.Fatalf("warnings = %+v, want empty", got.Warnings)
 	}
-	if !strings.Contains(output, `"warnings":[]`) {
-		t.Fatalf("output = %q, want warnings array", output)
+	if !strings.Contains(rendered, `"warnings":[]`) {
+		t.Fatalf("output = %q, want warnings array", rendered)
 	}
 }
 
@@ -370,6 +370,71 @@ func TestNewJSONOperationOutputNormalizesResults(t *testing.T) {
 	}
 	if got.Results == nil {
 		t.Fatal("results is nil, want empty slice")
+	}
+}
+
+func TestRenderJSONOperationOutput(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.Flags().String(outputFlag, "json", "")
+
+	err := renderJSONOperationOutput(
+		cmd,
+		struct {
+			Path string `json:"path"`
+		}{Path: "/file.txt"},
+		[]jsonOperationResult{
+			newJSONOperationResult(
+				"downloaded",
+				"file",
+				struct {
+					Source string `json:"source"`
+				}{Source: "/file.txt"},
+				struct {
+					Type string `json:"type"`
+				}{Type: "file"},
+			),
+		},
+	)
+	if err != nil {
+		t.Fatalf("renderJSONOperationOutput returned error: %v", err)
+	}
+
+	rendered := stdout.String()
+	for _, want := range []string{
+		`"input":{"path":"/file.txt"}`,
+		`"results":[{"status":"downloaded","kind":"file"`,
+		`"warnings":[]`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("output = %s, want %s", rendered, want)
+		}
+	}
+}
+
+func TestNewJSONOperationResultOmitsEmptyFields(t *testing.T) {
+	got := newJSONOperationResult(
+		"",
+		"",
+		struct {
+			Path string `json:"path"`
+		}{Path: "/file.txt"},
+		nil,
+	)
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal operation result: %v", err)
+	}
+	rendered := string(encoded)
+	for _, unwanted := range []string{`"status"`, `"kind"`, `"result"`} {
+		if strings.Contains(rendered, unwanted) {
+			t.Fatalf("encoded output = %s, did not expect %s", rendered, unwanted)
+		}
+	}
+	if !strings.Contains(rendered, `"input":{"path":"/file.txt"}`) {
+		t.Fatalf("encoded output = %s, want input", rendered)
 	}
 }
 

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -236,11 +236,6 @@ type putResult struct {
 	Result *jsonMetadata  `json:"result,omitempty"`
 }
 
-type putOutputData struct {
-	Input   putCommandInput `json:"input"`
-	Results []putResult     `json:"results"`
-}
-
 type putDestinationAction int
 
 const (
@@ -265,10 +260,19 @@ func newPutResult(status, kind, source, target string, metadata files.IsMetadata
 }
 
 func renderPutResults(cmd *cobra.Command, input putCommandInput, results []putResult) error {
-	return commandOutput(cmd).Render(nil, putOutputData{
-		Input:   input,
-		Results: results,
-	})
+	return renderJSONOperationOutput(cmd, input, putOperationResults(results))
+}
+
+func putOperationResults(results []putResult) []jsonOperationResult {
+	operationResults := make([]jsonOperationResult, 0, len(results))
+	for _, result := range results {
+		var metadata any
+		if result.Result != nil {
+			metadata = result.Result
+		}
+		operationResults = append(operationResults, newJSONOperationResult(result.Status, result.Kind, result.Input, metadata))
+	}
+	return operationResults
 }
 
 func put(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/put_test.go
+++ b/cmd/put_test.go
@@ -264,12 +264,24 @@ func testPutJSONCmd(stdout, stderr *bytes.Buffer) *cobra.Command {
 	return cmd
 }
 
+type putOutputData struct {
+	Input    putCommandInput `json:"input"`
+	Results  []putResult     `json:"results"`
+	Warnings []jsonWarning   `json:"warnings"`
+}
+
 func decodePutOutput(t *testing.T, stdout *bytes.Buffer) putOutputData {
 	t.Helper()
 
 	var got putOutputData
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("decode put JSON output: %v\noutput: %s", err, stdout.String())
+	}
+	if got.Warnings == nil {
+		t.Fatalf("warnings = nil, want empty array")
+	}
+	if len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %+v, want empty", got.Warnings)
 	}
 	return got
 }

--- a/cmd/relocation_output.go
+++ b/cmd/relocation_output.go
@@ -12,10 +12,6 @@ type relocationResult struct {
 	Result jsonMetadata    `json:"result"`
 }
 
-type relocationOutput struct {
-	Results []relocationResult `json:"results"`
-}
-
 func newRelocationResult(arg *files.RelocationArg, res *files.RelocationResult) relocationResult {
 	var metadata files.IsMetadata
 	if res != nil {
@@ -29,4 +25,12 @@ func newRelocationResult(arg *files.RelocationArg, res *files.RelocationResult) 
 		},
 		Result: jsonMetadataFromDropbox(metadata),
 	}
+}
+
+func relocationOperationResults(results []relocationResult) []jsonOperationResult {
+	operationResults := make([]jsonOperationResult, 0, len(results))
+	for _, result := range results {
+		operationResults = append(operationResults, newJSONOperationResult("", "", result.Input, result.Result))
+	}
+	return operationResults
 }

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -48,10 +48,6 @@ type removeResult struct {
 	Result jsonMetadata `json:"result"`
 }
 
-type removeOutput struct {
-	Results []removeResult `json:"results"`
-}
-
 func rm(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("rm: missing operand")
@@ -79,7 +75,15 @@ func rm(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 		return renderRemoveResults(w, results)
-	}, removeOutput{Results: results})
+	}, newJSONOperationOutput(nil, removeOperationResults(results), nil))
+}
+
+func removeOperationResults(results []removeResult) []jsonOperationResult {
+	operationResults := make([]jsonOperationResult, 0, len(results))
+	for _, result := range results {
+		operationResults = append(operationResults, newJSONOperationResult("", "", result.Input, result.Result))
+	}
+	return operationResults
 }
 
 func parseRemoveOptions(cmd *cobra.Command) (removeOptions, error) {

--- a/cmd/rm_test.go
+++ b/cmd/rm_test.go
@@ -66,6 +66,12 @@ func setRmOutputJSON(t *testing.T, cmd *cobra.Command) {
 	}
 }
 
+type removeOutput struct {
+	Input    map[string]any `json:"input"`
+	Results  []removeResult `json:"results"`
+	Warnings []jsonWarning  `json:"warnings"`
+}
+
 func decodeRemoveOutput(t *testing.T, stdout *bytes.Buffer) removeOutput {
 	t.Helper()
 
@@ -78,6 +84,18 @@ func decodeRemoveOutputString(t *testing.T, output string) removeOutput {
 	var got removeOutput
 	if err := json.Unmarshal([]byte(output), &got); err != nil {
 		t.Fatalf("decode JSON output: %v\noutput: %s", err, output)
+	}
+	if got.Input == nil {
+		t.Fatalf("input = nil, want empty object")
+	}
+	if len(got.Input) != 0 {
+		t.Fatalf("input = %+v, want empty object", got.Input)
+	}
+	if got.Warnings == nil {
+		t.Fatalf("warnings = nil, want empty array")
+	}
+	if len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %+v, want empty", got.Warnings)
 	}
 	return got
 }


### PR DESCRIPTION
## Summary
- Consolidates `cp`, `mv`, `put`, `get`, and `rm` to use shared `jsonOperationOutput` with consistent `input`/`results`/`warnings` structure
- All multi-result JSON responses now include top-level `"input"`, `"results"`, and `"warnings": []` fields
- Removes per-command output wrapper structs (`relocationOutput`, `putOutputData`, `getOutputData`, `removeOutput`) in favor of shared `renderJSONOperationOutput` helper
- Adds `newJSONOperationResult` constructor and per-command converter functions
- Updates README JSON examples to reflect the normalized schema

## Test plan
- [x] All existing tests pass
- [x] Test decode helpers now assert `warnings` is always `[]` (not null)
- [x] New tests for `renderJSONOperationOutput` and `newJSONOperationResult`
- [x] `gofmt`, `go vet`, `golangci-lint` clean