### PR TITLE
Normalize ls, search, and revs to shared JSON operation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ For commands such as `rm`, `input` uses command-specific path and flag fields:
 
 `get` also returns a top-level `input`, a `results` array, and `warnings: []`. File downloads use `downloaded`; recursive folder downloads may also include local directory results with `created` or `existing`.
 
-Commands that return entry lists, such as `ls`, `search`, and `revs`, return an `input` object and an `entries` array. `ls` input includes the listed path; `search` input includes the query and optional path scope; `revs` input includes the file path:
+Entry-list commands such as `ls`, `search`, and `revs` use the operation-style wrapper. `ls` input includes the listed path; `search` input includes the query and optional path scope; `revs` input includes the file path. Results use `listed`, `found`, or `revision` status values and put Dropbox metadata under `result`:
 
 ```json
 {
@@ -286,16 +286,21 @@ Commands that return entry lists, such as `ls`, `search`, and `revs`, return an 
     "reverse": false,
     "time": "server"
   },
-  "entries": [
+  "results": [
     {
-      "type": "file",
-      "path_display": "/Reports/q1.pdf",
-      "path_lower": "/reports/q1.pdf",
-      "id": "id:...",
-      "rev": "...",
-      "size": 123
+      "status": "listed",
+      "kind": "file",
+      "result": {
+        "type": "file",
+        "path_display": "/Reports/q1.pdf",
+        "path_lower": "/reports/q1.pdf",
+        "id": "id:...",
+        "rev": "...",
+        "size": 123
+      }
     }
-  ]
+  ],
+  "warnings": []
 }
 ```
 

--- a/cmd/json_output.go
+++ b/cmd/json_output.go
@@ -64,6 +64,14 @@ func newJSONOperationResult(status, kind string, input any, result any) jsonOper
 	}
 }
 
+func newJSONMetadataOperationResults(status string, entries []jsonMetadata) []jsonOperationResult {
+	results := make([]jsonOperationResult, 0, len(entries))
+	for _, entry := range entries {
+		results = append(results, newJSONOperationResult(status, entry.Type, nil, entry))
+	}
+	return results
+}
+
 func normalizeJSONInput(input any) any {
 	if input == nil {
 		return struct{}{}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -41,10 +41,7 @@ type lsInput struct {
 	TimeFormat     string `json:"time_format,omitempty"`
 }
 
-type lsOutput struct {
-	Input   lsInput        `json:"input"`
-	Entries []jsonMetadata `json:"entries"`
-}
+const lsJSONStatusListed = "listed"
 
 // Sends a get_metadata request for a given path and returns the response
 func getFileMetadata(c files.Client, path string) (files.IsMetadata, error) {
@@ -235,10 +232,9 @@ func renderLsOutput(cmd *cobra.Command, path string, arg *files.ListFolderArg, o
 		})
 	}
 
-	return out.Render(nil, lsOutput{
-		Input:   newLsInput(path, arg, onlyDeleted, opts),
-		Entries: jsonMetadataListFromLsEntries(entries),
-	})
+	input := newLsInput(path, arg, onlyDeleted, opts)
+	results := newJSONMetadataOperationResults(lsJSONStatusListed, jsonMetadataListFromLsEntries(entries))
+	return renderJSONOperationOutput(cmd, input, results)
 }
 
 func newLsInput(path string, arg *files.ListFolderArg, onlyDeleted bool, opts listOptions) lsInput {

--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -179,7 +178,7 @@ func TestRenderLsResultsShortModeUsesFourColumns(t *testing.T) {
 	}
 }
 
-func TestLsJSONListsEntriesAndInput(t *testing.T) {
+func TestLsJSONListsResultsAndInput(t *testing.T) {
 	cmd, stdout := testLsCmd(t)
 	setLsOutputJSON(t, cmd)
 	setLsFlag(t, cmd, "recurse", "true")
@@ -244,14 +243,18 @@ func TestLsJSONListsEntriesAndInput(t *testing.T) {
 	if got.Input.Sort != "name" || !got.Input.Reverse || got.Input.Time != "client" || got.Input.TimeFormat != "rfc3339" {
 		t.Fatalf("input options = %+v, want sort/name reverse/client/rfc3339", got.Input)
 	}
-	if len(got.Entries) != 2 {
-		t.Fatalf("entries = %d, want 2", len(got.Entries))
+	if len(got.Results) != 2 {
+		t.Fatalf("results = %d, want 2", len(got.Results))
 	}
-	if got.Entries[0].Type != "folder" || got.Entries[0].PathDisplay != "/Folder" {
-		t.Fatalf("first entry = %#v, want sorted folder", got.Entries[0])
+	if got.Results[0].Status != lsJSONStatusListed || got.Results[0].Kind != "folder" || got.Results[0].Result.PathDisplay != "/Folder" {
+		t.Fatalf("first result = %#v, want sorted listed folder", got.Results[0])
 	}
-	if got.Entries[1].Type != "file" || got.Entries[1].Rev != "rev-file" || got.Entries[1].Size == nil || *got.Entries[1].Size != 42 {
-		t.Fatalf("second entry = %#v, want file metadata", got.Entries[1])
+	second := got.Results[1].Result
+	if got.Results[1].Status != lsJSONStatusListed || got.Results[1].Kind != "file" || second.Type != "file" || second.Rev != "rev-file" || second.Size == nil || *second.Size != 42 {
+		t.Fatalf("second result = %#v, want listed file metadata", got.Results[1])
+	}
+	if strings.Contains(stdout.String(), `"entries"`) {
+		t.Fatalf("JSON output = %s, want operation results and no entries key", stdout.String())
 	}
 }
 
@@ -290,8 +293,8 @@ func TestLsJSONFilePathUsesMetadata(t *testing.T) {
 	if got.Input.Path != "/file.txt" {
 		t.Fatalf("input path = %q, want /file.txt", got.Input.Path)
 	}
-	if len(got.Entries) != 1 || got.Entries[0].Type != "file" {
-		t.Fatalf("entries = %#v, want one file", got.Entries)
+	if len(got.Results) != 1 || got.Results[0].Status != lsJSONStatusListed || got.Results[0].Kind != "file" || got.Results[0].Result.Type != "file" {
+		t.Fatalf("results = %#v, want one listed file", got.Results)
 	}
 }
 
@@ -336,10 +339,13 @@ func TestLsJSONDeletedEntryIsStructured(t *testing.T) {
 		t.Fatalf("ls error: %v", err)
 	}
 	got := decodeLsOutput(t, stdout)
-	if len(got.Entries) != 1 {
-		t.Fatalf("entries = %d, want 1", len(got.Entries))
+	if len(got.Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(got.Results))
 	}
-	entry := got.Entries[0]
+	if got.Results[0].Status != lsJSONStatusListed || got.Results[0].Kind != "file" {
+		t.Fatalf("result = %#v, want listed file", got.Results[0])
+	}
+	entry := got.Results[0].Result
 	if entry.PathDisplay != "/removed.txt" {
 		t.Fatalf("path_display = %q, want undecorated path", entry.PathDisplay)
 	}
@@ -481,12 +487,8 @@ func setLsFlag(t *testing.T, cmd *cobra.Command, name, value string) {
 	}
 }
 
-func decodeLsOutput(t *testing.T, out *bytes.Buffer) lsOutput {
+func decodeLsOutput(t *testing.T, out *bytes.Buffer) metadataOperationOutputForTest[lsInput] {
 	t.Helper()
 
-	var got lsOutput
-	if err := json.NewDecoder(out).Decode(&got); err != nil {
-		t.Fatalf("decode JSON output: %v\noutput: %s", err, out.String())
-	}
-	return got
+	return decodeMetadataOperationOutput[lsInput](t, out)
 }

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -13,6 +13,34 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type metadataOperationOutputForTest[I any] struct {
+	Input    I                                `json:"input"`
+	Results  []metadataOperationResultForTest `json:"results"`
+	Warnings []jsonWarning                    `json:"warnings"`
+}
+
+type metadataOperationResultForTest struct {
+	Status string       `json:"status"`
+	Kind   string       `json:"kind"`
+	Result jsonMetadata `json:"result"`
+}
+
+func decodeMetadataOperationOutput[I any](t *testing.T, out *bytes.Buffer) metadataOperationOutputForTest[I] {
+	t.Helper()
+
+	var got metadataOperationOutputForTest[I]
+	if err := json.NewDecoder(bytes.NewReader(out.Bytes())).Decode(&got); err != nil {
+		t.Fatalf("decode JSON output: %v\noutput: %s", err, out.String())
+	}
+	if got.Warnings == nil {
+		t.Fatalf("warnings = nil, want empty array")
+	}
+	if len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %+v, want empty", got.Warnings)
+	}
+	return got
+}
+
 func TestCommandOutputUsesCobraWriters(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -435,6 +463,38 @@ func TestNewJSONOperationResultOmitsEmptyFields(t *testing.T) {
 	}
 	if !strings.Contains(rendered, `"input":{"path":"/file.txt"}`) {
 		t.Fatalf("encoded output = %s, want input", rendered)
+	}
+}
+
+func TestNewJSONMetadataOperationResults(t *testing.T) {
+	size := uint64(42)
+	results := newJSONMetadataOperationResults("listed", []jsonMetadata{
+		{
+			Type:        "file",
+			PathDisplay: "/file.txt",
+			Size:        &size,
+		},
+		{
+			Type:        "folder",
+			PathDisplay: "/folder",
+		},
+	})
+
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	if results[0].Status != "listed" || results[0].Kind != "file" || results[0].Input != nil {
+		t.Fatalf("first result = %#v, want listed file with no per-result input", results[0])
+	}
+	first, ok := results[0].Result.(jsonMetadata)
+	if !ok {
+		t.Fatalf("first result metadata type = %T, want jsonMetadata", results[0].Result)
+	}
+	if first.PathDisplay != "/file.txt" || first.Size == nil || *first.Size != 42 {
+		t.Fatalf("first metadata = %#v, want file metadata", first)
+	}
+	if results[1].Status != "listed" || results[1].Kind != "folder" {
+		t.Fatalf("second result = %#v, want listed folder", results[1])
 	}
 }
 

--- a/cmd/revs.go
+++ b/cmd/revs.go
@@ -32,10 +32,7 @@ type revsInput struct {
 	TimeFormat string `json:"time_format,omitempty"`
 }
 
-type revsOutput struct {
-	Input   revsInput      `json:"input"`
-	Entries []jsonMetadata `json:"entries"`
-}
+const revsJSONStatusRevision = "revision"
 
 func revs(cmd *cobra.Command, args []string) (err error) {
 	if len(args) != 1 {
@@ -68,10 +65,9 @@ func renderRevisionsOutput(cmd *cobra.Command, path string, entries []*files.Fil
 		})
 	}
 
-	return out.Render(nil, revsOutput{
-		Input:   newRevsInput(path, opts),
-		Entries: jsonMetadataListFromRevisions(entries),
-	})
+	input := newRevsInput(path, opts)
+	results := newJSONMetadataOperationResults(revsJSONStatusRevision, jsonMetadataListFromRevisions(entries))
+	return renderJSONOperationOutput(cmd, input, results)
 }
 
 func newRevsInput(path string, opts listOptions) revsInput {

--- a/cmd/revs_test.go
+++ b/cmd/revs_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -96,7 +95,7 @@ func TestRevsUsesListRevisionsAndCommandOutput(t *testing.T) {
 	}
 }
 
-func TestRevsJSONOutputsInputAndEntries(t *testing.T) {
+func TestRevsJSONOutputsInputAndResults(t *testing.T) {
 	cmd, stdout := testRevsCmd()
 	setRevsOutputJSON(t, cmd)
 	setRevsFlag(t, cmd, "long", "true")
@@ -134,15 +133,21 @@ func TestRevsJSONOutputsInputAndEntries(t *testing.T) {
 	if got.Input.Path != "/report.pdf" || !got.Input.Long || got.Input.Time != "client" || got.Input.TimeFormat != "rfc3339" {
 		t.Fatalf("input = %#v, want path/long/time/time_format", got.Input)
 	}
-	if len(got.Entries) != 1 {
-		t.Fatalf("entries = %d, want 1", len(got.Entries))
+	if len(got.Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(got.Results))
 	}
-	entry := got.Entries[0]
+	if got.Results[0].Status != revsJSONStatusRevision || got.Results[0].Kind != "file" {
+		t.Fatalf("result = %#v, want revision file", got.Results[0])
+	}
+	entry := got.Results[0].Result
 	if entry.Type != "file" || entry.PathDisplay != "/report.pdf" || entry.Rev != "rev-a" || entry.Size == nil || *entry.Size != 42 {
 		t.Fatalf("entry = %#v, want file revision metadata", entry)
 	}
 	if entry.ClientModified == nil || *entry.ClientModified != "2026-06-22T10:00:00Z" {
 		t.Fatalf("client_modified = %#v, want RFC3339 timestamp", entry.ClientModified)
+	}
+	if strings.Contains(stdout.String(), `"entries"`) {
+		t.Fatalf("JSON output = %s, want operation results and no entries key", stdout.String())
 	}
 }
 
@@ -193,12 +198,8 @@ func setRevsFlag(t *testing.T, cmd *cobra.Command, name, value string) {
 	}
 }
 
-func decodeRevsOutput(t *testing.T, out *bytes.Buffer) revsOutput {
+func decodeRevsOutput(t *testing.T, out *bytes.Buffer) metadataOperationOutputForTest[revsInput] {
 	t.Helper()
 
-	var got revsOutput
-	if err := json.NewDecoder(out).Decode(&got); err != nil {
-		t.Fatalf("decode JSON output: %v\noutput: %s", err, out.String())
-	}
-	return got
+	return decodeMetadataOperationOutput[revsInput](t, out)
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -36,10 +36,7 @@ type searchInput struct {
 	TimeFormat string `json:"time_format,omitempty"`
 }
 
-type searchOutput struct {
-	Input   searchInput    `json:"input"`
-	Entries []jsonMetadata `json:"entries"`
-}
+const searchJSONStatusFound = "found"
 
 func search(cmd *cobra.Command, args []string) (err error) {
 	if len(args) == 0 {
@@ -101,10 +98,9 @@ func renderSearchOutput(cmd *cobra.Command, query, scope string, entries []files
 		})
 	}
 
-	return out.Render(nil, searchOutput{
-		Input:   newSearchInput(query, scope, opts),
-		Entries: jsonMetadataListFromDropbox(entries),
-	})
+	input := newSearchInput(query, scope, opts)
+	results := newJSONMetadataOperationResults(searchJSONStatusFound, jsonMetadataListFromDropbox(entries))
+	return renderJSONOperationOutput(cmd, input, results)
 }
 
 func newSearchInput(query, scope string, opts listOptions) searchInput {

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -128,7 +128,7 @@ func TestSearchUsesSearchV2AndCommandOutput(t *testing.T) {
 	}
 }
 
-func TestSearchJSONOutputsInputAndEntries(t *testing.T) {
+func TestSearchJSONOutputsInputAndResults(t *testing.T) {
 	cmd, stdout := testSearchCmd()
 	setSearchOutputJSON(t, cmd)
 	setSearchFlag(t, cmd, "long", "true")
@@ -183,14 +183,19 @@ func TestSearchJSONOutputsInputAndEntries(t *testing.T) {
 	if !got.Input.Long || got.Input.Sort != "name" || !got.Input.Reverse || got.Input.Time != "client" || got.Input.TimeFormat != "rfc3339" {
 		t.Fatalf("input options = %#v, want long/sort/reverse/time/time-format", got.Input)
 	}
-	if len(got.Entries) != 2 {
-		t.Fatalf("entries = %d, want 2", len(got.Entries))
+	if len(got.Results) != 2 {
+		t.Fatalf("results = %d, want 2", len(got.Results))
 	}
-	if got.Entries[0].Type != "file" || got.Entries[0].Rev != "rev-file" || got.Entries[0].Size == nil || *got.Entries[0].Size != 42 {
-		t.Fatalf("first entry = %#v, want file metadata", got.Entries[0])
+	first := got.Results[0].Result
+	if got.Results[0].Status != searchJSONStatusFound || got.Results[0].Kind != "file" || first.Type != "file" || first.Rev != "rev-file" || first.Size == nil || *first.Size != 42 {
+		t.Fatalf("first result = %#v, want found file metadata", got.Results[0])
 	}
-	if got.Entries[1].Type != "folder" || got.Entries[1].ID != "id:folder" {
-		t.Fatalf("second entry = %#v, want folder metadata", got.Entries[1])
+	second := got.Results[1].Result
+	if got.Results[1].Status != searchJSONStatusFound || got.Results[1].Kind != "folder" || second.Type != "folder" || second.ID != "id:folder" {
+		t.Fatalf("second result = %#v, want found folder metadata", got.Results[1])
+	}
+	if strings.Contains(stdout.String(), `"entries"`) {
+		t.Fatalf("JSON output = %s, want operation results and no entries key", stdout.String())
 	}
 }
 
@@ -279,14 +284,10 @@ func setSearchFlag(t *testing.T, cmd *cobra.Command, name, value string) {
 	}
 }
 
-func decodeSearchOutput(t *testing.T, out *bytes.Buffer) searchOutput {
+func decodeSearchOutput(t *testing.T, out *bytes.Buffer) metadataOperationOutputForTest[searchInput] {
 	t.Helper()
 
-	var got searchOutput
-	if err := json.NewDecoder(out).Decode(&got); err != nil {
-		t.Fatalf("decode JSON output: %v\noutput: %s", err, out.String())
-	}
-	return got
+	return decodeMetadataOperationOutput[searchInput](t, out)
 }
 
 func searchMatch(metadata files.IsMetadata) *files.SearchMatchV2 {


### PR DESCRIPTION
## Summary
- Replaces per-command `entries` arrays in `ls`, `search`, and `revs` with the standard `results` array
- Each entry now includes `status` (`listed`/`found`/`revision`) and `kind` derived from metadata type
- Removes `lsOutput`, `searchOutput`, `revsOutput` structs in favor of shared `renderJSONOperationOutput`
- Adds `newJSONMetadataOperationResults` helper for entry-list to operation-results conversion
- Adds generic `metadataOperationOutputForTest[I]` test decode type to DRY test helpers
- Updates README ls JSON example to show the normalized format

## Test plan
- [x] All existing tests pass
- [x] Tests verify `status`/`kind` on each result and assert no `"entries"` key in output
- [x] New test for `newJSONMetadataOperationResults` converter
- [x] `gofmt`, `go vet`, `golangci-lint` clean