### PR TITLE
Migrate put dry-run to renderOperation and unit-test the helper

### DIFF
--- a/cmd/dry_run_test.go
+++ b/cmd/dry_run_test.go
@@ -16,6 +16,8 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"io"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -97,6 +99,61 @@ func TestDryRunDisplayPath(t *testing.T) {
 	if got, want := dryRunDisplayPath(jsonMetadata{}, "/fallback.txt"), "/fallback.txt"; got != want {
 		t.Fatalf("dryRunDisplayPath fallback = %q, want %q", got, want)
 	}
+}
+
+func TestRenderOperationTextUsesClosure(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := renderOperationTestCommand(&stdout, "text")
+
+	results := []jsonOperationResult{newJSONOperationResult(jsonStatusPlanned, "folder", nil, plannedMetadata("folder", "/Projects"))}
+	err := renderOperation(cmd, nil, results, nil, func(w io.Writer) error {
+		return writeDryRunLine(w, "create directory", "/Projects")
+	})
+	if err != nil {
+		t.Fatalf("renderOperation error: %v", err)
+	}
+
+	if got, want := stdout.String(), "Would create directory /Projects\n"; got != want {
+		t.Fatalf("text output = %q, want %q", got, want)
+	}
+}
+
+func TestRenderOperationJSONRendersEnvelopeAndSkipsClosure(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := renderOperationTestCommand(&stdout, "json")
+
+	input := mkdirInput{Path: "/Projects", DryRun: true}
+	results := []jsonOperationResult{newJSONOperationResult(jsonStatusPlanned, "folder", input, plannedMetadata("folder", "/Projects"))}
+	warnings := []jsonWarning{{Code: jsonWarningCodeSkippedSymlink, Message: "skipped symlink", Path: "/link"}}
+
+	err := renderOperation(cmd, input, results, warnings, func(w io.Writer) error {
+		t.Fatalf("text closure called in JSON mode")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("renderOperation error: %v", err)
+	}
+
+	var got jsonOperationOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode output: %v (raw %s)", err, stdout.String())
+	}
+	if !got.OK || got.SchemaVersion != jsonSchemaVersion || got.Command != "render-op" {
+		t.Fatalf("envelope = %+v, want ok/schema_version/command populated", got)
+	}
+	if len(got.Results) != 1 || got.Results[0].Status != jsonStatusPlanned || got.Results[0].Kind != "folder" {
+		t.Fatalf("results = %+v, want one planned folder result", got.Results)
+	}
+	if len(got.Warnings) != 1 || got.Warnings[0].Code != jsonWarningCodeSkippedSymlink {
+		t.Fatalf("warnings = %+v, want skipped_symlink passthrough", got.Warnings)
+	}
+}
+
+func renderOperationTestCommand(stdout *bytes.Buffer, format string) *cobra.Command {
+	cmd := &cobra.Command{Use: "render-op"}
+	cmd.SetOut(stdout)
+	cmd.Flags().String(outputFlag, format, "")
+	return cmd
 }
 
 func TestPlannedMetadata(t *testing.T) {

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -823,7 +823,7 @@ func plannedPutFolderResult(src, dst string) putResult {
 }
 
 func renderPlannedPutResults(cmd *cobra.Command, input putCommandInput, results []putResult, warnings []jsonWarning) error {
-	return commandOutput(cmd).Render(func(w io.Writer) error {
+	return renderOperation(cmd, input, putOperationResults(results), warnings, func(w io.Writer) error {
 		for _, result := range results {
 			if result.Kind == putKindFolder {
 				if err := writeDryRunLine(w, "create directory", result.Input.Target); err != nil {
@@ -836,7 +836,7 @@ func renderPlannedPutResults(cmd *cobra.Command, input putCommandInput, results 
 			}
 		}
 		return nil
-	}, newJSONCommandOperationOutput(cmd, input, putOperationResults(results), warnings))
+	})
 }
 
 // Keep traversal semantics aligned with putRecursiveInternal. Dry-run walks the


### PR DESCRIPTION
## Summary

Sixth and final migration PR in the dry-run generalization series. Routes `renderPlannedPutResults` through the shared `renderOperation` helper (#350), completing the migration — every dry-run command now goes through one envelope path. Also adds direct unit tests for `renderOperation` itself.

## Changes

- `cmd/put.go` — `renderPlannedPutResults` uses `renderOperation`. All three put dry-run entry points (single file, recursive, stdin) funnel through this one function, so the single edit covers them.
- `cmd/dry_run_test.go` — direct unit tests for `renderOperation` (previously covered only transitively).

## Why put is the interesting case

put's dry-run emits **mixed line types** — `Would create directory …` interleaved with `Would upload a → b` — and carries **warnings** (skipped symlinks). This is the case that motivated keeping text as a per-command closure rather than a struct. It maps cleanly onto `renderOperation`: the closure keeps the mixed-line loop, and the helper's `warnings` argument carries the symlink warnings.

## New helper tests

- `TestRenderOperationTextUsesClosure` — text mode writes the closure's output verbatim.
- `TestRenderOperationJSONRendersEnvelopeAndSkipsClosure` — JSON mode renders the full envelope (ok/schema_version/command), results passthrough, and **warnings passthrough**, while not invoking the text closure. Verified to fail if the warnings argument is dropped.