### PR TITLE
Update Dropbox SDK version reporting

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"runtime/debug"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ const (
 )
 
 var dropboxVersionFunc = dropbox.Version
+var dropboxSDKModuleVersionFunc = dropboxSDKModuleVersion
 
 // NewVersionCommand creates the version command. The version value is supplied
 // by main so release builds can continue setting it with ldflags.
@@ -66,12 +68,29 @@ func renderVersion(out io.Writer, info versionOutput) error {
 }
 
 func newVersionOutput(version string) versionOutput {
-	sdkVersion, specVersion := dropboxVersionFunc()
+	_, specVersion := dropboxVersionFunc()
 	return versionOutput{
 		Version:     version,
-		SDKVersion:  sdkVersion,
+		SDKVersion:  dropboxSDKModuleVersionFunc(),
 		SpecVersion: specVersion,
 	}
+}
+
+func dropboxSDKModuleVersion() string {
+	const modulePath = "github.com/dropbox/dropbox-sdk-go-unofficial/v6"
+
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range buildInfo.Deps {
+			if dep.Path == modulePath && dep.Version != "" {
+				return dep.Version
+			}
+		}
+	}
+
+	// Fall back to the SDK's generated version when build metadata is absent,
+	// for example in binaries built with stripped build information.
+	sdkVersion, _ := dropboxVersionFunc()
+	return sdkVersion
 }
 
 func newVersionOperationOutput(info versionOutput) jsonOperationOutput {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -80,10 +80,13 @@ func stubDropboxVersion(t *testing.T, sdkVersion, specVersion string) {
 	t.Helper()
 
 	previous := dropboxVersionFunc
+	previousModuleVersion := dropboxSDKModuleVersionFunc
 	dropboxVersionFunc = func() (string, string) {
 		return sdkVersion, specVersion
 	}
+	dropboxSDKModuleVersionFunc = func() string { return sdkVersion }
 	t.Cleanup(func() {
 		dropboxVersionFunc = previous
+		dropboxSDKModuleVersionFunc = previousModuleVersion
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dropbox/dbxcli/v3
 go 1.25.0
 
 require (
-	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.0
+	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.0 h1:LWwNAeoGaMbNkbaa/0wlNc01SeT0JtISyTZOr4iLeXU=
-github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.0/go.mod h1:gDXhl0OElhzYoDsYWHr1RXjpxjGeLzEvjYzH7sZV73k=
+github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.1 h1:NS9fm6KmJTN2J6YzF70QrZ0tMPYOrs+GL9uPVI0K9Ug=
+github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.1/go.mod h1:gDXhl0OElhzYoDsYWHr1RXjpxjGeLzEvjYzH7sZV73k=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=


### PR DESCRIPTION
## Summary

- update `dropbox-sdk-go-unofficial/v6` to v6.6.1
- report the resolved Go module version in `dbxcli version`
- retain a fallback for stripped build metadata

## Why

The upstream SDK module version is v6.6.1, while its generated internal version string still reports 6.4.0. This made `dbxcli version` misleading after the dependency update.
