### PR TITLE
Add version JSON output and share list folder structured output

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Text output is the default. JSON output is available through the global `--outpu
 
 ```sh
 $ dbxcli <command> --output=json
+$ dbxcli version --output=json
 $ dbxcli account --output=json
 $ dbxcli du --output=json
 $ dbxcli ls --output=json /
@@ -153,12 +154,13 @@ $ dbxcli share-link info --output=json https://www.dropbox.com/s/example/old.pdf
 $ dbxcli share-link update --output=json https://www.dropbox.com/s/example/old.pdf --expires 2026-07-01T00:00:00Z
 $ dbxcli share-link revoke --output=json https://www.dropbox.com/s/example/old.pdf
 $ dbxcli share-link download --output=json https://www.dropbox.com/s/example/old.pdf ./old.pdf
+$ dbxcli share list folder --output=json
 $ dbxcli mkdir --output=json /new-folder
 $ dbxcli rm --output=json /old-file.txt
 $ dbxcli restore --output=json /Reports/old.pdf 015f...
 ```
 
-Structured success output is rolling out command by command. Currently migrated commands are `account`, `du`, `ls`, `search`, `revs`, `cp`, `mv`, `put`, `get`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
+Structured success output is rolling out command by command. Currently migrated commands are `version`, `account`, `du`, `ls`, `search`, `revs`, `cp`, `mv`, `put`, `get`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `share list folder`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
 
 Command results and JSON errors are written to stdout. Status, progress, human-facing warnings, diagnostics, and verbose logs are written to stderr. JSON errors include a `warnings` array for machine-actionable warnings; it is `[]` when no warnings are present. Successful JSON payloads use the same `warnings` field.
 
@@ -308,7 +310,25 @@ Entry-list commands such as `ls`, `search`, and `revs` use the operation-style w
 }
 ```
 
-Account and usage commands use the operation-style wrapper with a single result:
+Version, account, and usage commands use the operation-style wrapper with a single result:
+
+```json
+{
+  "input": {},
+  "results": [
+    {
+      "kind": "version",
+      "input": {},
+      "result": {
+        "version": "3.4.0",
+        "sdk_version": "6.0.5",
+        "spec_version": "c36ba27"
+      }
+    }
+  ],
+  "warnings": []
+}
+```
 
 ```json
 {
@@ -376,6 +396,31 @@ Shared-link commands use the same operation-style wrapper. `share-link create`, 
 ```
 
 `share-link revoke` uses `revoked` results whose `result` contains the revoked URL and, when available, the shared-link metadata. `share-link download` uses `downloaded` results whose `result` contains the local `target` and `link` metadata.
+
+The legacy `share list folder` command also supports operation-style JSON. It uses `listed` results with `shared_folder` metadata:
+
+```json
+{
+  "input": {},
+  "results": [
+    {
+      "status": "listed",
+      "kind": "shared_folder",
+      "result": {
+        "type": "shared_folder",
+        "name": "Reports",
+        "path_lower": "/reports",
+        "shared_folder_id": "1234567890",
+        "preview_url": "https://www.dropbox.com/scl/fo/...",
+        "access_type": "owner",
+        "is_inside_team_folder": false,
+        "is_team_folder": false
+      }
+    }
+  ],
+  "warnings": []
+}
+```
 
 `get --output=json <source> -` and `share-link download --output=json <url> -` are not supported because stdout is reserved for downloaded file bytes when the target is `-`.
 

--- a/cmd/share-list-folders.go
+++ b/cmd/share-list-folders.go
@@ -16,40 +16,138 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
 	"github.com/spf13/cobra"
 )
 
+type sharedFolderClient interface {
+	ListFolders(*sharing.ListFoldersArgs) (*sharing.ListFoldersResult, error)
+	ListFoldersContinue(*sharing.ListFoldersContinueArg) (*sharing.ListFoldersResult, error)
+}
+
+type shareFolderListInput struct{}
+
+type shareFolderJSONMetadata struct {
+	Type                 string   `json:"type"`
+	Name                 string   `json:"name"`
+	PathLower            string   `json:"path_lower,omitempty"`
+	SharedFolderID       string   `json:"shared_folder_id"`
+	PreviewURL           string   `json:"preview_url,omitempty"`
+	AccessType           string   `json:"access_type,omitempty"`
+	IsInsideTeamFolder   bool     `json:"is_inside_team_folder"`
+	IsTeamFolder         bool     `json:"is_team_folder"`
+	OwnerDisplayNames    []string `json:"owner_display_names,omitempty"`
+	ParentSharedFolderID string   `json:"parent_shared_folder_id,omitempty"`
+	ParentFolderName     string   `json:"parent_folder_name,omitempty"`
+	TimeInvited          *string  `json:"time_invited,omitempty"`
+	AccessInheritance    string   `json:"access_inheritance,omitempty"`
+}
+
+const (
+	shareFolderJSONStatusListed = "listed"
+	shareFolderJSONKindFolder   = "shared_folder"
+)
+
+var newSharedFolderClient = func(cfg dropbox.Config) sharedFolderClient {
+	return sharing.New(cfg)
+}
+
 func shareListFolders(cmd *cobra.Command, args []string) (err error) {
 	arg := sharing.NewListFoldersArgs()
 
-	dbx := sharing.New(config)
-	res, err := dbx.ListFolders(arg)
+	dbx := newSharedFolderClient(config)
+	entries, err := listSharedFolders(dbx, arg)
 	if err != nil {
 		return
 	}
 
-	printFolders(res.Entries)
+	commandVerboseStatus(cmd, "Listed %d shared folders", len(entries))
+
+	return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderSharedFolders(w, entries)
+	}, newJSONOperationOutput(
+		shareFolderListInput{},
+		shareFolderJSONOperationResults(shareFolderJSONMetadataListFromDropbox(entries)),
+		nil,
+	))
+}
+
+func listSharedFolders(dbx sharedFolderClient, arg *sharing.ListFoldersArgs) ([]*sharing.SharedFolderMetadata, error) {
+	var entries []*sharing.SharedFolderMetadata
+	res, err := dbx.ListFolders(arg)
+	if err != nil {
+		return nil, err
+	}
+	entries = append(entries, res.Entries...)
 
 	for len(res.Cursor) > 0 {
 		continueArg := sharing.NewListFoldersContinueArg(res.Cursor)
 
 		res, err = dbx.ListFoldersContinue(continueArg)
 		if err != nil {
-			return
+			return nil, err
 		}
 
-		printFolders(res.Entries)
+		entries = append(entries, res.Entries...)
 	}
 
-	return
+	return entries, nil
 }
 
-func printFolders(entries []*sharing.SharedFolderMetadata) {
+func renderSharedFolders(out io.Writer, entries []*sharing.SharedFolderMetadata) error {
 	for _, f := range entries {
-		fmt.Printf("%v\t%v\n", f.PathLower, f.PreviewUrl)
+		if _, err := fmt.Fprintf(out, "%v\t%v\n", f.PathLower, f.PreviewUrl); err != nil {
+			return err
+		}
 	}
+
+	return nil
+}
+
+func shareFolderJSONMetadataListFromDropbox(entries []*sharing.SharedFolderMetadata) []shareFolderJSONMetadata {
+	result := make([]shareFolderJSONMetadata, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, shareFolderJSONMetadataFromDropbox(entry))
+	}
+	return result
+}
+
+func shareFolderJSONMetadataFromDropbox(entry *sharing.SharedFolderMetadata) shareFolderJSONMetadata {
+	if entry == nil {
+		return shareFolderJSONMetadata{Type: shareFolderJSONKindFolder}
+	}
+
+	result := shareFolderJSONMetadata{
+		Type:                 shareFolderJSONKindFolder,
+		Name:                 entry.Name,
+		PathLower:            entry.PathLower,
+		SharedFolderID:       entry.SharedFolderId,
+		PreviewURL:           entry.PreviewUrl,
+		IsInsideTeamFolder:   entry.IsInsideTeamFolder,
+		IsTeamFolder:         entry.IsTeamFolder,
+		OwnerDisplayNames:    entry.OwnerDisplayNames,
+		ParentSharedFolderID: entry.ParentSharedFolderId,
+		ParentFolderName:     entry.ParentFolderName,
+		TimeInvited:          jsonTime(entry.TimeInvited),
+	}
+	if entry.AccessType != nil {
+		result.AccessType = entry.AccessType.Tag
+	}
+	if entry.AccessInheritance != nil {
+		result.AccessInheritance = entry.AccessInheritance.Tag
+	}
+	return result
+}
+
+func shareFolderJSONOperationResults(entries []shareFolderJSONMetadata) []jsonOperationResult {
+	results := make([]jsonOperationResult, 0, len(entries))
+	for _, entry := range entries {
+		results = append(results, newJSONOperationResult(shareFolderJSONStatusListed, shareFolderJSONKindFolder, nil, entry))
+	}
+	return results
 }
 
 var shareListFoldersCmd = &cobra.Command{
@@ -60,4 +158,5 @@ var shareListFoldersCmd = &cobra.Command{
 
 func init() {
 	shareListCmd.AddCommand(shareListFoldersCmd)
+	enableStructuredOutput(shareListFoldersCmd)
 }

--- a/cmd/share_list_folders_test.go
+++ b/cmd/share_list_folders_test.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
+	"github.com/spf13/cobra"
+)
+
+type mockSharedFolderClient struct {
+	listFoldersFn         func(arg *sharing.ListFoldersArgs) (*sharing.ListFoldersResult, error)
+	listFoldersContinueFn func(arg *sharing.ListFoldersContinueArg) (*sharing.ListFoldersResult, error)
+}
+
+func (m *mockSharedFolderClient) ListFolders(arg *sharing.ListFoldersArgs) (*sharing.ListFoldersResult, error) {
+	if m.listFoldersFn != nil {
+		return m.listFoldersFn(arg)
+	}
+	return sharing.NewListFoldersResult(nil), nil
+}
+
+func (m *mockSharedFolderClient) ListFoldersContinue(arg *sharing.ListFoldersContinueArg) (*sharing.ListFoldersResult, error) {
+	if m.listFoldersContinueFn != nil {
+		return m.listFoldersContinueFn(arg)
+	}
+	return sharing.NewListFoldersResult(nil), nil
+}
+
+func TestShareListFoldersTextUsesCommandOutput(t *testing.T) {
+	stubSharedFolderClient(t, &mockSharedFolderClient{
+		listFoldersFn: func(arg *sharing.ListFoldersArgs) (*sharing.ListFoldersResult, error) {
+			return sharing.NewListFoldersResult([]*sharing.SharedFolderMetadata{
+				testSharedFolder("/docs", "https://example.com/docs"),
+			}), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+
+	if err := shareListFolders(cmd, nil); err != nil {
+		t.Fatalf("shareListFolders error: %v", err)
+	}
+
+	if got, want := stdout.String(), "/docs\thttps://example.com/docs\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestShareListFoldersJSONOutputsSharedFolders(t *testing.T) {
+	invited := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	stubSharedFolderClient(t, &mockSharedFolderClient{
+		listFoldersFn: func(arg *sharing.ListFoldersArgs) (*sharing.ListFoldersResult, error) {
+			folder := testSharedFolder("/docs", "https://example.com/docs")
+			folder.Name = "Docs"
+			folder.SharedFolderId = "sfid:docs"
+			folder.AccessType = &sharing.AccessLevel{Tagged: dropbox.Tagged{Tag: sharing.AccessLevelOwner}}
+			folder.IsInsideTeamFolder = true
+			folder.IsTeamFolder = true
+			folder.OwnerDisplayNames = []string{"Owner One"}
+			folder.ParentSharedFolderId = "sfid:parent"
+			folder.ParentFolderName = "Parent"
+			folder.TimeInvited = invited
+			folder.AccessInheritance = &sharing.AccessInheritance{Tagged: dropbox.Tagged{Tag: sharing.AccessInheritanceInherit}}
+			return sharing.NewListFoldersResult([]*sharing.SharedFolderMetadata{folder}), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	setShareLinkOutputJSON(t, cmd)
+
+	if err := shareListFolders(cmd, nil); err != nil {
+		t.Fatalf("shareListFolders error: %v", err)
+	}
+
+	got := decodeShareLinkOperationOutput[map[string]any, shareFolderJSONMetadata](t, stdout.Bytes())
+	if len(got.Input) != 0 {
+		t.Fatalf("input = %#v, want empty object", got.Input)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results length = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if result.Status != shareFolderJSONStatusListed || result.Kind != shareFolderJSONKindFolder {
+		t.Fatalf("result = %#v, want listed shared_folder", result)
+	}
+	folder := result.Result
+	if folder.Type != shareFolderJSONKindFolder || folder.Name != "Docs" || folder.PathLower != "/docs" {
+		t.Fatalf("folder = %#v, want docs shared folder metadata", folder)
+	}
+	if folder.SharedFolderID != "sfid:docs" || folder.PreviewURL != "https://example.com/docs" {
+		t.Fatalf("folder = %#v, want id and preview URL", folder)
+	}
+	if folder.AccessType != sharing.AccessLevelOwner || folder.AccessInheritance != sharing.AccessInheritanceInherit {
+		t.Fatalf("folder = %#v, want access tags", folder)
+	}
+	if !folder.IsInsideTeamFolder || !folder.IsTeamFolder {
+		t.Fatalf("folder = %#v, want team folder flags", folder)
+	}
+	if len(folder.OwnerDisplayNames) != 1 || folder.OwnerDisplayNames[0] != "Owner One" {
+		t.Fatalf("owners = %#v, want owner display name", folder.OwnerDisplayNames)
+	}
+	if folder.ParentSharedFolderID != "sfid:parent" || folder.ParentFolderName != "Parent" {
+		t.Fatalf("folder = %#v, want parent fields", folder)
+	}
+	if folder.TimeInvited == nil || *folder.TimeInvited != "2026-06-24T12:00:00Z" {
+		t.Fatalf("time_invited = %#v, want RFC3339 time", folder.TimeInvited)
+	}
+	if strings.Contains(stdout.String(), `"entries"`) {
+		t.Fatalf("JSON output = %s, want operation results and no entries key", stdout.String())
+	}
+}
+
+func TestShareListFoldersJSONPaginates(t *testing.T) {
+	continueCalled := false
+	stubSharedFolderClient(t, &mockSharedFolderClient{
+		listFoldersFn: func(arg *sharing.ListFoldersArgs) (*sharing.ListFoldersResult, error) {
+			result := sharing.NewListFoldersResult([]*sharing.SharedFolderMetadata{
+				testSharedFolder("/one", "https://example.com/one"),
+			})
+			result.Cursor = "cursor-1"
+			return result, nil
+		},
+		listFoldersContinueFn: func(arg *sharing.ListFoldersContinueArg) (*sharing.ListFoldersResult, error) {
+			continueCalled = true
+			if arg.Cursor != "cursor-1" {
+				t.Fatalf("continue cursor = %q, want cursor-1", arg.Cursor)
+			}
+			return sharing.NewListFoldersResult([]*sharing.SharedFolderMetadata{
+				testSharedFolder("/two", "https://example.com/two"),
+			}), nil
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	setShareLinkOutputJSON(t, cmd)
+
+	if err := shareListFolders(cmd, nil); err != nil {
+		t.Fatalf("shareListFolders error: %v", err)
+	}
+	if !continueCalled {
+		t.Fatal("ListFoldersContinue was not called")
+	}
+	got := decodeShareLinkOperationOutput[shareFolderListInput, shareFolderJSONMetadata](t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("results length = %d, want 2", len(got.Results))
+	}
+	if got.Results[0].Result.PathLower != "/one" || got.Results[1].Result.PathLower != "/two" {
+		t.Fatalf("results = %#v, want paginated shared folders", got.Results)
+	}
+}
+
+func TestShareListFoldersJSONErrorWritesNoSuccessOutput(t *testing.T) {
+	stubSharedFolderClient(t, &mockSharedFolderClient{
+		listFoldersFn: func(arg *sharing.ListFoldersArgs) (*sharing.ListFoldersResult, error) {
+			return nil, errors.New("list failed")
+		},
+	})
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	setShareLinkOutputJSON(t, cmd)
+
+	if err := shareListFolders(cmd, nil); err == nil {
+		t.Fatal("expected shareListFolders error")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty output on error", got)
+	}
+}
+
+func TestShareListFoldersCommandSupportsStructuredOutput(t *testing.T) {
+	if !commandSupportsStructuredOutput(shareListFoldersCmd) {
+		t.Fatal("share list folder command should support structured output")
+	}
+}
+
+func stubSharedFolderClient(t *testing.T, client sharedFolderClient) {
+	t.Helper()
+
+	orig := newSharedFolderClient
+	newSharedFolderClient = func(_ dropbox.Config) sharedFolderClient { return client }
+	t.Cleanup(func() { newSharedFolderClient = orig })
+}
+
+func testSharedFolder(pathLower, previewURL string) *sharing.SharedFolderMetadata {
+	return &sharing.SharedFolderMetadata{
+		SharedFolderMetadataBase: sharing.SharedFolderMetadataBase{
+			PathLower: pathLower,
+		},
+		Name:           strings.TrimPrefix(pathLower, "/"),
+		PreviewUrl:     previewURL,
+		SharedFolderId: "sfid:" + strings.TrimPrefix(pathLower, "/"),
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,79 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/spf13/cobra"
+)
+
+type versionInput struct{}
+
+type versionOutput struct {
+	Version     string `json:"version"`
+	SDKVersion  string `json:"sdk_version"`
+	SpecVersion string `json:"spec_version"`
+}
+
+const versionKindVersion = "version"
+
+var dropboxVersionFunc = dropbox.Version
+
+// NewVersionCommand creates the version command. The version value is supplied
+// by main so release builds can continue setting it with ldflags.
+func NewVersionCommand(version string) *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return versionCommand(cmd, version)
+		},
+	}
+	enableStructuredOutput(versionCmd)
+	return versionCmd
+}
+
+func versionCommand(cmd *cobra.Command, version string) error {
+	info := newVersionOutput(version)
+	return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderVersion(w, info)
+	}, newVersionOperationOutput(info))
+}
+
+func renderVersion(out io.Writer, info versionOutput) error {
+	fmt.Fprintln(out, "dbxcli version:", info.Version)
+	fmt.Fprintln(out, "SDK version:", info.SDKVersion)
+	fmt.Fprintln(out, "Spec version:", info.SpecVersion)
+	return nil
+}
+
+func newVersionOutput(version string) versionOutput {
+	sdkVersion, specVersion := dropboxVersionFunc()
+	return versionOutput{
+		Version:     version,
+		SDKVersion:  sdkVersion,
+		SpecVersion: specVersion,
+	}
+}
+
+func newVersionOperationOutput(info versionOutput) jsonOperationOutput {
+	input := versionInput{}
+	return newJSONOperationOutput(input, []jsonOperationResult{
+		newJSONOperationResult("", versionKindVersion, input, info),
+	}, nil)
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+type versionOperationOutputForTest struct {
+	Input    map[string]any                  `json:"input"`
+	Results  []versionOperationResultForTest `json:"results"`
+	Warnings []jsonWarning                   `json:"warnings"`
+}
+
+type versionOperationResultForTest struct {
+	Kind   string         `json:"kind"`
+	Input  map[string]any `json:"input"`
+	Result versionOutput  `json:"result"`
+}
+
+func TestVersionTextUsesCommandOutput(t *testing.T) {
+	cmd := NewVersionCommand("1.2.3")
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	stubDropboxVersion(t, "sdk-test", "spec-test")
+
+	if err := versionCommand(cmd, "1.2.3"); err != nil {
+		t.Fatalf("versionCommand returned error: %v", err)
+	}
+
+	want := "dbxcli version: 1.2.3\nSDK version: sdk-test\nSpec version: spec-test\n"
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestVersionJSONOutputsVersionInfo(t *testing.T) {
+	cmd := NewVersionCommand("1.2.3")
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.Flags().String(outputFlag, "json", "")
+	stubDropboxVersion(t, "sdk-test", "spec-test")
+
+	if err := versionCommand(cmd, "1.2.3"); err != nil {
+		t.Fatalf("versionCommand returned error: %v", err)
+	}
+
+	var got versionOperationOutputForTest
+	if err := json.NewDecoder(bytes.NewReader(stdout.Bytes())).Decode(&got); err != nil {
+		t.Fatalf("decode JSON output: %v\noutput: %s", err, stdout.String())
+	}
+	if got.Input == nil || len(got.Input) != 0 {
+		t.Fatalf("input = %#v, want empty object", got.Input)
+	}
+	if got.Warnings == nil || len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %#v, want empty array", got.Warnings)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results length = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if result.Kind != versionKindVersion {
+		t.Fatalf("kind = %q, want %q", result.Kind, versionKindVersion)
+	}
+	if result.Input == nil || len(result.Input) != 0 {
+		t.Fatalf("result input = %#v, want empty object", result.Input)
+	}
+	if result.Result.Version != "1.2.3" || result.Result.SDKVersion != "sdk-test" || result.Result.SpecVersion != "spec-test" {
+		t.Fatalf("result = %#v, want version info", result.Result)
+	}
+}
+
+func TestVersionCommandSupportsStructuredOutput(t *testing.T) {
+	if !commandSupportsStructuredOutput(NewVersionCommand("1.2.3")) {
+		t.Fatal("version command should support structured output")
+	}
+}
+
+func stubDropboxVersion(t *testing.T, sdkVersion, specVersion string) {
+	t.Helper()
+
+	previous := dropboxVersionFunc
+	dropboxVersionFunc = func() (string, string) {
+		return sdkVersion, specVersion
+	}
+	t.Cleanup(func() {
+		dropboxVersionFunc = previous
+	})
+}

--- a/main.go
+++ b/main.go
@@ -15,32 +15,17 @@
 package main
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/dropbox/dbxcli/cmd"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
-	"github.com/spf13/cobra"
 )
 
 var version = "0.1.0"
 
-// versionCmd represents the version command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print version information",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("dbxcli version:", version)
-		sdkVersion, specVersion := dropbox.Version()
-		fmt.Println("SDK version:", sdkVersion)
-		fmt.Println("Spec version:", specVersion)
-	},
-}
-
 func init() {
 	// Log date, time and file information by default
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
-	cmd.RootCmd.AddCommand(versionCmd)
+	cmd.RootCmd.AddCommand(cmd.NewVersionCommand(version))
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- Move `version` command from `main.go` into `cmd/version.go` with JSON output support and testability via `dropboxVersionFunc` variable
- Add structured JSON output to the legacy `share list folder` command with full pagination, `sharedFolderClient` interface for testability, and complete shared folder metadata mapping
- Update README with examples and schema documentation for both commands

## Test plan
- [x] `go test ./cmd/...` passes — new tests for version text/JSON output, share list folder text/JSON/pagination/error paths
- [x] `golangci-lint run ./...` passes
- [x] `dbxcli version --output=json` outputs `{input, results, warnings}` with version info
- [x] `dbxcli share list folder --output=json` outputs operation results with shared folder metadata