### PR TITLE
Prepare plugin for Anthropic marketplace submission

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,13 +3,13 @@
   "owner": {
     "name": "Dropbox"
   },
-  "description": "Official Dropbox CLI plugin for Claude Code",
+  "description": "Official Dropbox CLI plugin. Upload/download files, manage shared links, search content, and automate team workflows.",
   "plugins": [
     {
       "name": "dbxcli",
       "version": "1.0.0",
       "source": "./plugin/claude",
-      "description": "Safely operate Dropbox through locally installed dbxcli CLI"
+      "description": "Upload/download files, manage shared links, search content, and automate team workflows through locally installed dbxcli with schema-backed JSON contracts"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -235,6 +235,15 @@ cd dbxcli
 go build .
 ```
 
+### Claude Code plugin
+
+```sh
+/plugin marketplace add Dropbox/dbxcli
+/plugin install dbxcli@dbxcli
+```
+
+Then use the `/dbxcli` skill to work with Dropbox from Claude Code.
+
 ## Support posture
 
 `dbxcli` is maintained in the Dropbox GitHub organization by Dropbox engineers,

--- a/plugin/claude/.claude-plugin/plugin.json
+++ b/plugin/claude/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "dbxcli",
   "displayName": "dbxcli",
-  "description": "Safely operate Dropbox through a locally installed dbxcli CLI, using its JSON manifest and schema-backed machine contract.",
-  "version": "0.1.0",
+  "description": "Official Dropbox CLI plugin. Upload/download files, manage shared links, search content, and automate team workflows through locally installed dbxcli with schema-backed JSON contracts.",
+  "version": "1.0.0",
   "author": {
     "name": "Dropbox"
   },
   "repository": "https://github.com/dropbox/dbxcli",
   "license": "Apache-2.0",
-  "keywords": ["dropbox", "cli", "files", "cloud-storage"],
+  "keywords": ["dropbox", "cli", "files", "cloud-storage", "automation", "file-management", "shared-links", "team", "json"],
   "defaultEnabled": true
 }


### PR DESCRIPTION
## Summary
- Bump plugin version to 1.0.0 (production ready)
- Add Claude Code plugin installation section to README
- Expand keywords for better marketplace discoverability
- Improve descriptions with specific feature highlights
- Sync metadata between marketplace.json and plugin.json

## Changes
- **Version**: 0.1.0 → 1.0.0
- **Keywords**: Added `automation`, `file-management`, `shared-links`, `team`, `json`
- **Descriptions**: Now mention specific capabilities (upload/download, shared links, search, team workflows)
- **README**: New Claude Code plugin section with installation commands

## Validation
- ✅ `claude plugin validate --strict` passes
- ✅ All metadata synchronized
- ✅ Ready for Anthropic marketplace submission