### PR TITLE
packaging: update Homebrew formula to v3.6.0 and add WinGet schema comments

### DIFF
--- a/packaging/homebrew/dbxcli.rb
+++ b/packaging/homebrew/dbxcli.rb
@@ -1,8 +1,8 @@
 class Dbxcli < Formula
   desc "Command-line tool for Dropbox users and team admins"
   homepage "https://github.com/dropbox/dbxcli"
-  url "https://github.com/dropbox/dbxcli/archive/refs/tags/v3.5.1.tar.gz"
-  sha256 "04e9dc214c481a0cdbf39deaadf6ec247188c9c207b3c440cb6b139a17020e80"
+  url "https://github.com/dropbox/dbxcli/archive/refs/tags/v3.6.0.tar.gz"
+  sha256 "49d80ff75f879420ae0e20bd77172a1435edd7e15bf3068cfbe5696d89a8c43b"
   license "Apache-2.0"
   head "https://github.com/dropbox/dbxcli.git", branch: "master"
 
@@ -18,7 +18,7 @@ class Dbxcli < Formula
     ENV["DBXCLI_AUTH_FILE"] = testpath/"missing-auth.json"
     assert_path_exists doc/"dbxcli_completion.md"
     assert_path_exists doc/"dbxcli_completion_bash.md"
-    output = shell_output("#{bin}/dbxcli ls 2>&1", 1)
+    output = shell_output("#{bin}/dbxcli ls 2>&1", 2)
     assert_match "no saved Dropbox credentials", output
   end
 end

--- a/packaging/winget/templates/Dropbox.dbxcli.installer.yaml.template
+++ b/packaging/winget/templates/Dropbox.dbxcli.installer.yaml.template
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 # Created with packaging/winget/render-manifests.sh.
 PackageIdentifier: Dropbox.dbxcli
 PackageVersion: {{VERSION}}

--- a/packaging/winget/templates/Dropbox.dbxcli.locale.en-US.yaml.template
+++ b/packaging/winget/templates/Dropbox.dbxcli.locale.en-US.yaml.template
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 # Created with packaging/winget/render-manifests.sh.
 PackageIdentifier: Dropbox.dbxcli
 PackageVersion: {{VERSION}}

--- a/packaging/winget/templates/Dropbox.dbxcli.yaml.template
+++ b/packaging/winget/templates/Dropbox.dbxcli.yaml.template
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 # Created with packaging/winget/render-manifests.sh.
 PackageIdentifier: Dropbox.dbxcli
 PackageVersion: {{VERSION}}


### PR DESCRIPTION
## Summary

- Bump Homebrew formula URL/SHA from v3.5.1 to v3.6.0
- Fix expected exit code in Homebrew test (1 → 2, matches stable exit codes)
- Add `yaml-language-server` schema comments to WinGet manifest templates for IDE validation

## Test plan

- [x] Homebrew formula Ruby syntax OK
- [x] WinGet templates still render correctly with `render-manifests.sh`