### PR TITLE
Resolve version from debug.ReadBuildInfo for go install users

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,18 +16,43 @@ package main
 
 import (
 	"log"
+	"runtime/debug"
+	"strings"
 
 	"github.com/dropbox/dbxcli/v3/cmd"
 )
 
-var version = "0.1.0"
+const defaultVersion = "dev"
+
+var (
+	version       = defaultVersion
+	readBuildInfo = debug.ReadBuildInfo
+)
 
 func init() {
 	// Log date, time and file information by default
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
-	cmd.RootCmd.AddCommand(cmd.NewVersionCommand(version))
+	cmd.RootCmd.AddCommand(cmd.NewVersionCommand(resolvedVersion()))
 }
 
 func main() {
 	cmd.Execute()
+}
+
+func resolvedVersion() string {
+	if version != "" && version != defaultVersion {
+		return version
+	}
+
+	info, ok := readBuildInfo()
+	if !ok {
+		return defaultVersion
+	}
+
+	moduleVersion := info.Main.Version
+	if moduleVersion == "" || moduleVersion == "(devel)" {
+		return defaultVersion
+	}
+
+	return strings.TrimPrefix(moduleVersion, "v")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolvedVersionPrefersInjectedVersion(t *testing.T) {
+	restoreVersionResolver(t, "1.2.3", debug.BuildInfo{
+		Main: debug.Module{Version: "v9.9.9"},
+	}, true)
+
+	if got, want := resolvedVersion(), "1.2.3"; got != want {
+		t.Fatalf("resolvedVersion() = %q, want %q", got, want)
+	}
+}
+
+func TestResolvedVersionUsesModuleVersion(t *testing.T) {
+	restoreVersionResolver(t, defaultVersion, debug.BuildInfo{
+		Main: debug.Module{Version: "v3.5.1"},
+	}, true)
+
+	if got, want := resolvedVersion(), "3.5.1"; got != want {
+		t.Fatalf("resolvedVersion() = %q, want %q", got, want)
+	}
+}
+
+func TestResolvedVersionFallsBackToDev(t *testing.T) {
+	restoreVersionResolver(t, defaultVersion, debug.BuildInfo{
+		Main: debug.Module{Version: "(devel)"},
+	}, true)
+
+	if got, want := resolvedVersion(), defaultVersion; got != want {
+		t.Fatalf("resolvedVersion() = %q, want %q", got, want)
+	}
+}
+
+func TestResolvedVersionFallsBackToDevWithoutBuildInfo(t *testing.T) {
+	restoreVersionResolver(t, defaultVersion, debug.BuildInfo{}, false)
+
+	if got, want := resolvedVersion(), defaultVersion; got != want {
+		t.Fatalf("resolvedVersion() = %q, want %q", got, want)
+	}
+}
+
+func restoreVersionResolver(t *testing.T, testVersion string, buildInfo debug.BuildInfo, ok bool) {
+	t.Helper()
+
+	previousVersion := version
+	previousReadBuildInfo := readBuildInfo
+	version = testVersion
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &buildInfo, ok
+	}
+
+	t.Cleanup(func() {
+		version = previousVersion
+		readBuildInfo = previousReadBuildInfo
+	})
+}


### PR DESCRIPTION
## Summary

- When version is not injected via `-ldflags` (e.g. `go install`), resolve it from `debug.ReadBuildInfo()` module version
- Falls back to `dev` when build info is unavailable or shows `(devel)`
- Injected ldflags version always takes priority

## Test plan

- [x] `go test ./...` passes (4 new test cases cover all branches)
- [x] `go build -o dbxcli .` → version shows module pseudo-version
- [x] `go build -ldflags "-X main.version=4.0.0"` → version shows `4.0.0`
- [x] Text and JSON output both correct