### PR TITLE
Normalize share-link commands to shared JSON operation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ $ dbxcli put --output=json README.md /README.md
 $ dbxcli get --output=json /Reports/old.pdf ./old.pdf
 $ dbxcli share-link create --output=json /Reports/old.pdf
 $ dbxcli share-link list --output=json /Reports/old.pdf
+$ dbxcli share-link info --output=json https://www.dropbox.com/s/example/old.pdf
+$ dbxcli share-link update --output=json https://www.dropbox.com/s/example/old.pdf --expires 2026-07-01T00:00:00Z
+$ dbxcli share-link revoke --output=json https://www.dropbox.com/s/example/old.pdf
+$ dbxcli share-link download --output=json https://www.dropbox.com/s/example/old.pdf ./old.pdf
 $ dbxcli mkdir --output=json /new-folder
 $ dbxcli rm --output=json /old-file.txt
 $ dbxcli restore --output=json /Reports/old.pdf 015f...
@@ -156,9 +160,9 @@ $ dbxcli restore --output=json /Reports/old.pdf 015f...
 
 Structured success output is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `cp`, `mv`, `put`, `get`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
 
-Command results and JSON errors are written to stdout. Status, progress, human-facing warnings, diagnostics, and verbose logs are written to stderr. JSON errors include a `warnings` array for machine-actionable warnings; it is `[]` when no warnings are present. New operation-style JSON payloads should use the same `warnings` field.
+Command results and JSON errors are written to stdout. Status, progress, human-facing warnings, diagnostics, and verbose logs are written to stderr. JSON errors include a `warnings` array for machine-actionable warnings; it is `[]` when no warnings are present. Successful JSON payloads use the same `warnings` field.
 
-Successful JSON responses are command-specific. Operation-style commands return an `input` object, a `results` array, and a `warnings` array. For commands such as `mkdir`, each result reports what happened to the requested path:
+Successful JSON responses for migrated commands return an `input` object, a `results` array, and a `warnings` array. Result payloads are command-specific. For commands such as `mkdir`, each result reports what happened to the requested path:
 
 ```json
 {
@@ -346,24 +350,32 @@ Account and usage commands use the operation-style wrapper with a single result:
 }
 ```
 
-Shared-link commands return command-specific objects built around shared-link metadata:
+Shared-link commands use the same operation-style wrapper. `share-link create`, `list`, `info`, and `update` put shared-link metadata directly under `result`; status values include `created`, `existing`, `listed`, `found`, and `updated`:
 
 ```json
 {
   "input": {
     "path": "/Reports/old.pdf"
   },
-  "result": {
-    "type": "file",
-    "url": "https://www.dropbox.com/s/...",
-    "name": "old.pdf",
-    "path_lower": "/reports/old.pdf",
-    "rev": "...",
-    "size": 123
-  },
-  "existing": false
+  "results": [
+    {
+      "status": "created",
+      "kind": "file",
+      "result": {
+        "type": "file",
+        "url": "https://www.dropbox.com/s/...",
+        "name": "old.pdf",
+        "path_lower": "/reports/old.pdf",
+        "rev": "...",
+        "size": 123
+      }
+    }
+  ],
+  "warnings": []
 }
 ```
+
+`share-link revoke` uses `revoked` results whose `result` contains the revoked URL and, when available, the shared-link metadata. `share-link download` uses `downloaded` results whose `result` contains the local `target` and `link` metadata.
 
 `get --output=json <source> -` and `share-link download --output=json <url> -` are not supported because stdout is reserved for downloaded file bytes when the target is `-`.
 

--- a/cmd/share-list-links.go
+++ b/cmd/share-list-links.go
@@ -28,11 +28,6 @@ type shareLinkListInput struct {
 	DirectOnly bool   `json:"direct_only"`
 }
 
-type shareLinkListOutput struct {
-	Input   shareLinkListInput      `json:"input"`
-	Entries []shareLinkJSONMetadata `json:"entries"`
-}
-
 func shareListLinks(cmd *cobra.Command, args []string) (err error) {
 	return shareLinkList(cmd, args)
 }
@@ -71,13 +66,14 @@ func shareLinkList(cmd *cobra.Command, args []string) error {
 
 	return commandOutput(cmd).Render(func(w io.Writer) error {
 		return renderSharedLinks(w, links)
-	}, shareLinkListOutput{
-		Input: shareLinkListInput{
+	}, newJSONOperationOutput(
+		shareLinkListInput{
 			Path:       arg.Path,
 			DirectOnly: arg.DirectOnly,
 		},
-		Entries: entries,
-	})
+		shareLinkJSONOperationResults(shareLinkJSONStatusListed, entries),
+		nil,
+	))
 }
 
 func listSharedLinks(dbx sharedLinkClient, arg *sharing.ListSharedLinksArg) ([]sharing.IsSharedLinkMetadata, error) {

--- a/cmd/share_link_create.go
+++ b/cmd/share_link_create.go
@@ -47,12 +47,6 @@ type shareLinkCreateInput struct {
 	Password         bool   `json:"password,omitempty"`
 }
 
-type shareLinkCreateOutput struct {
-	Input    shareLinkCreateInput  `json:"input"`
-	Result   shareLinkJSONMetadata `json:"result"`
-	Existing bool                  `json:"existing"`
-}
-
 func shareLinkCreate(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("`share-link create` requires a `path` argument")
@@ -103,14 +97,19 @@ func shareLinkCreate(cmd *cobra.Command, args []string) error {
 		return errors.New("found unknown shared link type")
 	}
 
+	status := shareLinkJSONStatusCreated
+	if usedExisting {
+		status = shareLinkJSONStatusExisting
+	}
+
 	return out.Render(func(w io.Writer) error {
 		_, err := fmt.Fprintln(w, url)
 		return err
-	}, shareLinkCreateOutput{
-		Input:    newShareLinkCreateInput(path, opts),
-		Result:   result,
-		Existing: usedExisting,
-	})
+	}, newJSONOperationOutput(
+		newShareLinkCreateInput(path, opts),
+		[]jsonOperationResult{shareLinkJSONOperationResult(status, result)},
+		nil,
+	))
 }
 
 func newShareLinkCreateInput(path string, opts shareLinkCreateOptions) shareLinkCreateInput {

--- a/cmd/share_link_download.go
+++ b/cmd/share_link_download.go
@@ -50,11 +50,6 @@ type shareLinkDownloadResult struct {
 	Link   shareLinkJSONMetadata `json:"link"`
 }
 
-type shareLinkDownloadOutput struct {
-	Input  shareLinkDownloadInput  `json:"input"`
-	Result shareLinkDownloadResult `json:"result"`
-}
-
 func shareLinkDownload(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 || len(args) > 2 {
 		return errors.New("`share-link download` requires a `url` and optional `target` argument")
@@ -531,18 +526,22 @@ func newShareLinkDownloadInput(url, target string, opts shareLinkDownloadOptions
 }
 
 func renderShareLinkDownloadOutput(cmd *cobra.Command, input shareLinkDownloadInput, target string, link sharing.IsSharedLinkMetadata) error {
-	result, ok := shareLinkJSONMetadataFromDropbox(link)
+	metadata, ok := shareLinkJSONMetadataFromDropbox(link)
 	if !ok {
 		return errors.New("found unknown shared link type")
 	}
 
-	return commandOutput(cmd).Render(nil, shareLinkDownloadOutput{
-		Input: input,
-		Result: shareLinkDownloadResult{
-			Target: target,
-			Link:   result,
+	result := shareLinkDownloadResult{
+		Target: target,
+		Link:   metadata,
+	}
+	return renderJSONOperationOutput(
+		cmd,
+		input,
+		[]jsonOperationResult{
+			newJSONOperationResult(shareLinkJSONStatusDownloaded, result.Link.Type, nil, result),
 		},
-	})
+	)
 }
 
 var shareLinkDownloadCmd = &cobra.Command{

--- a/cmd/share_link_info.go
+++ b/cmd/share_link_info.go
@@ -37,11 +37,6 @@ type shareLinkInfoInput struct {
 	Password bool   `json:"password,omitempty"`
 }
 
-type shareLinkInfoOutput struct {
-	Input  shareLinkInfoInput    `json:"input"`
-	Result shareLinkJSONMetadata `json:"result"`
-}
-
 func shareLinkInfo(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("`share-link info` requires a `url` argument")
@@ -78,14 +73,15 @@ func shareLinkInfo(cmd *cobra.Command, args []string) error {
 
 	return commandOutput(cmd).Render(func(w io.Writer) error {
 		return renderSharedLinkInfo(w, link)
-	}, shareLinkInfoOutput{
-		Input: shareLinkInfoInput{
+	}, newJSONOperationOutput(
+		shareLinkInfoInput{
 			URL:      url,
 			Path:     opts.path,
 			Password: opts.password.set,
 		},
-		Result: result,
-	})
+		[]jsonOperationResult{shareLinkJSONOperationResult(shareLinkJSONStatusFound, result)},
+		nil,
+	))
 }
 
 func parseShareLinkInfoOptions(cmd *cobra.Command) (shareLinkInfoOptions, error) {

--- a/cmd/share_link_json.go
+++ b/cmd/share_link_json.go
@@ -38,6 +38,18 @@ type shareLinkJSONPermissions struct {
 	CanUseExtendedSharingControls bool   `json:"can_use_extended_sharing_controls,omitempty"`
 }
 
+const (
+	shareLinkJSONStatusCreated    = "created"
+	shareLinkJSONStatusDownloaded = "downloaded"
+	shareLinkJSONStatusExisting   = "existing"
+	shareLinkJSONStatusFound      = "found"
+	shareLinkJSONStatusListed     = "listed"
+	shareLinkJSONStatusRevoked    = "revoked"
+	shareLinkJSONStatusUpdated    = "updated"
+
+	shareLinkJSONKindSharedLink = "shared_link"
+)
+
 func shareLinkJSONMetadataFromDropbox(link sharing.IsSharedLinkMetadata) (shareLinkJSONMetadata, bool) {
 	base, linkType, ok := sharedLinkBaseMetadata(link)
 	if !ok {
@@ -63,6 +75,18 @@ func shareLinkJSONMetadataFromDropbox(link sharing.IsSharedLinkMetadata) (shareL
 	}
 
 	return result, true
+}
+
+func shareLinkJSONOperationResult(status string, metadata shareLinkJSONMetadata) jsonOperationResult {
+	return newJSONOperationResult(status, metadata.Type, nil, metadata)
+}
+
+func shareLinkJSONOperationResults(status string, entries []shareLinkJSONMetadata) []jsonOperationResult {
+	results := make([]jsonOperationResult, 0, len(entries))
+	for _, entry := range entries {
+		results = append(results, shareLinkJSONOperationResult(status, entry))
+	}
+	return results
 }
 
 func shareLinkJSONMetadataListFromDropbox(links []sharing.IsSharedLinkMetadata) ([]shareLinkJSONMetadata, bool) {

--- a/cmd/share_link_json_test.go
+++ b/cmd/share_link_json_test.go
@@ -14,6 +14,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type shareLinkOperationOutputForTest[I, R any] struct {
+	Input    I                                    `json:"input"`
+	Results  []shareLinkOperationResultForTest[R] `json:"results"`
+	Warnings []jsonWarning                        `json:"warnings"`
+}
+
+type shareLinkOperationResultForTest[R any] struct {
+	Status string `json:"status"`
+	Kind   string `json:"kind"`
+	Result R      `json:"result"`
+}
+
 func TestShareLinkCreateJSONOutputsLinkMetadata(t *testing.T) {
 	expires := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	stubSharedLinkClient(t, &mockSharedLinkClient{
@@ -35,26 +47,60 @@ func TestShareLinkCreateJSONOutputsLinkMetadata(t *testing.T) {
 		t.Fatalf("shareLinkCreate error: %v", err)
 	}
 
-	var got shareLinkCreateOutput
-	decodeJSONOutput(t, stdout.Bytes(), &got)
+	got := decodeShareLinkOperationOutput[shareLinkCreateInput, shareLinkJSONMetadata](t, stdout.Bytes())
 	if got.Input.Path != "/docs/report.txt" {
 		t.Fatalf("input.path = %q, want /docs/report.txt", got.Input.Path)
 	}
-	if got.Existing {
-		t.Fatal("existing = true, want false")
+	if len(got.Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(got.Results))
 	}
-	if got.Result.Type != "file" || got.Result.URL != "https://example.com/report" || got.Result.PathLower != "/docs/report.txt" {
-		t.Fatalf("result = %#v, want file shared link metadata", got.Result)
+	result := got.Results[0]
+	if result.Status != shareLinkJSONStatusCreated || result.Kind != "file" {
+		t.Fatalf("operation result = %#v, want created file", result)
 	}
-	if got.Result.Size == nil || *got.Result.Size != 42 {
-		t.Fatalf("result.size = %#v, want 42", got.Result.Size)
+	if result.Result.Type != "file" || result.Result.URL != "https://example.com/report" || result.Result.PathLower != "/docs/report.txt" {
+		t.Fatalf("result = %#v, want file shared link metadata", result.Result)
 	}
-	if got.Result.Expires == nil || *got.Result.Expires != "2026-07-01T00:00:00Z" {
-		t.Fatalf("result.expires = %#v, want RFC3339 expiration", got.Result.Expires)
+	if result.Result.Size == nil || *result.Result.Size != 42 {
+		t.Fatalf("result.size = %#v, want 42", result.Result.Size)
 	}
+	if result.Result.Expires == nil || *result.Result.Expires != "2026-07-01T00:00:00Z" {
+		t.Fatalf("result.expires = %#v, want RFC3339 expiration", result.Result.Expires)
+	}
+	assertNoTopLevelJSONField(t, stdout.Bytes(), "existing")
 }
 
-func TestShareLinkListJSONOutputsEntriesAndInput(t *testing.T) {
+func TestShareLinkCreateJSONReportsExistingAsStatus(t *testing.T) {
+	existing := sharedLinkFolder("/docs", "https://example.com/docs")
+	stubSharedLinkClient(t, &mockSharedLinkClient{
+		createSharedLinkWithSettingsFn: func(arg *sharing.CreateSharedLinkWithSettingsArg) (sharing.IsSharedLinkMetadata, error) {
+			return nil, alreadyExistsError(existing)
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	setShareLinkOutputJSON(t, cmd)
+
+	if err := shareLinkCreate(cmd, []string{"/docs"}); err != nil {
+		t.Fatalf("shareLinkCreate error: %v", err)
+	}
+
+	got := decodeShareLinkOperationOutput[shareLinkCreateInput, shareLinkJSONMetadata](t, stdout.Bytes())
+	if len(got.Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(got.Results))
+	}
+	if got.Results[0].Status != shareLinkJSONStatusExisting || got.Results[0].Kind != "folder" {
+		t.Fatalf("result = %#v, want existing folder", got.Results[0])
+	}
+	if got.Results[0].Result.URL != "https://example.com/docs" {
+		t.Fatalf("result.url = %q, want existing URL", got.Results[0].Result.URL)
+	}
+	assertNoTopLevelJSONField(t, stdout.Bytes(), "existing")
+}
+
+func TestShareLinkListJSONOutputsResultsAndInput(t *testing.T) {
 	stubSharedLinkClient(t, &mockSharedLinkClient{
 		listSharedLinksFn: func(arg *sharing.ListSharedLinksArg) (*sharing.ListSharedLinksResult, error) {
 			if arg.Path != "/docs/report.txt" || !arg.DirectOnly {
@@ -75,13 +121,15 @@ func TestShareLinkListJSONOutputsEntriesAndInput(t *testing.T) {
 		t.Fatalf("shareLinkList error: %v", err)
 	}
 
-	var got shareLinkListOutput
-	decodeJSONOutput(t, stdout.Bytes(), &got)
+	got := decodeShareLinkOperationOutput[shareLinkListInput, shareLinkJSONMetadata](t, stdout.Bytes())
 	if got.Input.Path != "/docs/report.txt" || !got.Input.DirectOnly {
 		t.Fatalf("input = %#v, want direct path input", got.Input)
 	}
-	if len(got.Entries) != 1 || got.Entries[0].URL != "https://example.com/report" {
-		t.Fatalf("entries = %#v, want report shared link", got.Entries)
+	if len(got.Results) != 1 || got.Results[0].Status != shareLinkJSONStatusListed || got.Results[0].Kind != "file" || got.Results[0].Result.URL != "https://example.com/report" {
+		t.Fatalf("results = %#v, want listed report shared link", got.Results)
+	}
+	if strings.Contains(stdout.String(), `"entries"`) {
+		t.Fatalf("JSON output = %s, want operation results and no entries key", stdout.String())
 	}
 }
 
@@ -108,19 +156,22 @@ func TestShareLinkInfoJSONOutputsPermissions(t *testing.T) {
 		t.Fatalf("shareLinkInfo error: %v", err)
 	}
 
-	var got shareLinkInfoOutput
-	decodeJSONOutput(t, stdout.Bytes(), &got)
+	got := decodeShareLinkOperationOutput[shareLinkInfoInput, shareLinkJSONMetadata](t, stdout.Bytes())
 	if got.Input.URL != "https://example.com/report" {
 		t.Fatalf("input.url = %q, want https://example.com/report", got.Input.URL)
 	}
-	if got.Result.Permissions == nil {
+	if len(got.Results) != 1 || got.Results[0].Status != shareLinkJSONStatusFound || got.Results[0].Kind != "file" {
+		t.Fatalf("results = %#v, want found file", got.Results)
+	}
+	result := got.Results[0].Result
+	if result.Permissions == nil {
 		t.Fatal("result.permissions = nil, want permissions")
 	}
-	if got.Result.Permissions.ResolvedVisibility != "public" || got.Result.Permissions.AccessLevel != "viewer" {
-		t.Fatalf("permissions = %#v, want visibility and access level", got.Result.Permissions)
+	if result.Permissions.ResolvedVisibility != "public" || result.Permissions.AccessLevel != "viewer" {
+		t.Fatalf("permissions = %#v, want visibility and access level", result.Permissions)
 	}
-	if !got.Result.Permissions.AllowDownload || !got.Result.Permissions.RequirePassword {
-		t.Fatalf("permissions = %#v, want allow_download and require_password", got.Result.Permissions)
+	if !result.Permissions.AllowDownload || !result.Permissions.RequirePassword {
+		t.Fatalf("permissions = %#v, want allow_download and require_password", result.Permissions)
 	}
 }
 
@@ -142,13 +193,15 @@ func TestShareLinkUpdateJSONOutputsUpdatedMetadata(t *testing.T) {
 		t.Fatalf("shareLinkUpdate error: %v", err)
 	}
 
-	var got shareLinkUpdateOutput
-	decodeJSONOutput(t, stdout.Bytes(), &got)
+	got := decodeShareLinkOperationOutput[shareLinkUpdateInput, shareLinkJSONMetadata](t, stdout.Bytes())
 	if got.Input.URL != "https://example.com/report" || !got.Input.AllowDownload {
 		t.Fatalf("input = %#v, want update input", got.Input)
 	}
-	if got.Result.URL != "https://example.com/report" {
-		t.Fatalf("result.url = %q, want updated URL", got.Result.URL)
+	if len(got.Results) != 1 || got.Results[0].Status != shareLinkJSONStatusUpdated || got.Results[0].Kind != "file" {
+		t.Fatalf("results = %#v, want updated file", got.Results)
+	}
+	if got.Results[0].Result.URL != "https://example.com/report" {
+		t.Fatalf("result.url = %q, want updated URL", got.Results[0].Result.URL)
 	}
 }
 
@@ -167,13 +220,12 @@ func TestShareLinkRevokeJSONOutputsRevokedURL(t *testing.T) {
 		t.Fatalf("shareLinkRevoke error: %v", err)
 	}
 
-	var got shareLinkRevokeOutput
-	decodeJSONOutput(t, stdout.Bytes(), &got)
+	got := decodeShareLinkOperationOutput[shareLinkRevokeInput, shareLinkRevokeResult](t, stdout.Bytes())
 	if got.Input.URL != "https://example.com/report" {
 		t.Fatalf("input.url = %q, want revoked URL", got.Input.URL)
 	}
-	if len(got.Revoked) != 1 || got.Revoked[0].URL != "https://example.com/report" {
-		t.Fatalf("revoked = %#v, want revoked URL", got.Revoked)
+	if len(got.Results) != 1 || got.Results[0].Status != shareLinkJSONStatusRevoked || got.Results[0].Kind != shareLinkJSONKindSharedLink || got.Results[0].Result.URL != "https://example.com/report" {
+		t.Fatalf("results = %#v, want revoked URL", got.Results)
 	}
 }
 
@@ -200,13 +252,15 @@ func TestShareLinkDownloadJSONOutputsTargetAndMetadata(t *testing.T) {
 	}
 	assertFileContent(t, target, "content")
 
-	var got shareLinkDownloadOutput
-	decodeJSONOutput(t, stdout.Bytes(), &got)
+	got := decodeShareLinkOperationOutput[shareLinkDownloadInput, shareLinkDownloadResult](t, stdout.Bytes())
 	if got.Input.URL != "https://example.com/report" || got.Input.Target != target {
 		t.Fatalf("input = %#v, want download input", got.Input)
 	}
-	if got.Result.Target != target || got.Result.Link.URL != "https://example.com/report" {
-		t.Fatalf("result = %#v, want target and link metadata", got.Result)
+	if len(got.Results) != 1 || got.Results[0].Status != shareLinkJSONStatusDownloaded || got.Results[0].Kind != "file" {
+		t.Fatalf("results = %#v, want downloaded file", got.Results)
+	}
+	if got.Results[0].Result.Target != target || got.Results[0].Result.Link.URL != "https://example.com/report" {
+		t.Fatalf("result = %#v, want target and link metadata", got.Results[0].Result)
 	}
 }
 
@@ -265,5 +319,27 @@ func decodeJSONOutput(t *testing.T, data []byte, out any) {
 	t.Helper()
 	if err := json.Unmarshal(data, out); err != nil {
 		t.Fatalf("decode JSON output: %v\noutput: %s", err, string(data))
+	}
+}
+
+func decodeShareLinkOperationOutput[I, R any](t *testing.T, data []byte) shareLinkOperationOutputForTest[I, R] {
+	t.Helper()
+	var got shareLinkOperationOutputForTest[I, R]
+	decodeJSONOutput(t, data, &got)
+	if got.Warnings == nil {
+		t.Fatalf("warnings = nil, want empty array")
+	}
+	if len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %+v, want empty", got.Warnings)
+	}
+	return got
+}
+
+func assertNoTopLevelJSONField(t *testing.T, data []byte, field string) {
+	t.Helper()
+	var raw map[string]any
+	decodeJSONOutput(t, data, &raw)
+	if _, ok := raw[field]; ok {
+		t.Fatalf("JSON output = %s, want no top-level %q field", string(data), field)
 	}
 }

--- a/cmd/share_link_revoke.go
+++ b/cmd/share_link_revoke.go
@@ -36,11 +36,6 @@ type shareLinkRevokeResult struct {
 	Link *shareLinkJSONMetadata `json:"link,omitempty"`
 }
 
-type shareLinkRevokeOutput struct {
-	Input   shareLinkRevokeInput    `json:"input"`
-	Revoked []shareLinkRevokeResult `json:"revoked"`
-}
-
 func shareLinkRevoke(cmd *cobra.Command, args []string) error {
 	opts, err := parseShareLinkRevokeOptions(cmd, args)
 	if err != nil {
@@ -52,12 +47,7 @@ func shareLinkRevoke(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		return commandOutput(cmd).Render(nil, shareLinkRevokeOutput{
-			Input: shareLinkRevokeInput{
-				Path: opts.path,
-			},
-			Revoked: revoked,
-		})
+		return renderJSONOperationOutput(cmd, shareLinkRevokeInput{Path: opts.path}, shareLinkRevokeOperationResults(revoked))
 	}
 
 	if len(args) != 1 {
@@ -76,12 +66,23 @@ func shareLinkRevoke(cmd *cobra.Command, args []string) error {
 	}
 
 	commandVerboseStatus(cmd, "Revoked shared link %s", url)
-	return commandOutput(cmd).Render(nil, shareLinkRevokeOutput{
-		Input: shareLinkRevokeInput{
-			URL: url,
-		},
-		Revoked: []shareLinkRevokeResult{{URL: url}},
-	})
+	return renderJSONOperationOutput(
+		cmd,
+		shareLinkRevokeInput{URL: url},
+		shareLinkRevokeOperationResults([]shareLinkRevokeResult{{URL: url}}),
+	)
+}
+
+func shareLinkRevokeOperationResults(revoked []shareLinkRevokeResult) []jsonOperationResult {
+	results := make([]jsonOperationResult, 0, len(revoked))
+	for _, result := range revoked {
+		kind := shareLinkJSONKindSharedLink
+		if result.Link != nil {
+			kind = result.Link.Type
+		}
+		results = append(results, newJSONOperationResult(shareLinkJSONStatusRevoked, kind, nil, result))
+	}
+	return results
 }
 
 func parseShareLinkRevokeOptions(cmd *cobra.Command, args []string) (shareLinkRevokeOptions, error) {

--- a/cmd/share_link_update.go
+++ b/cmd/share_link_update.go
@@ -45,11 +45,6 @@ type shareLinkUpdateInput struct {
 	RemovePassword   bool   `json:"remove_password,omitempty"`
 }
 
-type shareLinkUpdateOutput struct {
-	Input  shareLinkUpdateInput  `json:"input"`
-	Result shareLinkJSONMetadata `json:"result"`
-}
-
 func shareLinkUpdate(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("`share-link update` requires a `url` argument")
@@ -126,10 +121,11 @@ func renderShareLinkUpdateOutput(cmd *cobra.Command, dbx sharedLinkClient, url s
 		return errors.New("found unknown shared link type")
 	}
 
-	return commandOutput(cmd).Render(nil, shareLinkUpdateOutput{
-		Input:  newShareLinkUpdateInput(url, opts),
-		Result: result,
-	})
+	return renderJSONOperationOutput(
+		cmd,
+		newShareLinkUpdateInput(url, opts),
+		[]jsonOperationResult{shareLinkJSONOperationResult(shareLinkJSONStatusUpdated, result)},
+	)
 }
 
 func newShareLinkUpdateInput(url string, opts shareLinkUpdateOptions) shareLinkUpdateInput {


### PR DESCRIPTION
## Summary
- Replace command-specific output structs with the standard `input`/`results`/`warnings` schema for all share-link subcommands (`create`, `list`, `info`, `update`, `revoke`, `download`)
- Encode `share-link create`'s `existing` boolean as a status value (`"created"` vs `"existing"`) instead of a separate field
- Replace `share-link list`'s `entries` array with `results` array using per-entry `status`/`kind`
- Add shared helpers `shareLinkJSONOperationResult()` and `shareLinkJSONOperationResults()` for converting shared-link metadata into operation results
- Update README to document the normalized schema and add examples for `info`, `update`, `revoke`, `download`

## Test plan
- [x] `go test ./cmd/...` passes — all share-link JSON tests updated to verify the new operation output structure
- [x] `TestShareLinkCreateJSONReportsExistingAsStatus` covers the already-exists path
- [x] `assertNoTopLevelJSONField` verifies old `existing` and `entries` keys are absent
- [x] Verify `share-link revoke` kind falls back to `shared_link` when revoking by URL without metadata