### PR TITLE
Migrate cp/mv relocation dry-run to renderOperation

### DIFF
--- a/cmd/relocation.go
+++ b/cmd/relocation.go
@@ -156,9 +156,9 @@ func runRelocation(cmd *cobra.Command, args []string, spec relocationSpec) error
 	}
 
 	if opts.dryRun {
-		return commandOutput(cmd).Render(func(w io.Writer) error {
+		return renderOperation(cmd, nil, results, nil, func(w io.Writer) error {
 			return renderPlannedRelocationResults(w, spec.verb, plannedResults)
-		}, newJSONCommandOperationOutput(cmd, nil, results, nil))
+		})
 	}
 
 	if !collectResults {


### PR DESCRIPTION
## Summary

Fifth PR in the dry-run generalization series. Routes the shared cp/mv relocation driver's dry-run branch through the `renderOperation` helper (#350), dropping the duplicated `commandOutput(cmd).Render(..., newJSONCommandOperationOutput(cmd, ...))` glue.

## Changes

- `cmd/relocation.go` — dry-run branch uses `renderOperation`.

One edit covers both cp and mv, since they share this driver. The `renderPlannedRelocationResults` closure (multi-result "Would move/copy X to Y" text) moves into `renderOperation` unchanged.

## Behavior

Unchanged. Verified byte-for-byte against a pre-refactor baseline binary on a live account:

- `cp --dry-run --output json` — **identical** (`status:"planned"`, `dry_run:true`, full metadata)
- `mv --dry-run` text — **identical**
- multi-source `mv --dry-run` into a folder — both entries planned
- nonexistent source — clean error, exit 1, no partial output
- source tree confirmed untouched (dry-run performs its GetMetadata lookups but creates nothing)