### PR TITLE
Bump CI Go to 1.25.12 for GO-2026-5856

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
           cache-dependency-path: go.sum
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck ./...
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
           cache-dependency-path: go.sum
       - run: go test -race ./...
 
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
           cache-dependency-path: go.sum
       - uses: golangci/golangci-lint-action@v9
         with:
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
           cache-dependency-path: go.sum
       - run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
       - run: actionlint
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
           cache-dependency-path: go.sum
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck ./...
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
           cache-dependency-path: go.sum
       - run: go run ./tools/gen-docs
       - run: go run ./tools/gen-json-schemas
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
           cache-dependency-path: go.sum
       - name: Build Windows binary
         shell: pwsh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
           cache-dependency-path: go.sum
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
           cache-dependency-path: go.sum
       - name: Set release version
         id: version


### PR DESCRIPTION
## Summary

CI `govulncheck` is failing on all open PRs (and `master`) due to a Go standard-library vulnerability, before build/test/vet even run.

- **Vuln:** [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) — Encrypted Client Hello privacy leak in `crypto/tls`
- **Found in:** `crypto/tls@go1.25.11` (what `setup-go` resolves `"1.25"` to)
- **Fixed in:** `crypto/tls@go1.25.12`

The call traces `govulncheck` reports (`cmd/share_link_raw.go`, `internal/output/output.go`) are unrelated to any in-flight feature work — this is purely a toolchain CVE.

This pins `go-version` to `1.25.12` (the patched release) across the CI, CodeQL, and release workflows. `go.mod`'s `go 1.25.0` language floor is left unchanged.