### PR TITLE
Migrate rm and share-link revoke dry-run to renderOperation

### DIFF
--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -76,12 +76,12 @@ func rm(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return commandOutput(cmd).Render(func(w io.Writer) error {
+	return renderOperation(cmd, nil, removeOperationResults(results), nil, func(w io.Writer) error {
 		if !opts.dryRun && !opts.verbose {
 			return nil
 		}
 		return renderRemoveResults(w, results)
-	}, newJSONCommandOperationOutput(cmd, nil, removeOperationResults(results), nil))
+	})
 }
 
 func removeOperationResults(results []removeResult) []jsonOperationResult {

--- a/cmd/share_link_revoke.go
+++ b/cmd/share_link_revoke.go
@@ -177,7 +177,7 @@ func revokeSharedLinksForPath(cmd *cobra.Command, path string, dryRun bool) ([]s
 }
 
 func renderShareLinkRevokeOutput(cmd *cobra.Command, input shareLinkRevokeInput, results []jsonOperationResult) error {
-	return commandOutput(cmd).Render(func(w io.Writer) error {
+	return renderOperation(cmd, input, results, nil, func(w io.Writer) error {
 		if !input.DryRun {
 			return nil
 		}
@@ -191,7 +191,7 @@ func renderShareLinkRevokeOutput(cmd *cobra.Command, input shareLinkRevokeInput,
 			}
 		}
 		return nil
-	}, newJSONCommandOperationOutput(cmd, input, results, nil))
+	})
 }
 
 var shareLinkRevokeCmd = &cobra.Command{


### PR DESCRIPTION
## Summary

Fourth PR in the dry-run generalization series. Routes rm's terminal output and `renderShareLinkRevokeOutput` through the shared `renderOperation` helper (#350), dropping the duplicated `commandOutput(cmd).Render(..., newJSONCommandOperationOutput(cmd, ...))` glue.

## Changes

- `cmd/rm.go` — final render call uses `renderOperation`.
- `cmd/share_link_revoke.go` — `renderShareLinkRevokeOutput` uses `renderOperation`.

## Why this one needed care

Unlike the earlier migrations (single dry-run-only branch), rm and share-link revoke run **one code path for both dry-run and live modes**, gating only the destructive API call. The migration deliberately does **not** split that path: the text closures move into `renderOperation` verbatim, preserving their internal branching —

- rm: the `if !opts.dryRun && !opts.verbose { return nil }` guard, then `renderRemoveResults` which prints "Would delete" vs "Deleted".
- revoke: the `if !input.DryRun { return nil }` guard and per-URL loop.

Only the envelope construction is shared. Output is unchanged in both modes.