### PR TITLE
Fix Release workflow: remove disallowed SBOM/Cosign actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
     outputs:
       asset_version: ${{ steps.version.outputs.asset_version }}
     steps:
@@ -35,29 +34,15 @@ jobs:
       - run: go test ./...
       - run: go build ./...
       - run: mkdir -p dist
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0
-        with:
-          path: .
-          format: spdx-json
-          output-file: dist/dbxcli_${{ steps.version.outputs.asset_version }}_sbom.spdx.json
-          upload-artifact: false
-          upload-release-assets: false
       - run: ./build.sh
         env:
           VERSION: ${{ github.ref_name }}
       - run: ./packaging/package-release.sh
         env:
           VERSION: ${{ github.ref_name }}
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.0
-      - name: Sign checksums
-        run: cosign sign-blob --yes --bundle dist/SHA256SUMS.sigstore.json dist/SHA256SUMS
       - uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/*.tar.gz
             dist/*.zip
             dist/SHA256SUMS
-            dist/SHA256SUMS.sigstore.json
-            dist/*_sbom.spdx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@
 - Added scheduled/manual OSSF Scorecard scanning without public Scorecard API publishing.
 - Replaced standalone Staticcheck workflow steps with a narrow `golangci-lint` configuration.
 - Added explicit `go.sum` cache dependency paths for `actions/setup-go`.
-- Added SBOM generation and Cosign signatures to release artifacts.
 - Added race detector, workflow linting, and CodeQL security scanning to CI.
 - Hardened CI workflows with explicit read-only permissions.
 - Generate a non-constant OAuth2 `state` value to resolve the CodeQL `go/constant-oauth2-state` alert.


### PR DESCRIPTION
## Problem

After dropping the SLSA reusable workflow (#332), the `v3.6.1` tag still hit `startup_failure`. Annotation:

> The actions `anchore/sbom-action@v0` and `sigstore/cosign-installer@v4.1.0` are not allowed in dropbox/dbxcli because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the allowed patterns.

The org's allowed-actions policy is enforced at workflow load time, so these two step-level actions (both new since v3.6.0) failed the whole Release workflow before any job ran.

## Fix

Remove the SBOM generation (`anchore/sbom-action`) and Cosign signing (`sigstore/cosign-installer`) steps, plus the now-unneeded `id-token: write` permission and the sbom/sigstore release assets.

Remaining actions are all policy-approved:
- `actions/checkout`, `actions/setup-go` — GitHub-created
- `golangci/golangci-lint-action@*` — on the allowlist
- `softprops/action-gh-release@v3` — used successfully in the v3.6.0 release

This matches the job shape that released v3.6.0. CHANGELOG updated to drop the SBOM/Cosign line.

## Follow-up (optional)
To restore SBOM/Cosign/SLSA later, an org/enterprise admin would need to add `anchore/sbom-action`, `sigstore/cosign-installer`, and `slsa-framework/slsa-github-generator` to the org's allowed actions/reusable-workflows list.