### PR TITLE
Add marketplace manifest for Claude Code plugin distribution

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "dbxcli",
+  "displayName": "Dropbox dbxcli",
+  "description": "Official Dropbox CLI plugin for Claude Code",
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "dbxcli",
+      "path": "dist/claude/dbxcli-plugin",
+      "version": "0.1.0",
+      "description": "Safely operate Dropbox through locally installed dbxcli CLI"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `marketplace.json` to enable zero-clone installation of the dbxcli Claude Code plugin via the marketplace flow.

## Changes

- Created `marketplace.json` at repository root
- Manifest points to `dist/claude/dbxcli-plugin`
- Enables installation without manual cloning