### PR TITLE
Add dryRunOptionalEnabled and collapse duplicated flag guards

### DIFF
--- a/cmd/dry_run.go
+++ b/cmd/dry_run.go
@@ -38,6 +38,16 @@ func dryRunEnabled(cmd *cobra.Command) (bool, error) {
 	return cmd.Flags().GetBool(dryRunFlagName)
 }
 
+// dryRunOptionalEnabled returns the dry-run flag state, or false when the flag
+// is not registered. Option parsers shared with callers that do not register
+// --dry-run use this instead of dryRunEnabled to avoid a missing-flag error.
+func dryRunOptionalEnabled(cmd *cobra.Command) (bool, error) {
+	if cmd == nil || cmd.Flags().Lookup(dryRunFlagName) == nil {
+		return false, nil
+	}
+	return dryRunEnabled(cmd)
+}
+
 // Dry-run JSON results use status "planned" and include dry_run=true in the
 // result input. They do not preserve the real mutation status, because no
 // mutation happened.

--- a/cmd/relocation_if_exists.go
+++ b/cmd/relocation_if_exists.go
@@ -23,13 +23,10 @@ func parseRelocationOptions(cmd *cobra.Command) (relocationOptions, error) {
 	if err != nil {
 		return relocationOptions{}, err
 	}
-	dryRun := false
 	// Some tests and callers use relocation parsing without registering --dry-run.
-	if cmd != nil && cmd.Flags().Lookup(dryRunFlagName) != nil {
-		dryRun, err = dryRunEnabled(cmd)
-		if err != nil {
-			return relocationOptions{}, err
-		}
+	dryRun, err := dryRunOptionalEnabled(cmd)
+	if err != nil {
+		return relocationOptions{}, err
 	}
 	return relocationOptions{ifExists: ifExists, dryRun: dryRun}, nil
 }

--- a/cmd/share_link_create.go
+++ b/cmd/share_link_create.go
@@ -213,13 +213,11 @@ func parseShareLinkCreateOptions(cmd *cobra.Command) (shareLinkCreateOptions, er
 		return opts, err
 	}
 	opts.password = password
-	if cmd.Flags().Lookup(dryRunFlagName) != nil {
-		dryRun, err := dryRunEnabled(cmd)
-		if err != nil {
-			return opts, err
-		}
-		opts.dryRun = dryRun
+	dryRun, err := dryRunOptionalEnabled(cmd)
+	if err != nil {
+		return opts, err
 	}
+	opts.dryRun = dryRun
 
 	if opts.expires != nil && opts.removeExpiration {
 		return opts, invalidArgumentsErrorWithDetails("`--expires` and `--remove-expiration` cannot be used together", flagsErrorDetails("expires", "remove-expiration"))

--- a/cmd/share_link_revoke.go
+++ b/cmd/share_link_revoke.go
@@ -97,13 +97,11 @@ func shareLinkRevokeOperationResults(revoked []shareLinkRevokeResult, dryRun boo
 func parseShareLinkRevokeOptions(cmd *cobra.Command, args []string) (shareLinkRevokeOptions, error) {
 	var opts shareLinkRevokeOptions
 
-	if cmd.Flags().Lookup(dryRunFlagName) != nil {
-		dryRun, err := dryRunEnabled(cmd)
-		if err != nil {
-			return opts, err
-		}
-		opts.dryRun = dryRun
+	dryRun, err := dryRunOptionalEnabled(cmd)
+	if err != nil {
+		return opts, err
 	}
+	opts.dryRun = dryRun
 
 	if !localFlagChanged(cmd, "path") {
 		return opts, nil

--- a/cmd/share_link_update.go
+++ b/cmd/share_link_update.go
@@ -182,12 +182,9 @@ func parseShareLinkUpdateOptions(cmd *cobra.Command) (shareLinkUpdateOptions, er
 	if err != nil {
 		return shareLinkUpdateOptions{}, err
 	}
-	var dryRun bool
-	if cmd.Flags().Lookup(dryRunFlagName) != nil {
-		dryRun, err = dryRunEnabled(cmd)
-		if err != nil {
-			return shareLinkUpdateOptions{}, err
-		}
+	dryRun, err := dryRunOptionalEnabled(cmd)
+	if err != nil {
+		return shareLinkUpdateOptions{}, err
 	}
 
 	if expiresChanged && removeExpiration {


### PR DESCRIPTION
## Summary

Follow-up cleanup to the dry-run generalization series. Several option parsers are shared with callers that do not register the `--dry-run` flag, so each guarded the lookup with `if cmd.Flags().Lookup(dryRunFlagName) != nil { ... }` before reading it. This extracts that repeated pattern into a single helper.

## Changes

- `cmd/dry_run.go` — add `dryRunOptionalEnabled(cmd)`: returns false when the flag isn't registered, else delegates to `dryRunEnabled`.
- `cmd/share_link_create.go`, `cmd/share_link_update.go`, `cmd/share_link_revoke.go`, `cmd/relocation_if_exists.go` — each drops its inline guard for a call to the helper.

## Why only these four

mkdir/restore/rm/put call `dryRunEnabled(cmd)` directly and are left as-is — they always register the flag, so routing them through the optional helper would wrongly imply it might be absent. The helper is only for parsers shared with non-dry-run callers.