### PR TITLE
Migrate share-link create/update dry-run to renderOperation

### DIFF
--- a/cmd/share_link_create.go
+++ b/cmd/share_link_create.go
@@ -245,14 +245,15 @@ func plannedShareLinkCreateMetadata(path string) shareLinkJSONMetadata {
 
 func renderShareLinkCreateDryRunOutput(cmd *cobra.Command, path string, opts shareLinkCreateOptions) error {
 	result := plannedShareLinkCreateMetadata(path)
-	return commandOutput(cmd).Render(func(w io.Writer) error {
-		return writeDryRunLine(w, "create shared link", path)
-	}, newJSONCommandOperationOutput(
+	return renderOperation(
 		cmd,
 		newShareLinkCreateInput(path, opts),
 		[]jsonOperationResult{shareLinkCreateOperationResult(shareLinkJSONStatusCreated, result, opts)},
 		nil,
-	))
+		func(w io.Writer) error {
+			return writeDryRunLine(w, "create shared link", path)
+		},
+	)
 }
 
 func applyExistingSharedLinkCreateOptions(dbx sharedLinkClient, link sharing.IsSharedLinkMetadata, opts shareLinkCreateOptions) (sharing.IsSharedLinkMetadata, error) {

--- a/cmd/share_link_update.go
+++ b/cmd/share_link_update.go
@@ -279,14 +279,15 @@ func plannedShareLinkUpdateMetadata(url string) shareLinkJSONMetadata {
 
 func renderShareLinkUpdateDryRunOutput(cmd *cobra.Command, url string, opts shareLinkUpdateOptions) error {
 	result := plannedShareLinkUpdateMetadata(url)
-	return commandOutput(cmd).Render(func(w io.Writer) error {
-		return writeDryRunLine(w, "update shared link", url)
-	}, newJSONCommandOperationOutput(
+	return renderOperation(
 		cmd,
 		newShareLinkUpdateInput(url, opts),
 		[]jsonOperationResult{shareLinkUpdateOperationResult(shareLinkJSONStatusUpdated, result, opts)},
 		nil,
-	))
+		func(w io.Writer) error {
+			return writeDryRunLine(w, "update shared link", url)
+		},
+	)
 }
 
 var shareLinkUpdateCmd = &cobra.Command{


### PR DESCRIPTION
## Summary

Third PR in the dry-run generalization series. Routes the two share-link mutation commands' dry-run branches through the shared `renderOperation` helper (added in #350), dropping the duplicated `commandOutput(cmd).Render(..., newJSONCommandOperationOutput(cmd, ...))` glue.

## Changes

- `cmd/share_link_create.go` — `renderShareLinkCreateDryRunOutput` calls `renderOperation`.
- `cmd/share_link_update.go` — `renderShareLinkUpdateDryRunOutput` calls `renderOperation`.

## Why these two next

They validate that `renderOperation` generalizes beyond the mkdir/restore shape: share-link uses `shareLinkJSONMetadata` plus a dedicated result-input struct carrying `dry_run`, not `jsonMetadata`. It slotted in with no change to the helper — confirming the envelope-only abstraction is shape-agnostic. Risk stays low: both are single planned operations with no discovery or both-modes path.

## Behavior

Unchanged. The text closure already passed to `.Render` moves into `renderOperation` verbatim. The share-link dry-run JSON tests and the cross-command contract tests all pass.