### PR TITLE
Scope WinGet token to the submit step only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,6 @@ jobs:
     env:
       VERSION: ${{ needs.release.outputs.asset_version }}
       INSTALLER_URL: https://github.com/dropbox/dbxcli/releases/download/v${{ needs.release.outputs.asset_version }}/${{ needs.release.outputs.windows_archive }}
-      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
     steps:
       - uses: actions/setup-dotnet@v5
         with:
@@ -78,6 +77,8 @@ jobs:
           }
       - name: Submit WinGet manifest
         shell: pwsh
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
         run: |
           if ([string]::IsNullOrWhiteSpace($env:WINGET_CREATE_GITHUB_TOKEN)) {
             throw "The WINGET_CREATE_GITHUB_TOKEN repository secret is not configured"


### PR DESCRIPTION
## Summary

Follow-up to #357. Moves `WINGET_CREATE_GITHUB_TOKEN` from the `winget` job's `env` down to the `Submit WinGet manifest` step's `env`.

## Why

The token is only needed when WingetCreate opens the pull request. With it declared at job level it was also present in the environment of the `Download WingetCreate` step, which fetches and checksums an executable over the network. Scoping the secret to the single step that needs it follows least-privilege and reduces its exposure surface.

## Changes

- `.github/workflows/release.yml` — token declared at step level instead of job level.

## Verification

- YAML validates.
- The presence check (`throw` if the secret is unset) and the WingetCreate invocation both remain within the step that now owns the token, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)