### PR TITLE
Add JSON output to team commands with pagination support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,17 @@ $ dbxcli share-link update --output=json https://www.dropbox.com/s/example/old.p
 $ dbxcli share-link revoke --output=json https://www.dropbox.com/s/example/old.pdf
 $ dbxcli share-link download --output=json https://www.dropbox.com/s/example/old.pdf ./old.pdf
 $ dbxcli share list folder --output=json
+$ dbxcli team info --output=json
+$ dbxcli team list-members --output=json
+$ dbxcli team list-groups --output=json
+$ dbxcli team add-member --output=json user@example.com User Name
+$ dbxcli team remove-member --output=json user@example.com
 $ dbxcli mkdir --output=json /new-folder
 $ dbxcli rm --output=json /old-file.txt
 $ dbxcli restore --output=json /Reports/old.pdf 015f...
 ```
 
-Structured success output is rolling out command by command. Currently migrated commands are `version`, `account`, `du`, `ls`, `search`, `revs`, `cp`, `mv`, `put`, `get`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `share list folder`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
+Structured success output is rolling out command by command. Currently migrated commands are `version`, `account`, `du`, `ls`, `search`, `revs`, `cp`, `mv`, `put`, `get`, `share-link create`, `share-link list`, `share-link info`, `share-link update`, `share-link revoke`, `share-link download`, `share list folder`, `team info`, `team list-members`, `team list-groups`, `team add-member`, `team remove-member`, `mkdir`, `rm`, and `restore`. Commands that have not been migrated return a JSON error whose `error.message` is `structured output is not supported for this command yet` when used with `--output=json`.
 
 Command results and JSON errors are written to stdout. Status, progress, human-facing warnings, diagnostics, and verbose logs are written to stderr. JSON errors include a `warnings` array for machine-actionable warnings; it is `[]` when no warnings are present. Successful JSON payloads use the same `warnings` field.
 
@@ -415,6 +420,29 @@ The legacy `share list folder` command also supports operation-style JSON. It us
         "access_type": "owner",
         "is_inside_team_folder": false,
         "is_team_folder": false
+      }
+    }
+  ],
+  "warnings": []
+}
+```
+
+Team commands use the same operation-style wrapper. `team info` returns a single `team` result, `team list-members` and `team list-groups` return `listed` results, and mutating member commands return the Dropbox launch status:
+
+```json
+{
+  "input": {},
+  "results": [
+    {
+      "status": "listed",
+      "kind": "team_member",
+      "result": {
+        "type": "team_member",
+        "team_member_id": "dbmid:...",
+        "email": "user@example.com",
+        "email_verified": true,
+        "status": "active",
+        "role": "member_only"
       }
     }
   ],

--- a/cmd/add-member.go
+++ b/cmd/add-member.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team"
 	"github.com/spf13/cobra"
@@ -26,7 +27,7 @@ func addMember(cmd *cobra.Command, args []string) (err error) {
 	if len(args) != 3 {
 		return errors.New("`add-member` requires `email`, `first`, and `last` arguments")
 	}
-	dbx := team.New(config)
+	dbx := teamNewFunc(config)
 
 	email := args[0]
 	firstName := args[1]
@@ -39,10 +40,22 @@ func addMember(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	if res.Tag == "complete" {
-		fmt.Printf("User successfully added to the team.\n")
+	input := teamMemberAddInput{
+		Email:     email,
+		FirstName: firstName,
+		LastName:  lastName,
 	}
-	return
+	return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderTeamMemberAdd(w, res)
+	}, teamMemberAddOperationOutput(input, res))
+}
+
+func renderTeamMemberAdd(out io.Writer, res *team.MembersAddLaunch) error {
+	if res != nil && res.Tag == "complete" {
+		_, err := fmt.Fprintln(out, "User successfully added to the team.")
+		return err
+	}
+	return nil
 }
 
 // addMemberCmd represents the add-member command
@@ -54,4 +67,5 @@ var addMemberCmd = &cobra.Command{
 
 func init() {
 	teamCmd.AddCommand(addMemberCmd)
+	enableStructuredOutput(addMemberCmd)
 }

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -16,7 +16,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team"
@@ -24,14 +24,20 @@ import (
 )
 
 func info(cmd *cobra.Command, args []string) (err error) {
-	dbx := team.New(config)
+	dbx := teamNewFunc(config)
 	res, err := dbx.GetInfo()
 	if err != nil {
 		return err
 	}
 
+	return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderTeamInfo(w, res)
+	}, teamInfoOperationOutput(res))
+}
+
+func renderTeamInfo(out io.Writer, res *team.TeamGetInfoResult) error {
 	w := new(tabwriter.Writer)
-	w.Init(os.Stdout, 4, 8, 1, ' ', 0)
+	w.Init(out, 4, 8, 1, ' ', 0)
 	fmt.Fprintf(w, "Name:\t%s\n", res.Name)
 	fmt.Fprintf(w, "Team Id:\t%s\n", res.TeamId)
 	fmt.Fprintf(w, "Licensed Users:\t%d\n", res.NumLicensedUsers)
@@ -48,4 +54,5 @@ var infoCmd = &cobra.Command{
 
 func init() {
 	teamCmd.AddCommand(infoCmd)
+	enableStructuredOutput(infoCmd)
 }

--- a/cmd/list-groups.go
+++ b/cmd/list-groups.go
@@ -15,30 +15,61 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team_common"
 	"github.com/spf13/cobra"
 )
 
 func listGroups(cmd *cobra.Command, args []string) (err error) {
-	dbx := team.New(config)
+	dbx := teamNewFunc(config)
 	arg := team.NewGroupsListArg()
-	res, err := dbx.GroupsList(arg)
+	groups, err := listTeamGroups(dbx, arg)
 	if err != nil {
 		return err
 	}
 
-	if len(res.Groups) == 0 {
-		return
+	commandVerboseStatus(cmd, "Listed %d team groups", len(groups))
+
+	return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderTeamGroups(w, groups)
+	}, newJSONOperationOutput(teamInfoInput{}, teamGroupOperationResults(groups), nil))
+}
+
+func listTeamGroups(dbx teamClient, arg *team.GroupsListArg) ([]*team_common.GroupSummary, error) {
+	var groups []*team_common.GroupSummary
+	res, err := dbx.GroupsList(arg)
+	if err != nil {
+		return nil, err
+	}
+	groups = append(groups, res.Groups...)
+
+	for res.HasMore {
+		if res.Cursor == "" {
+			return nil, errors.New("team group list has more results but no cursor")
+		}
+		res, err = dbx.GroupsListContinue(team.NewGroupsListContinueArg(res.Cursor))
+		if err != nil {
+			return nil, err
+		}
+		groups = append(groups, res.Groups...)
+	}
+	return groups, nil
+}
+
+func renderTeamGroups(out io.Writer, groups []*team_common.GroupSummary) error {
+	if len(groups) == 0 {
+		return nil
 	}
 
 	w := new(tabwriter.Writer)
-	w.Init(os.Stdout, 4, 8, 1, ' ', 0)
+	w.Init(out, 4, 8, 1, ' ', 0)
 	fmt.Fprintf(w, "Name\tId\t# Members\tExternal Id\n")
-	for _, group := range res.Groups {
+	for _, group := range groups {
 		fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", group.GroupName, group.GroupId, group.MemberCount, group.GroupExternalId)
 	}
 	return w.Flush()
@@ -53,4 +84,5 @@ var listGroupsCmd = &cobra.Command{
 
 func init() {
 	teamCmd.AddCommand(listGroupsCmd)
+	enableStructuredOutput(listGroupsCmd)
 }

--- a/cmd/list-members.go
+++ b/cmd/list-members.go
@@ -15,8 +15,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team"
@@ -24,22 +25,51 @@ import (
 )
 
 func listMembers(cmd *cobra.Command, args []string) (err error) {
-	dbx := team.New(config)
+	dbx := teamNewFunc(config)
 	arg := team.NewMembersListArg()
-	res, err := dbx.MembersList(arg)
+	members, err := listTeamMembers(dbx, arg)
 	if err != nil {
 		return err
 	}
 
-	if len(res.Members) == 0 {
-		return
+	commandVerboseStatus(cmd, "Listed %d team members", len(members))
+
+	return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderTeamMembers(w, members)
+	}, newJSONOperationOutput(teamInfoInput{}, teamMemberOperationResults(members), nil))
+}
+
+func listTeamMembers(dbx teamClient, arg *team.MembersListArg) ([]*team.TeamMemberInfo, error) {
+	var members []*team.TeamMemberInfo
+	res, err := dbx.MembersList(arg)
+	if err != nil {
+		return nil, err
+	}
+	members = append(members, res.Members...)
+
+	for res.HasMore {
+		if res.Cursor == "" {
+			return nil, errors.New("team member list has more results but no cursor")
+		}
+		res, err = dbx.MembersListContinue(team.NewMembersListContinueArg(res.Cursor))
+		if err != nil {
+			return nil, err
+		}
+		members = append(members, res.Members...)
+	}
+	return members, nil
+}
+
+func renderTeamMembers(out io.Writer, members []*team.TeamMemberInfo) error {
+	if len(members) == 0 {
+		return nil
 	}
 
 	w := new(tabwriter.Writer)
-	w.Init(os.Stdout, 4, 8, 1, ' ', 0)
+	w.Init(out, 4, 8, 1, ' ', 0)
 	fmtStr := "%s\t%s\t%s\t%s\t%s\n"
 	fmt.Fprintf(w, fmtStr, "Name", "Id", "Status", "Email", "Role")
-	for _, member := range res.Members {
+	for _, member := range members {
 		fmt.Fprintf(w, fmtStr,
 			member.Profile.Name.DisplayName,
 			member.Profile.TeamMemberId,
@@ -59,4 +89,5 @@ var listMembersCmd = &cobra.Command{
 
 func init() {
 	teamCmd.AddCommand(listMembersCmd)
+	enableStructuredOutput(listMembersCmd)
 }

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -180,7 +180,7 @@ func jsonErrorCode(err error) string {
 		return "unknown_flag"
 	case strings.Contains(message, "path exists and is not a folder"):
 		return "path_conflict"
-	case strings.Contains(message, "requires a"):
+	case strings.Contains(message, "requires "):
 		return "invalid_arguments"
 	case strings.Contains(message, "accepts an optional"):
 		return "invalid_arguments"

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -608,6 +608,13 @@ func TestJSONErrorCodeOptionalArgumentValidation(t *testing.T) {
 	}
 }
 
+func TestJSONErrorCodeRequiredArgumentValidation(t *testing.T) {
+	err := errors.New("`add-member` requires `email`, `first`, and `last` arguments")
+	if got, want := jsonErrorCode(err), "invalid_arguments"; got != want {
+		t.Fatalf("jsonErrorCode = %q, want %q", got, want)
+	}
+}
+
 func decodeJSONErrorResponse(t *testing.T, value string) jsonErrorResponse {
 	t.Helper()
 

--- a/cmd/remove-member.go
+++ b/cmd/remove-member.go
@@ -17,7 +17,9 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/async"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +29,7 @@ func removeMember(cmd *cobra.Command, args []string) (err error) {
 		return errors.New("`remove-member` requires an `email` argument")
 	}
 
-	dbx := team.New(config)
+	dbx := teamNewFunc(config)
 	email := args[0]
 	selector := &team.UserSelectorArg{Email: email}
 	selector.Tag = "email"
@@ -36,10 +38,18 @@ func removeMember(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	if res.Tag == "complete" {
-		fmt.Printf("User successfully removed from team.\n")
+	input := teamMemberRemoveInput{Email: email}
+	return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderTeamMemberRemove(w, res)
+	}, teamMemberRemoveOperationOutput(input, res))
+}
+
+func renderTeamMemberRemove(out io.Writer, res *async.LaunchEmptyResult) error {
+	if res != nil && res.Tag == "complete" {
+		_, err := fmt.Fprintln(out, "User successfully removed from team.")
+		return err
 	}
-	return
+	return nil
 }
 
 // removeMemberCmd represents the remove-member command
@@ -51,4 +61,5 @@ var removeMemberCmd = &cobra.Command{
 
 func init() {
 	teamCmd.AddCommand(removeMemberCmd)
+	enableStructuredOutput(removeMemberCmd)
 }

--- a/cmd/team_json.go
+++ b/cmd/team_json.go
@@ -1,0 +1,307 @@
+// Copyright © 2016 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/async"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team_common"
+)
+
+type teamClient interface {
+	GetInfo() (*team.TeamGetInfoResult, error)
+	GroupsList(*team.GroupsListArg) (*team.GroupsListResult, error)
+	GroupsListContinue(*team.GroupsListContinueArg) (*team.GroupsListResult, error)
+	MembersAdd(*team.MembersAddArg) (*team.MembersAddLaunch, error)
+	MembersList(*team.MembersListArg) (*team.MembersListResult, error)
+	MembersListContinue(*team.MembersListContinueArg) (*team.MembersListResult, error)
+	MembersRemove(*team.MembersRemoveArg) (*async.LaunchEmptyResult, error)
+}
+
+type teamInfoInput struct{}
+
+type teamInfoJSON struct {
+	Type                string `json:"type"`
+	Name                string `json:"name"`
+	TeamID              string `json:"team_id"`
+	NumLicensedUsers    uint32 `json:"num_licensed_users"`
+	NumProvisionedUsers uint32 `json:"num_provisioned_users"`
+}
+
+type teamMemberJSON struct {
+	Type                  string           `json:"type"`
+	TeamMemberID          string           `json:"team_member_id"`
+	ExternalID            string           `json:"external_id,omitempty"`
+	AccountID             string           `json:"account_id,omitempty"`
+	Email                 string           `json:"email"`
+	EmailVerified         bool             `json:"email_verified"`
+	Status                string           `json:"status,omitempty"`
+	Name                  *jsonAccountName `json:"name,omitempty"`
+	Role                  string           `json:"role,omitempty"`
+	Groups                []string         `json:"groups,omitempty"`
+	MemberFolderID        string           `json:"member_folder_id,omitempty"`
+	MembershipType        string           `json:"membership_type,omitempty"`
+	InvitedOn             *string          `json:"invited_on,omitempty"`
+	JoinedOn              *string          `json:"joined_on,omitempty"`
+	SuspendedOn           *string          `json:"suspended_on,omitempty"`
+	PersistentID          string           `json:"persistent_id,omitempty"`
+	IsDirectoryRestricted bool             `json:"is_directory_restricted,omitempty"`
+	ProfilePhotoURL       string           `json:"profile_photo_url,omitempty"`
+}
+
+type teamGroupJSON struct {
+	Type                string `json:"type"`
+	GroupName           string `json:"group_name"`
+	GroupID             string `json:"group_id"`
+	GroupExternalID     string `json:"group_external_id,omitempty"`
+	MemberCount         uint32 `json:"member_count,omitempty"`
+	GroupManagementType string `json:"group_management_type,omitempty"`
+}
+
+type teamMemberAddInput struct {
+	Email     string `json:"email"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+}
+
+type teamMemberRemoveInput struct {
+	Email string `json:"email"`
+}
+
+type teamMemberMutationJSON struct {
+	Type       string                  `json:"type"`
+	Tag        string                  `json:"tag"`
+	AsyncJobID string                  `json:"async_job_id,omitempty"`
+	Results    []teamMemberAddItemJSON `json:"results,omitempty"`
+}
+
+type teamMemberAddItemJSON struct {
+	Tag    string          `json:"tag"`
+	Email  string          `json:"email,omitempty"`
+	Member *teamMemberJSON `json:"member,omitempty"`
+}
+
+const (
+	teamJSONKindTeam         = "team"
+	teamJSONKindTeamGroup    = "team_group"
+	teamJSONKindTeamMember   = "team_member"
+	teamJSONStatusAdded      = "added"
+	teamJSONStatusCompleted  = "completed"
+	teamJSONStatusListed     = "listed"
+	teamJSONStatusFound      = "found"
+	teamJSONStatusRemoved    = "removed"
+	teamJSONStatusStarted    = "started"
+	teamJSONTypeMemberAdd    = "team_member_add"
+	teamJSONTypeMemberRemove = "team_member_remove"
+)
+
+var teamNewFunc = func(cfg dropbox.Config) teamClient {
+	return team.New(cfg)
+}
+
+func teamInfoOperationOutput(info *team.TeamGetInfoResult) jsonOperationOutput {
+	input := teamInfoInput{}
+	return newJSONOperationOutput(input, []jsonOperationResult{
+		newJSONOperationResult(teamJSONStatusFound, teamJSONKindTeam, input, teamInfoJSONFromDropbox(info)),
+	}, nil)
+}
+
+func teamMemberOperationResults(members []*team.TeamMemberInfo) []jsonOperationResult {
+	results := make([]jsonOperationResult, 0, len(members))
+	for _, member := range members {
+		results = append(results, newJSONOperationResult(teamJSONStatusListed, teamJSONKindTeamMember, nil, teamMemberJSONFromDropbox(member)))
+	}
+	return results
+}
+
+func teamGroupOperationResults(groups []*team_common.GroupSummary) []jsonOperationResult {
+	results := make([]jsonOperationResult, 0, len(groups))
+	for _, group := range groups {
+		results = append(results, newJSONOperationResult(teamJSONStatusListed, teamJSONKindTeamGroup, nil, teamGroupJSONFromDropbox(group)))
+	}
+	return results
+}
+
+func teamMemberAddOperationOutput(input teamMemberAddInput, res *team.MembersAddLaunch) jsonOperationOutput {
+	return newJSONOperationOutput(input, []jsonOperationResult{
+		newJSONOperationResult(teamMemberAddStatus(res), teamJSONKindTeamMember, input, teamMemberAddJSONFromDropbox(res)),
+	}, nil)
+}
+
+func teamMemberRemoveOperationOutput(input teamMemberRemoveInput, res *async.LaunchEmptyResult) jsonOperationOutput {
+	return newJSONOperationOutput(input, []jsonOperationResult{
+		newJSONOperationResult(teamMemberRemoveStatus(res), teamJSONKindTeamMember, input, teamMemberRemoveJSONFromDropbox(res)),
+	}, nil)
+}
+
+func teamInfoJSONFromDropbox(info *team.TeamGetInfoResult) teamInfoJSON {
+	if info == nil {
+		return teamInfoJSON{Type: teamJSONKindTeam}
+	}
+	return teamInfoJSON{
+		Type:                teamJSONKindTeam,
+		Name:                info.Name,
+		TeamID:              info.TeamId,
+		NumLicensedUsers:    info.NumLicensedUsers,
+		NumProvisionedUsers: info.NumProvisionedUsers,
+	}
+}
+
+func teamMemberJSONFromDropbox(member *team.TeamMemberInfo) teamMemberJSON {
+	result := teamMemberJSON{Type: teamJSONKindTeamMember}
+	if member == nil {
+		return result
+	}
+	if member.Role != nil {
+		result.Role = member.Role.Tag
+	}
+	profile := member.Profile
+	if profile == nil {
+		return result
+	}
+	result.TeamMemberID = profile.TeamMemberId
+	result.ExternalID = profile.ExternalId
+	result.AccountID = profile.AccountId
+	result.Email = profile.Email
+	result.EmailVerified = profile.EmailVerified
+	if profile.Status != nil {
+		result.Status = profile.Status.Tag
+	}
+	result.Name = jsonAccountNameFromDropbox(profile.Name)
+	result.Groups = profile.Groups
+	result.MemberFolderID = profile.MemberFolderId
+	if profile.MembershipType != nil {
+		result.MembershipType = profile.MembershipType.Tag
+	}
+	result.InvitedOn = jsonTimePtr(profile.InvitedOn)
+	result.JoinedOn = jsonTimePtr(profile.JoinedOn)
+	result.SuspendedOn = jsonTimePtr(profile.SuspendedOn)
+	result.PersistentID = profile.PersistentId
+	result.IsDirectoryRestricted = profile.IsDirectoryRestricted
+	result.ProfilePhotoURL = profile.ProfilePhotoUrl
+	return result
+}
+
+func teamGroupJSONFromDropbox(group *team_common.GroupSummary) teamGroupJSON {
+	if group == nil {
+		return teamGroupJSON{Type: teamJSONKindTeamGroup}
+	}
+	result := teamGroupJSON{
+		Type:            teamJSONKindTeamGroup,
+		GroupName:       group.GroupName,
+		GroupID:         group.GroupId,
+		GroupExternalID: group.GroupExternalId,
+		MemberCount:     group.MemberCount,
+	}
+	if group.GroupManagementType != nil {
+		result.GroupManagementType = group.GroupManagementType.Tag
+	}
+	return result
+}
+
+func teamMemberAddJSONFromDropbox(res *team.MembersAddLaunch) teamMemberMutationJSON {
+	result := teamMemberMutationJSON{Type: teamJSONTypeMemberAdd}
+	if res == nil {
+		return result
+	}
+	result.Tag = res.Tag
+	result.AsyncJobID = res.AsyncJobId
+	result.Results = make([]teamMemberAddItemJSON, 0, len(res.Complete))
+	for _, item := range res.Complete {
+		result.Results = append(result.Results, teamMemberAddItemJSONFromDropbox(item))
+	}
+	return result
+}
+
+func teamMemberAddItemJSONFromDropbox(item *team.MemberAddResult) teamMemberAddItemJSON {
+	if item == nil {
+		return teamMemberAddItemJSON{}
+	}
+	result := teamMemberAddItemJSON{
+		Tag:   item.Tag,
+		Email: teamMemberAddResultEmail(item),
+	}
+	if item.Success != nil {
+		member := teamMemberJSONFromDropbox(item.Success)
+		result.Member = &member
+		if item.Success.Profile != nil {
+			result.Email = item.Success.Profile.Email
+		}
+	}
+	return result
+}
+
+func teamMemberAddResultEmail(item *team.MemberAddResult) string {
+	switch item.Tag {
+	case "team_license_limit":
+		return item.TeamLicenseLimit
+	case "free_team_member_limit_reached":
+		return item.FreeTeamMemberLimitReached
+	case "user_already_on_team":
+		return item.UserAlreadyOnTeam
+	case "user_on_another_team":
+		return item.UserOnAnotherTeam
+	case "user_already_paired":
+		return item.UserAlreadyPaired
+	case "user_migration_failed":
+		return item.UserMigrationFailed
+	case "duplicate_external_member_id":
+		return item.DuplicateExternalMemberId
+	case "duplicate_member_persistent_id":
+		return item.DuplicateMemberPersistentId
+	case "persistent_id_disabled":
+		return item.PersistentIdDisabled
+	case "user_creation_failed":
+		return item.UserCreationFailed
+	default:
+		return ""
+	}
+}
+
+func teamMemberRemoveJSONFromDropbox(res *async.LaunchEmptyResult) teamMemberMutationJSON {
+	result := teamMemberMutationJSON{Type: teamJSONTypeMemberRemove}
+	if res == nil {
+		return result
+	}
+	result.Tag = res.Tag
+	result.AsyncJobID = res.AsyncJobId
+	return result
+}
+
+func teamMemberAddStatus(res *team.MembersAddLaunch) string {
+	if res == nil {
+		return teamJSONStatusCompleted
+	}
+	if res.Tag != "complete" {
+		return teamJSONStatusStarted
+	}
+	for _, item := range res.Complete {
+		if item != nil && item.Tag != "success" {
+			return teamJSONStatusCompleted
+		}
+	}
+	return teamJSONStatusAdded
+}
+
+func teamMemberRemoveStatus(res *async.LaunchEmptyResult) string {
+	if res == nil {
+		return teamJSONStatusCompleted
+	}
+	if res.Tag == "complete" {
+		return teamJSONStatusRemoved
+	}
+	return teamJSONStatusStarted
+}

--- a/cmd/team_json_test.go
+++ b/cmd/team_json_test.go
@@ -1,0 +1,392 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/async"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team_common"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
+	"github.com/spf13/cobra"
+)
+
+type mockTeamClient struct {
+	getInfoFn             func() (*team.TeamGetInfoResult, error)
+	groupsListFn          func(arg *team.GroupsListArg) (*team.GroupsListResult, error)
+	groupsListContinueFn  func(arg *team.GroupsListContinueArg) (*team.GroupsListResult, error)
+	membersAddFn          func(arg *team.MembersAddArg) (*team.MembersAddLaunch, error)
+	membersListFn         func(arg *team.MembersListArg) (*team.MembersListResult, error)
+	membersListContinueFn func(arg *team.MembersListContinueArg) (*team.MembersListResult, error)
+	membersRemoveFn       func(arg *team.MembersRemoveArg) (*async.LaunchEmptyResult, error)
+}
+
+func (m *mockTeamClient) GetInfo() (*team.TeamGetInfoResult, error) {
+	if m.getInfoFn != nil {
+		return m.getInfoFn()
+	}
+	return nil, nil
+}
+
+func (m *mockTeamClient) GroupsList(arg *team.GroupsListArg) (*team.GroupsListResult, error) {
+	if m.groupsListFn != nil {
+		return m.groupsListFn(arg)
+	}
+	return team.NewGroupsListResult(nil, "", false), nil
+}
+
+func (m *mockTeamClient) GroupsListContinue(arg *team.GroupsListContinueArg) (*team.GroupsListResult, error) {
+	if m.groupsListContinueFn != nil {
+		return m.groupsListContinueFn(arg)
+	}
+	return team.NewGroupsListResult(nil, "", false), nil
+}
+
+func (m *mockTeamClient) MembersAdd(arg *team.MembersAddArg) (*team.MembersAddLaunch, error) {
+	if m.membersAddFn != nil {
+		return m.membersAddFn(arg)
+	}
+	return nil, nil
+}
+
+func (m *mockTeamClient) MembersList(arg *team.MembersListArg) (*team.MembersListResult, error) {
+	if m.membersListFn != nil {
+		return m.membersListFn(arg)
+	}
+	return team.NewMembersListResult(nil, "", false), nil
+}
+
+func (m *mockTeamClient) MembersListContinue(arg *team.MembersListContinueArg) (*team.MembersListResult, error) {
+	if m.membersListContinueFn != nil {
+		return m.membersListContinueFn(arg)
+	}
+	return team.NewMembersListResult(nil, "", false), nil
+}
+
+func (m *mockTeamClient) MembersRemove(arg *team.MembersRemoveArg) (*async.LaunchEmptyResult, error) {
+	if m.membersRemoveFn != nil {
+		return m.membersRemoveFn(arg)
+	}
+	return nil, nil
+}
+
+type teamOperationOutputForTest[I, R any] struct {
+	Input    I                                  `json:"input"`
+	Results  []teamOperationResultForTest[I, R] `json:"results"`
+	Warnings []jsonWarning                      `json:"warnings"`
+}
+
+type teamOperationResultForTest[I, R any] struct {
+	Status string `json:"status"`
+	Kind   string `json:"kind"`
+	Input  I      `json:"input"`
+	Result R      `json:"result"`
+}
+
+func TestTeamInfoJSONOutputsTeamInfo(t *testing.T) {
+	stubTeamClient(t, &mockTeamClient{
+		getInfoFn: func() (*team.TeamGetInfoResult, error) {
+			return &team.TeamGetInfoResult{
+				Name:                "Example Team",
+				TeamId:              "tid:team",
+				NumLicensedUsers:    10,
+				NumProvisionedUsers: 7,
+			}, nil
+		},
+	})
+
+	cmd, stdout := teamTestCmd(t, true)
+	if err := info(cmd, nil); err != nil {
+		t.Fatalf("info error: %v", err)
+	}
+
+	got := decodeTeamOperationOutput[map[string]any, teamInfoJSON](t, stdout.Bytes())
+	if len(got.Input) != 0 {
+		t.Fatalf("input = %#v, want empty object", got.Input)
+	}
+	result := onlyTeamResult(t, got)
+	if result.Status != teamJSONStatusFound || result.Kind != teamJSONKindTeam {
+		t.Fatalf("operation result = %#v, want found team", result)
+	}
+	if result.Result.Name != "Example Team" || result.Result.TeamID != "tid:team" || result.Result.NumLicensedUsers != 10 || result.Result.NumProvisionedUsers != 7 {
+		t.Fatalf("result = %#v, want team info", result.Result)
+	}
+}
+
+func TestTeamInfoTextUsesCommandOutput(t *testing.T) {
+	stubTeamClient(t, &mockTeamClient{
+		getInfoFn: func() (*team.TeamGetInfoResult, error) {
+			return &team.TeamGetInfoResult{Name: "Example Team", TeamId: "tid:team", NumLicensedUsers: 10, NumProvisionedUsers: 7}, nil
+		},
+	})
+
+	cmd, stdout := teamTestCmd(t, false)
+	if err := info(cmd, nil); err != nil {
+		t.Fatalf("info error: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Name:") || !strings.Contains(got, "Example Team") {
+		t.Fatalf("stdout = %q, want team info text", got)
+	}
+}
+
+func TestTeamListMembersJSONPaginates(t *testing.T) {
+	continueCalled := false
+	stubTeamClient(t, &mockTeamClient{
+		membersListFn: func(arg *team.MembersListArg) (*team.MembersListResult, error) {
+			return team.NewMembersListResult([]*team.TeamMemberInfo{
+				testTeamMember("dbmid:one", "one@example.com", "One User"),
+			}, "member-cursor", true), nil
+		},
+		membersListContinueFn: func(arg *team.MembersListContinueArg) (*team.MembersListResult, error) {
+			continueCalled = true
+			if arg.Cursor != "member-cursor" {
+				t.Fatalf("continue cursor = %q, want member-cursor", arg.Cursor)
+			}
+			return team.NewMembersListResult([]*team.TeamMemberInfo{
+				testTeamMember("dbmid:two", "two@example.com", "Two User"),
+			}, "", false), nil
+		},
+	})
+
+	cmd, stdout := teamTestCmd(t, true)
+	if err := listMembers(cmd, nil); err != nil {
+		t.Fatalf("listMembers error: %v", err)
+	}
+	if !continueCalled {
+		t.Fatal("MembersListContinue was not called")
+	}
+	got := decodeTeamOperationOutput[map[string]any, teamMemberJSON](t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("results length = %d, want 2", len(got.Results))
+	}
+	first := got.Results[0]
+	if first.Status != teamJSONStatusListed || first.Kind != teamJSONKindTeamMember {
+		t.Fatalf("first result = %#v, want listed team_member", first)
+	}
+	if first.Result.Email != "one@example.com" || first.Result.TeamMemberID != "dbmid:one" || first.Result.Name.DisplayName != "One User" {
+		t.Fatalf("first result = %#v, want first member", first.Result)
+	}
+	if got.Results[1].Result.Email != "two@example.com" {
+		t.Fatalf("second result = %#v, want second member", got.Results[1].Result)
+	}
+}
+
+func TestTeamListGroupsJSONPaginates(t *testing.T) {
+	continueCalled := false
+	stubTeamClient(t, &mockTeamClient{
+		groupsListFn: func(arg *team.GroupsListArg) (*team.GroupsListResult, error) {
+			return team.NewGroupsListResult([]*team_common.GroupSummary{
+				testTeamGroup("Engineering", "gid:eng", 3),
+			}, "group-cursor", true), nil
+		},
+		groupsListContinueFn: func(arg *team.GroupsListContinueArg) (*team.GroupsListResult, error) {
+			continueCalled = true
+			if arg.Cursor != "group-cursor" {
+				t.Fatalf("continue cursor = %q, want group-cursor", arg.Cursor)
+			}
+			return team.NewGroupsListResult([]*team_common.GroupSummary{
+				testTeamGroup("Support", "gid:support", 2),
+			}, "", false), nil
+		},
+	})
+
+	cmd, stdout := teamTestCmd(t, true)
+	if err := listGroups(cmd, nil); err != nil {
+		t.Fatalf("listGroups error: %v", err)
+	}
+	if !continueCalled {
+		t.Fatal("GroupsListContinue was not called")
+	}
+	got := decodeTeamOperationOutput[map[string]any, teamGroupJSON](t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("results length = %d, want 2", len(got.Results))
+	}
+	if got.Results[0].Status != teamJSONStatusListed || got.Results[0].Kind != teamJSONKindTeamGroup {
+		t.Fatalf("first result = %#v, want listed team_group", got.Results[0])
+	}
+	if got.Results[0].Result.GroupName != "Engineering" || got.Results[0].Result.MemberCount != 3 {
+		t.Fatalf("first result = %#v, want engineering group", got.Results[0].Result)
+	}
+	if got.Results[1].Result.GroupName != "Support" {
+		t.Fatalf("second result = %#v, want support group", got.Results[1].Result)
+	}
+}
+
+func TestTeamAddMemberJSONOutputsMutationResult(t *testing.T) {
+	var gotArg *team.MembersAddArg
+	member := testTeamMember("dbmid:new", "new@example.com", "New User")
+	stubTeamClient(t, &mockTeamClient{
+		membersAddFn: func(arg *team.MembersAddArg) (*team.MembersAddLaunch, error) {
+			gotArg = arg
+			return &team.MembersAddLaunch{
+				Tagged: dropbox.Tagged{Tag: "complete"},
+				Complete: []*team.MemberAddResult{
+					{Tagged: dropbox.Tagged{Tag: "success"}, Success: member},
+				},
+			}, nil
+		},
+	})
+
+	cmd, stdout := teamTestCmd(t, true)
+	if err := addMember(cmd, []string{"new@example.com", "New", "User"}); err != nil {
+		t.Fatalf("addMember error: %v", err)
+	}
+	if gotArg == nil || len(gotArg.NewMembers) != 1 || gotArg.NewMembers[0].MemberEmail != "new@example.com" || gotArg.NewMembers[0].MemberGivenName != "New" || gotArg.NewMembers[0].MemberSurname != "User" {
+		t.Fatalf("MembersAdd arg = %#v, want new member", gotArg)
+	}
+
+	got := decodeTeamOperationOutput[teamMemberAddInput, teamMemberMutationJSON](t, stdout.Bytes())
+	if got.Input.Email != "new@example.com" || got.Input.FirstName != "New" || got.Input.LastName != "User" {
+		t.Fatalf("input = %#v, want add member input", got.Input)
+	}
+	result := onlyTeamResult(t, got)
+	if result.Status != teamJSONStatusAdded || result.Kind != teamJSONKindTeamMember {
+		t.Fatalf("operation result = %#v, want added team_member", result)
+	}
+	if result.Result.Type != teamJSONTypeMemberAdd || result.Result.Tag != "complete" || len(result.Result.Results) != 1 {
+		t.Fatalf("mutation result = %#v, want complete add result", result.Result)
+	}
+	if result.Result.Results[0].Member == nil || result.Result.Results[0].Member.Email != "new@example.com" {
+		t.Fatalf("add item = %#v, want new member metadata", result.Result.Results[0])
+	}
+}
+
+func TestTeamRemoveMemberJSONOutputsMutationResult(t *testing.T) {
+	var gotArg *team.MembersRemoveArg
+	stubTeamClient(t, &mockTeamClient{
+		membersRemoveFn: func(arg *team.MembersRemoveArg) (*async.LaunchEmptyResult, error) {
+			gotArg = arg
+			return &async.LaunchEmptyResult{Tagged: dropbox.Tagged{Tag: "complete"}}, nil
+		},
+	})
+
+	cmd, stdout := teamTestCmd(t, true)
+	if err := removeMember(cmd, []string{"old@example.com"}); err != nil {
+		t.Fatalf("removeMember error: %v", err)
+	}
+	if gotArg == nil || gotArg.User == nil || gotArg.User.Tag != "email" || gotArg.User.Email != "old@example.com" {
+		t.Fatalf("MembersRemove arg = %#v, want email selector", gotArg)
+	}
+
+	got := decodeTeamOperationOutput[teamMemberRemoveInput, teamMemberMutationJSON](t, stdout.Bytes())
+	if got.Input.Email != "old@example.com" {
+		t.Fatalf("input = %#v, want remove input", got.Input)
+	}
+	result := onlyTeamResult(t, got)
+	if result.Status != teamJSONStatusRemoved || result.Kind != teamJSONKindTeamMember {
+		t.Fatalf("operation result = %#v, want removed team_member", result)
+	}
+	if result.Result.Type != teamJSONTypeMemberRemove || result.Result.Tag != "complete" {
+		t.Fatalf("mutation result = %#v, want complete remove result", result.Result)
+	}
+}
+
+func TestTeamJSONErrorWritesNoSuccessOutput(t *testing.T) {
+	stubTeamClient(t, &mockTeamClient{
+		getInfoFn: func() (*team.TeamGetInfoResult, error) {
+			return nil, errors.New("team failed")
+		},
+	})
+
+	cmd, stdout := teamTestCmd(t, true)
+	if err := info(cmd, nil); err == nil {
+		t.Fatal("expected info error")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want no success output", got)
+	}
+}
+
+func TestTeamCommandsSupportStructuredOutput(t *testing.T) {
+	for _, cmd := range []*cobra.Command{
+		infoCmd,
+		listMembersCmd,
+		listGroupsCmd,
+		addMemberCmd,
+		removeMemberCmd,
+	} {
+		if !commandSupportsStructuredOutput(cmd) {
+			t.Fatalf("%s should support structured output", cmd.CommandPath())
+		}
+	}
+}
+
+func teamTestCmd(t *testing.T, jsonOutput bool) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	if jsonOutput {
+		cmd.Flags().String(outputFlag, "text", "")
+		if err := cmd.Flags().Set(outputFlag, "json"); err != nil {
+			t.Fatalf("set output: %v", err)
+		}
+	}
+	return cmd, &stdout
+}
+
+func decodeTeamOperationOutput[I, R any](t *testing.T, data []byte) teamOperationOutputForTest[I, R] {
+	t.Helper()
+	var got teamOperationOutputForTest[I, R]
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("decode JSON output: %v\noutput: %s", err, string(data))
+	}
+	if got.Warnings == nil {
+		t.Fatalf("warnings = nil, want empty array")
+	}
+	if len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %#v, want empty", got.Warnings)
+	}
+	return got
+}
+
+func onlyTeamResult[I, R any](t *testing.T, got teamOperationOutputForTest[I, R]) teamOperationResultForTest[I, R] {
+	t.Helper()
+	if len(got.Results) != 1 {
+		t.Fatalf("results length = %d, want 1", len(got.Results))
+	}
+	return got.Results[0]
+}
+
+func stubTeamClient(t *testing.T, client teamClient) {
+	t.Helper()
+	orig := teamNewFunc
+	teamNewFunc = func(dropbox.Config) teamClient { return client }
+	t.Cleanup(func() {
+		teamNewFunc = orig
+	})
+}
+
+func testTeamMember(memberID, email, displayName string) *team.TeamMemberInfo {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	return &team.TeamMemberInfo{
+		Profile: &team.TeamMemberProfile{
+			MemberProfile: team.MemberProfile{
+				TeamMemberId:    memberID,
+				AccountId:       "dbid:" + memberID,
+				Email:           email,
+				EmailVerified:   true,
+				Status:          &team.TeamMemberStatus{Tagged: dropbox.Tagged{Tag: "active"}},
+				Name:            users.NewName(strings.Split(displayName, " ")[0], "User", strings.Split(displayName, " ")[0], displayName, "TU"),
+				MembershipType:  &team.TeamMembershipType{Tagged: dropbox.Tagged{Tag: "full"}},
+				JoinedOn:        &now,
+				ProfilePhotoUrl: "https://example.com/photo",
+			},
+			Groups:         []string{"gid:eng"},
+			MemberFolderId: "ns:" + memberID,
+		},
+		Role: &team.AdminTier{Tagged: dropbox.Tagged{Tag: "member_only"}},
+	}
+}
+
+func testTeamGroup(name, id string, memberCount uint32) *team_common.GroupSummary {
+	group := team_common.NewGroupSummary(name, id, &team_common.GroupManagementType{Tagged: dropbox.Tagged{Tag: "user_managed"}})
+	group.MemberCount = memberCount
+	group.GroupExternalId = "external:" + id
+	return group
+}


### PR DESCRIPTION
## Summary
- Add structured JSON output (`--output=json`) to `team info`, `team list-members`, `team list-groups`, `team add-member`, and `team remove-member`
- Extract `teamClient` interface and `teamNewFunc` factory for testability
- Add full pagination to `list-members` and `list-groups` (previously only returned the first page)
- Fix text output to use command writers instead of `os.Stdout`
- Broaden `jsonErrorCode` matching from `"requires a"` to `"requires "` to cover team command argument errors

## Test plan
- [x] `go test ./cmd/...` passes — new tests cover JSON output, pagination, text output, error paths, and structured output support for all 5 team commands
- [x] `golangci-lint run ./...` passes
- [x] `dbxcli team info --output=json` outputs team metadata in operation format
- [x] `dbxcli team list-members --output=json` paginates and returns all members
- [x] `dbxcli team list-groups --output=json` paginates and returns all groups
- [x] `dbxcli team add-member --output=json` outputs mutation result with launch status
- [x] `dbxcli team remove-member --output=json` outputs mutation result with launch status