### PR TITLE
Add renderOperation helper and migrate mkdir/restore dry-run

### DIFF
--- a/cmd/dry_run.go
+++ b/cmd/dry_run.go
@@ -48,6 +48,14 @@ func plannedStatus(dryRun bool, realStatus string) string {
 	return realStatus
 }
 
+// renderOperation renders a command's operation output through the shared
+// command output writer: the text closure produces the human-readable form and
+// the JSON form is the standard operation envelope. Dry-run branches use this
+// to avoid duplicating the commandOutput/newJSONCommandOperationOutput glue.
+func renderOperation(cmd *cobra.Command, input any, results []jsonOperationResult, warnings []jsonWarning, text func(io.Writer) error) error {
+	return commandOutput(cmd).Render(text, newJSONCommandOperationOutput(cmd, input, results, warnings))
+}
+
 func writeDryRunLine(w io.Writer, verb, path string) error {
 	_, err := fmt.Fprintf(w, "Would %s %s\n", verb, path)
 	return err

--- a/cmd/mkdir.go
+++ b/cmd/mkdir.go
@@ -65,9 +65,9 @@ func mkdir(cmd *cobra.Command, args []string) (err error) {
 
 	if opts.dryRun {
 		result := newPlannedMkdirResult(dst, opts)
-		return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderOperation(cmd, result.Input, []jsonOperationResult{mkdirOperationResult(result)}, nil, func(w io.Writer) error {
 			return writeDryRunLine(w, "create directory", result.displayPath())
-		}, newJSONCommandOperationOutput(cmd, result.Input, []jsonOperationResult{mkdirOperationResult(result)}, nil))
+		})
 	}
 
 	arg := files.NewCreateFolderArg(dst)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -63,9 +63,9 @@ func restore(cmd *cobra.Command, args []string) (err error) {
 	}
 	if opts.dryRun {
 		result := newPlannedRestoreResult(path, rev, opts)
-		return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderOperation(cmd, result.Input, []jsonOperationResult{restoreOperationResult(result)}, nil, func(w io.Writer) error {
 			return renderPlannedRestoreResult(w, result)
-		}, newJSONCommandOperationOutput(cmd, result.Input, []jsonOperationResult{restoreOperationResult(result)}, nil))
+		})
 	}
 
 	arg := files.NewRestoreArg(path, rev)


### PR DESCRIPTION
## Summary

Second PR in the dry-run generalization series. Introduces `renderOperation`, a shared helper that renders a command's operation output — the text closure plus the standard JSON operation envelope — so dry-run branches stop duplicating the `commandOutput(cmd).Render(..., newJSONCommandOperationOutput(cmd, ...))` glue.

Migrates the two simplest dry-run commands, **mkdir** and **restore**, onto it. These are single planned operations with no discovery or both-modes path, so they validate the helper before it touches more complex commands.

## Changes

- `cmd/dry_run.go` — add `renderOperation(cmd, input, results, warnings, textFn)`.
- `cmd/mkdir.go` — dry-run branch calls `renderOperation`.
- `cmd/restore.go` — dry-run branch calls `renderOperation`.

## Behavior

Unchanged. The text closure that was already passed to `.Render` is passed to `renderOperation` verbatim. The existing byte-exact dry-run snapshots (`TestMkdirJSONDryRunOutputSnapshot`, `TestMkdirDryRunTextOutputSnapshot`, restore's JSON dry-run test) and the cross-command contract tests all continue to pass.

## Testing

- `go build ./...` clean
- `go vet ./cmd/` clean
- `go test ./cmd/` green (`-count=1`)

## Notes

Text stays a per-command closure by design — restore's `Would restore <path> to revision <rev>` and later put/revoke output cannot be modeled by a shared struct. `renderOperation` owns only the envelope. Later PRs migrate share-link create/update, rm + share-link revoke, cp/mv, and put onto the same helper.