### PR TITLE
Fix Release workflow: drop disallowed SLSA provenance job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
       id-token: write
     outputs:
       asset_version: ${{ steps.version.outputs.asset_version }}
-      slsa_subjects_file: ${{ steps.slsa_subjects.outputs.handle }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
@@ -50,14 +49,6 @@ jobs:
       - run: ./packaging/package-release.sh
         env:
           VERSION: ${{ github.ref_name }}
-      - name: Generate SLSA subjects
-        shell: bash
-        run: base64 -w0 dist/SHA256SUMS > dist/SHA256SUMS.base64
-      - name: Upload SLSA subjects
-        id: slsa_subjects
-        uses: slsa-framework/slsa-github-generator/actions/generator/generic/create-base64-subjects-from-file@v2.1.0
-        with:
-          path: dist/SHA256SUMS.base64
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.0
       - name: Sign checksums
@@ -70,15 +61,3 @@ jobs:
             dist/SHA256SUMS
             dist/SHA256SUMS.sigstore.json
             dist/*_sbom.spdx.json
-
-  provenance:
-    needs: release
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-    with:
-      base64-subjects-as-file: ${{ needs.release.outputs.slsa_subjects_file }}
-      upload-assets: true
-      provenance-name: dbxcli_${{ needs.release.outputs.asset_version }}_slsa.intoto.jsonl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Added scheduled/manual OSSF Scorecard scanning without public Scorecard API publishing.
 - Replaced standalone Staticcheck workflow steps with a narrow `golangci-lint` configuration.
 - Added explicit `go.sum` cache dependency paths for `actions/setup-go`.
-- Added SBOM, Cosign signatures, and SLSA provenance to release artifacts.
+- Added SBOM generation and Cosign signatures to release artifacts.
 - Added race detector, workflow linting, and CodeQL security scanning to CI.
 - Hardened CI workflows with explicit read-only permissions.
 - Generate a non-constant OAuth2 `state` value to resolve the CodeQL `go/constant-oauth2-state` alert.


### PR DESCRIPTION
## Problem

Pushing the `v3.6.1` tag produced a `startup_failure` — the Release workflow never ran. Annotation:

> The reusable workflow `slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0` is not allowed in dropbox/dbxcli because all reusable workflows must be from a repository owned by your enterprise or match one of the allowed patterns.

GitHub validates reusable-workflow references at load time, so the disallowed `provenance` job failed the entire workflow before any job started. No v3.6.1 release or artifacts were produced.

This was the first tag to exercise the new supply-chain release.yml (SLSA/SBOM/Cosign added after v3.6.0), so it was never validated against org policy.

## Fix

- Remove the `provenance` job and its orphaned SLSA subject-generation steps + `slsa_subjects_file` output.
- Keep SBOM generation (`anchore/sbom-action`) and Cosign signing (`sigstore/cosign-installer`), which are step-level actions, not reusable workflows.
- Update CHANGELOG to say "SBOM generation and Cosign signatures" (drop the SLSA provenance claim).

## Follow-up (optional)
To restore SLSA provenance later, an org/enterprise admin would need to add `slsa-framework/slsa-github-generator` to the allowed reusable-workflows list.

## Release steps after merge
Re-point the existing `v3.6.1` tag to the merge commit and force-push it to re-trigger the Release workflow.