### PR TITLE
Automate WinGet manifest updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
     outputs:
       asset_version: ${{ steps.version.outputs.asset_version }}
+      windows_archive: ${{ steps.version.outputs.windows_archive }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
@@ -24,7 +25,10 @@ jobs:
       - name: Set release version
         id: version
         shell: bash
-        run: echo "asset_version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          asset_version="${GITHUB_REF_NAME#v}"
+          echo "asset_version=${asset_version}" >> "$GITHUB_OUTPUT"
+          echo "windows_archive=dbxcli_${asset_version}_windows_amd64.zip" >> "$GITHUB_OUTPUT"
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck ./...
       - uses: golangci/golangci-lint-action@v9
@@ -40,9 +44,48 @@ jobs:
       - run: ./packaging/package-release.sh
         env:
           VERSION: ${{ github.ref_name }}
+      - name: Verify Windows release archive
+        run: test -f "dist/${{ steps.version.outputs.windows_archive }}"
       - uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/*.tar.gz
             dist/*.zip
             dist/SHA256SUMS
+
+  winget:
+    name: Submit WinGet update
+    needs: release
+    runs-on: windows-latest
+    env:
+      VERSION: ${{ needs.release.outputs.asset_version }}
+      INSTALLER_URL: https://github.com/dropbox/dbxcli/releases/download/v${{ needs.release.outputs.asset_version }}/${{ needs.release.outputs.windows_archive }}
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+    steps:
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "9.0.x"
+      - name: Download WingetCreate
+        shell: pwsh
+        run: |
+          $url = "https://github.com/microsoft/winget-create/releases/download/v1.12.8.0/wingetcreate.exe"
+          Invoke-WebRequest -Uri $url -OutFile wingetcreate.exe
+
+          $expected = "8bd738851b524885410112678e3771b341c5c716de60fbbecb88ab0a363ed85d"
+          $actual = (Get-FileHash .\wingetcreate.exe -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $expected) {
+            throw "WingetCreate checksum mismatch: expected $expected, got $actual"
+          }
+      - name: Submit WinGet manifest
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WINGET_CREATE_GITHUB_TOKEN)) {
+            throw "The WINGET_CREATE_GITHUB_TOKEN repository secret is not configured"
+          }
+
+          .\wingetcreate.exe update Dropbox.dbxcli `
+            --urls "$env:INSTALLER_URL|x64" `
+            --version $env:VERSION `
+            --release-notes-url "https://github.com/dropbox/dbxcli/releases/tag/v$env:VERSION" `
+            --submit `
+            --no-open

--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ brew install dbxcli
 
 Homebrew formula: [formulae.brew.sh/formula/dbxcli](https://formulae.brew.sh/formula/dbxcli)
 
+### WinGet
+
+```powershell
+winget install --exact --id Dropbox.dbxcli
+```
+
+WinGet manifest: [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs/tree/master/manifests/d/Dropbox/dbxcli)
+
 ### Release archives
 
 Download the archive for your platform from the

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -15,6 +15,20 @@ https://github.com/dropbox/dbxcli/releases/download/vX.Y.Z/dbxcli_X.Y.Z_windows_
 The generated manifest is for a portable zip package. It installs the nested
 `dbxcli.exe` binary and exposes `dbxcli` as the portable command alias.
 
+## Automatic release updates
+
+The release workflow submits a WinGet update after publishing the GitHub
+Release assets. It uses Microsoft's WingetCreate tool to open a pull request in
+`microsoft/winget-pkgs`; Microsoft validation and review still apply.
+
+Configure an Actions repository secret named `WINGET_CREATE_GITHUB_TOKEN`
+before publishing a release. The secret must contain a GitHub personal access
+token (classic) with the `public_repo` scope. WingetCreate does not support
+fine-grained personal access tokens.
+
+WingetCreate is pinned and checksum-verified in the release workflow. Update
+both its release URL and expected SHA-256 digest when upgrading the tool.
+
 ## Generate manifests
 
 Run the normal release packaging first so `dist/SHA256SUMS` exists:
@@ -48,7 +62,7 @@ This creates files under:
 /path/to/winget-pkgs/manifests/d/Dropbox/dbxcli/X.Y.Z/
 ```
 
-## Validate and submit
+## Manual validation and submission
 
 From the `winget-pkgs` checkout:
 
@@ -60,5 +74,8 @@ winget install --manifest .\manifests\d\Dropbox\dbxcli\X.Y.Z
 Open a pull request against `microsoft/winget-pkgs` after local validation
 passes.
 
-Do not add `winget install Dropbox.dbxcli` to the main README until the package
-has been accepted into the public WinGet source.
+The package is available from the public WinGet source as `Dropbox.dbxcli`:
+
+```powershell
+winget install --exact --id Dropbox.dbxcli
+```


### PR DESCRIPTION
## Summary

Adds a `winget` CI job that runs after the `release` job and submits a WinGet manifest update to `microsoft/winget-pkgs` via WingetCreate. WingetCreate opens a pull request that Microsoft validation and review still gate.

## Changes

- `.github/workflows/release.yml` — new `winget` job (needs `release`); downloads WingetCreate, verifies its checksum, and submits the manifest update.
- `README.md` — WinGet install section.
- `packaging/winget/README.md` — document the automation; update manual instructions now that the package is published.

## Safety / hygiene

- WingetCreate pinned to `v1.12.8.0` **and** SHA-256 verified before it runs.
- Job fails fast if the `WINGET_CREATE_GITHUB_TOKEN` secret is unset.
- Installer URL reuses the release job's `windows_archive` output rather than duplicating the asset name; an earlier release step already asserts that asset exists.

## Verification

- Confirmed `Dropbox.dbxcli` is live in the public WinGet source (v3.6.0 present in `microsoft/winget-pkgs`), so the README install command is accurate.
- Asset naming (`dbxcli_<version>_windows_amd64.zip`) matches the release job's `windows_archive` output.