### PR TITLE
packaging: update Homebrew formula and add WinGet manifest templates

### DIFF
--- a/packaging/homebrew/dbxcli.rb
+++ b/packaging/homebrew/dbxcli.rb
@@ -1,8 +1,8 @@
 class Dbxcli < Formula
   desc "Command-line tool for Dropbox users and team admins"
   homepage "https://github.com/dropbox/dbxcli"
-  url "https://github.com/dropbox/dbxcli/archive/refs/tags/v3.3.3.tar.gz"
-  sha256 "be0187b703ef726b21ace33212a9b9f743502e74a8149d2f356fda650408c1a7"
+  url "https://github.com/dropbox/dbxcli/archive/refs/tags/v3.5.1.tar.gz"
+  sha256 "04e9dc214c481a0cdbf39deaadf6ec247188c9c207b3c440cb6b139a17020e80"
   license "Apache-2.0"
   head "https://github.com/dropbox/dbxcli.git", branch: "master"
 
@@ -11,10 +11,13 @@ class Dbxcli < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}")
     generate_completions_from_executable bin/"dbxcli", "completion", shells: [:bash, :zsh, :fish]
+    doc.install Dir["docs/commands/*.md"]
   end
 
   test do
     ENV["DBXCLI_AUTH_FILE"] = testpath/"missing-auth.json"
+    assert_path_exists doc/"dbxcli_completion.md"
+    assert_path_exists doc/"dbxcli_completion_bash.md"
     output = shell_output("#{bin}/dbxcli ls 2>&1", 1)
     assert_match "no saved Dropbox credentials", output
   end

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,64 @@
+# WinGet package maintenance
+
+WinGet packages are published through the Microsoft community package
+repository:
+
+https://github.com/microsoft/winget-pkgs
+
+Use these templates after a GitHub Release is published and the Windows archive
+is available at:
+
+```text
+https://github.com/dropbox/dbxcli/releases/download/vX.Y.Z/dbxcli_X.Y.Z_windows_amd64.zip
+```
+
+The generated manifest is for a portable zip package. It installs the nested
+`dbxcli.exe` binary and exposes `dbxcli` as the portable command alias.
+
+## Generate manifests
+
+Run the normal release packaging first so `dist/SHA256SUMS` exists:
+
+```sh
+VERSION=vX.Y.Z ./build.sh
+VERSION=vX.Y.Z ./packaging/package-release.sh
+```
+
+Then render the WinGet manifests:
+
+```sh
+./packaging/winget/render-manifests.sh vX.Y.Z
+```
+
+By default this writes:
+
+```text
+dist/winget/manifests/d/Dropbox/dbxcli/X.Y.Z/
+```
+
+To write directly into a local `winget-pkgs` checkout:
+
+```sh
+OUTPUT_DIR=/path/to/winget-pkgs ./packaging/winget/render-manifests.sh vX.Y.Z
+```
+
+This creates files under:
+
+```text
+/path/to/winget-pkgs/manifests/d/Dropbox/dbxcli/X.Y.Z/
+```
+
+## Validate and submit
+
+From the `winget-pkgs` checkout:
+
+```powershell
+winget validate .\manifests\d\Dropbox\dbxcli\X.Y.Z
+winget install --manifest .\manifests\d\Dropbox\dbxcli\X.Y.Z
+```
+
+Open a pull request against `microsoft/winget-pkgs` after local validation
+passes.
+
+Do not add `winget install Dropbox.dbxcli` to the main README until the package
+has been accepted into the public WinGet source.

--- a/packaging/winget/render-manifests.sh
+++ b/packaging/winget/render-manifests.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+package_id="Dropbox.dbxcli"
+version="${1:-${VERSION:-${GITHUB_REF_NAME:-}}}"
+
+if [[ -z "${version}" ]]; then
+  echo "usage: $0 vX.Y.Z" >&2
+  echo "or set VERSION/GITHUB_REF_NAME" >&2
+  exit 1
+fi
+
+version="${version#v}"
+dist_dir="${DIST_DIR:-dist}"
+checksum_file="${dist_dir}/SHA256SUMS"
+archive_name="dbxcli_${version}_windows_amd64.zip"
+
+if [[ ! -f "${checksum_file}" ]]; then
+  echo "missing checksum file: ${checksum_file}" >&2
+  exit 1
+fi
+
+if ! checksum="$(
+  awk -v archive="${archive_name}" '
+    $2 == archive {
+      print toupper($1)
+      found = 1
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' "${checksum_file}"
+)"; then
+  echo "missing checksum for ${archive_name} in ${checksum_file}" >&2
+  exit 1
+fi
+
+if [[ -z "${checksum}" ]]; then
+  echo "missing checksum for ${archive_name} in ${checksum_file}" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+template_dir="${script_dir}/templates"
+output_root="${OUTPUT_DIR:-${dist_dir}/winget}"
+output_dir="${output_root}/manifests/d/Dropbox/dbxcli/${version}"
+
+mkdir -p "${output_dir}"
+
+render_template() {
+  local input="$1"
+  local output="$2"
+
+  sed \
+    -e "s/{{VERSION}}/${version}/g" \
+    -e "s/{{WINDOWS_AMD64_SHA256}}/${checksum}/g" \
+    "${input}" > "${output}"
+}
+
+render_template "${template_dir}/${package_id}.yaml.template" "${output_dir}/${package_id}.yaml"
+render_template "${template_dir}/${package_id}.installer.yaml.template" "${output_dir}/${package_id}.installer.yaml"
+render_template "${template_dir}/${package_id}.locale.en-US.yaml.template" "${output_dir}/${package_id}.locale.en-US.yaml"
+
+echo "Created WinGet manifests in ${output_dir}:"
+echo "  ${package_id}.yaml"
+echo "  ${package_id}.installer.yaml"
+echo "  ${package_id}.locale.en-US.yaml"

--- a/packaging/winget/templates/Dropbox.dbxcli.installer.yaml.template
+++ b/packaging/winget/templates/Dropbox.dbxcli.installer.yaml.template
@@ -1,0 +1,16 @@
+# Created with packaging/winget/render-manifests.sh.
+PackageIdentifier: Dropbox.dbxcli
+PackageVersion: {{VERSION}}
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - dbxcli
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dropbox/dbxcli/releases/download/v{{VERSION}}/dbxcli_{{VERSION}}_windows_amd64.zip
+    InstallerSha256: {{WINDOWS_AMD64_SHA256}}
+    NestedInstallerFiles:
+      - RelativeFilePath: dbxcli_{{VERSION}}_windows_amd64/dbxcli.exe
+        PortableCommandAlias: dbxcli
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/packaging/winget/templates/Dropbox.dbxcli.locale.en-US.yaml.template
+++ b/packaging/winget/templates/Dropbox.dbxcli.locale.en-US.yaml.template
@@ -1,0 +1,24 @@
+# Created with packaging/winget/render-manifests.sh.
+PackageIdentifier: Dropbox.dbxcli
+PackageVersion: {{VERSION}}
+PackageLocale: en-US
+Publisher: Dropbox
+PublisherUrl: https://www.dropbox.com
+PublisherSupportUrl: https://github.com/dropbox/dbxcli/issues
+PrivacyUrl: https://www.dropbox.com/privacy
+Author: Dropbox
+PackageName: dbxcli
+PackageUrl: https://github.com/dropbox/dbxcli
+License: Apache-2.0
+LicenseUrl: https://github.com/dropbox/dbxcli/blob/v{{VERSION}}/LICENSE
+ShortDescription: Command-line tool for Dropbox users and team admins
+Description: dbxcli is a scriptable Dropbox CLI for files, shared links, teams, and automation workflows.
+Moniker: dbxcli
+Tags:
+  - cli
+  - dropbox
+  - files
+  - storage
+ReleaseNotesUrl: https://github.com/dropbox/dbxcli/releases/tag/v{{VERSION}}
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/packaging/winget/templates/Dropbox.dbxcli.yaml.template
+++ b/packaging/winget/templates/Dropbox.dbxcli.yaml.template
@@ -1,0 +1,6 @@
+# Created with packaging/winget/render-manifests.sh.
+PackageIdentifier: Dropbox.dbxcli
+PackageVersion: {{VERSION}}
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

- **Homebrew**: bump formula from v3.3.3 to v3.5.1, install generated docs into `doc/`, add doc path assertions in test block
- **WinGet**: add `render-manifests.sh` script and YAML templates for submitting portable zip packages to `microsoft/winget-pkgs`

## Test plan

- [x] `render-manifests.sh v3.5.1` generates correct manifests with version/SHA substitution
- [x] Error cases handled: missing version, missing SHA256SUMS, missing archive entry
- [x] Homebrew formula passes Ruby syntax check
- [x] `go build ./...` / `go test ./...` unaffected (no Go changes)